### PR TITLE
feat(config): support .claude/, AGENTS.md, CLAUDE.md and use python-frontmatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 .mypy_cache/
 .pytest_cache/
 .ruff_cache/
+.coverage

--- a/README.md
+++ b/README.md
@@ -54,14 +54,26 @@ The service needs a publicly reachable URL. For local dev, use [ngrok](https://n
 
 The agent automatically loads project-specific config from the reviewed repo:
 
+**Skills and agents** (from `.github/` and `.claude/`):
+
 | Path | What | How |
 |---|---|---|
 | `.github/skills/*/SKILL.md` | Skills | SDK-native `skill_directories` |
+| `.claude/skills/*/SKILL.md` | Skills | SDK-native `skill_directories` |
 | `.github/agents/*.agent.md` | Custom agents | SDK-native `custom_agents` (YAML frontmatter) |
-| `.github/copilot-instructions.md` | Global instructions | Appended to system message |
-| `.github/instructions/*.md` | Per-language instructions | Appended to system message |
+| `.claude/agents/*.agent.md` | Custom agents | SDK-native `custom_agents` (YAML frontmatter) |
 
-`.gitlab/` paths are also supported.
+**Instructions** (all discovered, concatenated into system message):
+
+| Path | Standard | Scope |
+|---|---|---|
+| `.github/copilot-instructions.md` | GitHub Copilot | Project-wide |
+| `.github/instructions/*.md` | GitHub Copilot | Per-language |
+| `.claude/CLAUDE.md` | Claude Code | Project-wide |
+| `AGENTS.md` | Universal (Copilot, Claude, Codex, Cursor, GitLab Duo) | Project root + subdirectories |
+| `CLAUDE.md` | Claude Code | Project root |
+
+Symlinked files (e.g., `ln -s AGENTS.md CLAUDE.md`) are deduplicated automatically.
 
 ## Review Output
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pydantic==2.10.6",
     "pydantic-settings==2.7.1",
     "structlog==25.1.0",
+    "python-frontmatter>=1.1.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_repo_config.py
+++ b/tests/test_repo_config.py
@@ -21,16 +21,16 @@ def test_skills_discovery_github(tmp_path: Path) -> None:
     assert config.skill_directories[0].endswith(".github/skills")
 
 
-def test_skills_discovery_gitlab(tmp_path: Path) -> None:
-    (tmp_path / ".gitlab" / "skills" / "review").mkdir(parents=True)
+def test_skills_discovery_claude(tmp_path: Path) -> None:
+    (tmp_path / ".claude" / "skills" / "review").mkdir(parents=True)
     config = discover_repo_config(str(tmp_path))
     assert len(config.skill_directories) == 1
-    assert config.skill_directories[0].endswith(".gitlab/skills")
+    assert config.skill_directories[0].endswith(".claude/skills")
 
 
 def test_skills_discovery_both(tmp_path: Path) -> None:
     (tmp_path / ".github" / "skills" / "a").mkdir(parents=True)
-    (tmp_path / ".gitlab" / "skills" / "b").mkdir(parents=True)
+    (tmp_path / ".claude" / "skills" / "b").mkdir(parents=True)
     config = discover_repo_config(str(tmp_path))
     assert len(config.skill_directories) == 2
 
@@ -115,3 +115,131 @@ def test_parse_agent_file_missing_name(tmp_path: Path) -> None:
     f = tmp_path / "noname.agent.md"
     f.write_text("---\ndescription: No name field\n---\n\nPrompt.\n")
     assert _parse_agent_file(f) is None
+
+
+def test_agents_md_root(tmp_path: Path) -> None:
+    (tmp_path / "AGENTS.md").write_text("Global agent rules.\n")
+    config = discover_repo_config(str(tmp_path))
+    assert config.instructions is not None
+    assert "Global agent rules." in config.instructions
+
+
+def test_agents_md_subdirectories(tmp_path: Path) -> None:
+    (tmp_path / "AGENTS.md").write_text("Root rules.")
+    sub = tmp_path / "packages" / "backend"
+    sub.mkdir(parents=True)
+    (sub / "AGENTS.md").write_text("Backend rules.")
+    config = discover_repo_config(str(tmp_path))
+    assert config.instructions is not None
+    assert "Root rules." in config.instructions
+    assert "Backend rules." in config.instructions
+    # Root should come before subdirectory
+    assert config.instructions.index("Root rules.") < config.instructions.index("Backend rules.")
+
+
+def test_claude_md_root(tmp_path: Path) -> None:
+    (tmp_path / "CLAUDE.md").write_text("Claude project instructions.\n")
+    config = discover_repo_config(str(tmp_path))
+    assert config.instructions is not None
+    assert "Claude project instructions." in config.instructions
+
+
+def test_claude_md_in_config_root(tmp_path: Path) -> None:
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    (claude_dir / "CLAUDE.md").write_text("Claude scoped instructions.")
+    config = discover_repo_config(str(tmp_path))
+    assert config.instructions is not None
+    assert "Claude scoped instructions." in config.instructions
+
+
+def test_symlink_dedup(tmp_path: Path) -> None:
+    (tmp_path / "AGENTS.md").write_text("Shared instructions.")
+    (tmp_path / "CLAUDE.md").symlink_to(tmp_path / "AGENTS.md")
+    config = discover_repo_config(str(tmp_path))
+    assert config.instructions is not None
+    # Content should appear only once despite two files
+    assert config.instructions.count("Shared instructions.") == 1
+
+
+def test_all_instruction_sources_combined(tmp_path: Path) -> None:
+    gh = tmp_path / ".github"
+    gh.mkdir()
+    (gh / "copilot-instructions.md").write_text("Copilot global.")
+    (tmp_path / "AGENTS.md").write_text("Universal agents.")
+    (tmp_path / "CLAUDE.md").write_text("Claude root.")
+    config = discover_repo_config(str(tmp_path))
+    assert config.instructions is not None
+    assert "Copilot global." in config.instructions
+    assert "Universal agents." in config.instructions
+    assert "Claude root." in config.instructions
+
+
+def test_agent_all_custom_fields(tmp_path: Path) -> None:
+    agents_dir = tmp_path / ".github" / "agents"
+    agents_dir.mkdir(parents=True)
+    (agents_dir / "full.agent.md").write_text(
+        "---\n"
+        "name: full-agent\n"
+        "description: A fully configured agent\n"
+        "tools:\n  - read\n  - search\n"
+        "display_name: Full Agent\n"
+        "infer: true\n"
+        "---\n\n"
+        "You are a full agent.\n"
+    )
+    config = discover_repo_config(str(tmp_path))
+    assert len(config.custom_agents) == 1
+    agent = config.custom_agents[0]
+    assert agent["name"] == "full-agent"
+    assert agent["description"] == "A fully configured agent"
+    assert agent["tools"] == ["read", "search"]
+    assert agent["display_name"] == "Full Agent"
+    assert agent["infer"] is True
+    assert agent["prompt"] == "You are a full agent."
+
+
+def test_agent_nested_yaml(tmp_path: Path) -> None:
+    agents_dir = tmp_path / ".github" / "agents"
+    agents_dir.mkdir(parents=True)
+    (agents_dir / "nested.agent.md").write_text(
+        "---\n"
+        "name: nested\n"
+        "description: |\n"
+        "  A multi-line\n"
+        "  description block\n"
+        "---\n\n"
+        "Prompt body.\n"
+    )
+    config = discover_repo_config(str(tmp_path))
+    assert len(config.custom_agents) == 1
+    assert "multi-line" in config.custom_agents[0]["description"]
+
+
+def test_claude_md_not_loaded_from_github(tmp_path: Path) -> None:
+    gh = tmp_path / ".github"
+    gh.mkdir()
+    (gh / "CLAUDE.md").write_text("Should not be loaded.")
+    config = discover_repo_config(str(tmp_path))
+    assert config.instructions is None
+
+
+def test_copilot_instructions_not_loaded_from_claude(tmp_path: Path) -> None:
+    claude = tmp_path / ".claude"
+    claude.mkdir()
+    (claude / "copilot-instructions.md").write_text("Should not be loaded.")
+    config = discover_repo_config(str(tmp_path))
+    assert config.instructions is None
+
+
+def test_agents_md_not_loaded_from_config_roots(tmp_path: Path) -> None:
+    (tmp_path / ".github").mkdir()
+    (tmp_path / ".github" / "AGENTS.md").write_text("Wrong location.")
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "AGENTS.md").write_text("Also wrong.")
+    (tmp_path / "AGENTS.md").write_text("Correct root.")
+    config = discover_repo_config(str(tmp_path))
+    assert config.instructions is not None
+    assert "Correct root." in config.instructions
+    assert "Wrong location." not in config.instructions
+    assert "Also wrong." not in config.instructions

--- a/uv.lock
+++ b/uv.lock
@@ -236,6 +236,7 @@ dependencies = [
     { name = "github-copilot-sdk" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "python-frontmatter" },
     { name = "python-gitlab" },
     { name = "structlog" },
     { name = "uvicorn", extra = ["standard"] },
@@ -265,6 +266,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = "==2.7.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==8.3.4" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==0.25.3" },
+    { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "python-gitlab", specifier = "==5.6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.9.6" },
     { name = "structlog", specifier = "==25.1.0" },
@@ -537,6 +539,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "python-frontmatter"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/de/910fa208120314a12f9a88ea63e03707261692af782c99283f1a2c8a5e6f/python-frontmatter-1.1.0.tar.gz", hash = "sha256:7118d2bd56af9149625745c58c9b51fb67e8d1294a0c76796dafdc72c36e5f6d", size = 16256, upload-time = "2024-01-16T18:50:04.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/87/3c8da047b3ec5f99511d1b4d7a5bc72d4b98751c7e78492d14dc736319c5/python_frontmatter-1.1.0-py3-none-any.whl", hash = "sha256:335465556358d9d0e6c98bbeb69b1c969f2a4a21360587b9873bfc3b213407c1", size = 9834, upload-time = "2024-01-16T18:50:00.911Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Expand config discovery to support the universal `AGENTS.md` standard and Claude Code conventions alongside GitHub Copilot's `.github/` layout.

## Changes

- **Config roots**: Replace `.gitlab/` with `.claude/` — `.gitlab/` is for CI/CD, not agent config
- **AGENTS.md**: Discover at project root + subdirectories (universal standard: Copilot, Claude, Codex, Cursor, GitLab Duo)
- **CLAUDE.md**: Discover at project root and `.claude/` config root
- **Symlink dedup**: `AGENTS.md` and `CLAUDE.md` are often symlinked together — resolved paths prevent duplicate loading
- **python-frontmatter**: Replace hand-rolled regex parser with `python-frontmatter` library for robust YAML/TOML/JSON frontmatter handling
- **All CustomAgentConfig fields**: Pass through `display_name`, `mcp_servers`, `infer` (previously dropped)
- **Scoped instructions**: `.github/` only loads `copilot-instructions.md`, `.claude/` only loads `CLAUDE.md` (no cross-loading)
- **Config root exclusion**: `AGENTS.md` subdirectory traversal skips `.github/` and `.claude/` dirs

## Testing

- 60 tests, 95% coverage
- Live E2E: `AGENTS.md` added to GitLab test repo, service loaded it alongside `.github/` config, 8 inline comments posted with apply-able suggestions

## Diff

+309 -49 (7 files)