### PR TITLE
refactor(copilot): extract shared session runner and add coding engine

### DIFF
--- a/src/gitlab_copilot_agent/coding_engine.py
+++ b/src/gitlab_copilot_agent/coding_engine.py
@@ -1,0 +1,64 @@
+"""Copilot coding engine — implements changes from a Jira issue."""
+
+from gitlab_copilot_agent.config import Settings
+from gitlab_copilot_agent.copilot_session import run_copilot_session
+
+SYSTEM_PROMPT = """\
+You are a senior software engineer implementing changes described in a Jira issue.
+
+Your workflow:
+1. Read the issue description carefully to understand requirements
+2. Explore the existing codebase using file tools to understand structure and conventions
+3. Make minimal, focused changes that address the issue
+4. Follow existing project conventions (code style, patterns, architecture)
+5. Run tests if available to verify your changes
+6. Output a summary of changes made
+
+Guidelines:
+- Make the smallest change that solves the problem
+- Preserve existing behavior unless the issue explicitly requires changes
+- Follow SOLID principles and existing patterns
+- Add tests for new functionality
+- Update documentation if needed
+- Do not introduce new dependencies without strong justification
+
+Output format:
+Provide a summary of:
+- Files modified or created
+- Key changes made
+- Test results (if tests were run)
+- Any concerns or follow-up items
+"""
+
+
+def build_coding_prompt(
+    issue_key: str,
+    summary: str,
+    description: str | None,
+) -> str:
+    """Build the user prompt for a coding task."""
+    desc_text = description if description else "(no description provided)"
+    return (
+        f"## Jira Issue: {issue_key}\n"
+        f"**Summary:** {summary}\n"
+        f"**Description:**\n{desc_text}\n\n"
+        f"Implement the changes described in this issue. "
+        f"Explore the repository, make necessary changes, run tests, "
+        f"and provide a summary of what you did."
+    )
+
+
+async def run_coding_task(
+    settings: Settings,
+    repo_path: str,
+    issue_key: str,
+    summary: str,
+    description: str | None,
+) -> str:
+    """Run a Copilot agent session to implement changes from a Jira issue."""
+    return await run_copilot_session(
+        settings=settings,
+        repo_path=repo_path,
+        system_prompt=SYSTEM_PROMPT,
+        user_prompt=build_coding_prompt(issue_key, summary, description),
+    )

--- a/src/gitlab_copilot_agent/copilot_session.py
+++ b/src/gitlab_copilot_agent/copilot_session.py
@@ -1,0 +1,99 @@
+"""Shared Copilot SDK session runner — extracted from review_engine."""
+
+import asyncio
+from typing import Any, cast
+
+import structlog
+from copilot import CopilotClient
+from copilot.types import (
+    CopilotClientOptions,
+    CustomAgentConfig,
+    ProviderConfig,
+    SessionConfig,
+)
+
+from gitlab_copilot_agent.config import Settings
+from gitlab_copilot_agent.repo_config import discover_repo_config
+
+log = structlog.get_logger()
+
+
+async def run_copilot_session(
+    settings: Settings,
+    repo_path: str,
+    system_prompt: str,
+    user_prompt: str,
+    timeout: int = 300,
+) -> str:
+    """Run a Copilot agent session and return the last assistant message."""
+    client_opts: CopilotClientOptions = {}
+    if settings.github_token:
+        client_opts["github_token"] = settings.github_token
+
+    client = CopilotClient(client_opts)
+    await client.start()
+
+    try:
+        repo_config = discover_repo_config(repo_path)
+
+        system_content = system_prompt
+        if repo_config.instructions:
+            system_content += (
+                f"\n\n## Project-Specific Instructions\n\n{repo_config.instructions}\n"
+            )
+
+        session_opts: SessionConfig = {
+            "system_message": {"content": system_content},
+            "working_directory": repo_path,
+        }
+
+        if repo_config.skill_directories:
+            session_opts["skill_directories"] = repo_config.skill_directories
+            await log.ainfo("skills_loaded", directories=repo_config.skill_directories)
+        if repo_config.custom_agents:
+            session_opts["custom_agents"] = [
+                cast(CustomAgentConfig, a) for a in repo_config.custom_agents
+            ]
+            await log.ainfo(
+                "agents_loaded",
+                agents=[a["name"] for a in repo_config.custom_agents],
+            )
+        if repo_config.instructions:
+            await log.ainfo("instructions_loaded")
+
+        if settings.copilot_provider_type:
+            provider: ProviderConfig = {
+                "type": cast(Any, settings.copilot_provider_type),
+            }
+            if settings.copilot_provider_base_url:
+                provider["base_url"] = settings.copilot_provider_base_url
+            if settings.copilot_provider_api_key:
+                provider["api_key"] = settings.copilot_provider_api_key
+            if settings.copilot_provider_type == "azure":
+                provider["azure"] = {"api_version": "2024-10-21"}
+            session_opts["provider"] = provider
+            session_opts["model"] = settings.copilot_model
+
+        session = await client.create_session(session_opts)
+        try:
+            done = asyncio.Event()
+            messages: list[str] = []
+
+            def on_event(event: Any) -> None:
+                match getattr(event, "type", None):
+                    case t if t and t.value == "assistant.message":
+                        content = getattr(event.data, "content", "")
+                        if content:
+                            messages.append(content)
+                    case t if t and t.value == "session.idle":
+                        done.set()
+
+            session.on(on_event)
+            await session.send({"prompt": user_prompt})
+            await asyncio.wait_for(done.wait(), timeout=timeout)
+        finally:
+            await session.destroy()
+
+        return messages[-1] if messages else ""
+    finally:
+        await client.stop()

--- a/tests/test_coding_engine.py
+++ b/tests/test_coding_engine.py
@@ -1,0 +1,27 @@
+"""Tests for the coding engine."""
+
+from unittest.mock import AsyncMock, patch
+
+from gitlab_copilot_agent.coding_engine import SYSTEM_PROMPT, run_coding_task
+from tests.conftest import make_settings
+
+
+@patch("gitlab_copilot_agent.coding_engine.run_copilot_session")
+async def test_run_coding_task_delegates_to_copilot_session(
+    mock_run_session: AsyncMock,
+) -> None:
+    mock_run_session.return_value = "Changes completed"
+
+    result = await run_coding_task(
+        settings=make_settings(),
+        repo_path="/tmp/repo",
+        issue_key="PROJ-789",
+        summary="Implement feature X",
+        description="Add X to the codebase",
+    )
+
+    assert result == "Changes completed"
+    call_args = mock_run_session.call_args[1]
+    assert call_args["system_prompt"] == SYSTEM_PROMPT
+    assert "PROJ-789" in call_args["user_prompt"]
+    assert "Implement feature X" in call_args["user_prompt"]

--- a/tests/test_copilot_session.py
+++ b/tests/test_copilot_session.py
@@ -1,0 +1,115 @@
+"""Tests for the shared Copilot session runner."""
+
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gitlab_copilot_agent.copilot_session import run_copilot_session
+from gitlab_copilot_agent.repo_config import RepoConfig
+from tests.conftest import make_settings
+
+
+def _make_event(event_type: str, content: str = "") -> SimpleNamespace:
+    """Create a mock SDK event."""
+    return SimpleNamespace(
+        type=SimpleNamespace(value=event_type),
+        data=SimpleNamespace(content=content),
+    )
+
+
+def _setup_mock_session(
+    mock_client_class: MagicMock,
+    events: list[SimpleNamespace],
+) -> AsyncMock:
+    """Wire up mock client/session that emits the given events on send."""
+    mock_client = AsyncMock()
+    mock_client_class.return_value = mock_client
+    mock_session = AsyncMock()
+    mock_session.on = MagicMock()
+    mock_client.create_session.return_value = mock_session
+
+    captured: dict[str, Callable[..., Any] | None] = {"handler": None}
+
+    def capture_on(handler: Callable[..., Any]) -> None:
+        captured["handler"] = handler
+
+    mock_session.on.side_effect = capture_on
+
+    async def fake_send(msg: object) -> None:
+        assert captured["handler"] is not None
+        for event in events:
+            captured["handler"](event)
+
+    mock_session.send.side_effect = fake_send
+    return mock_client
+
+
+@pytest.fixture
+def _run(tmp_path: Path) -> Callable[..., Any]:
+    """Return a helper that calls run_copilot_session with defaults."""
+
+    async def _inner(**kwargs: Any) -> str:
+        defaults = {
+            "settings": make_settings(),
+            "repo_path": str(tmp_path),
+            "system_prompt": "System",
+            "user_prompt": "User",
+        }
+        return await run_copilot_session(**(defaults | kwargs))
+
+    return _inner
+
+
+@patch("gitlab_copilot_agent.copilot_session.discover_repo_config")
+@patch("gitlab_copilot_agent.copilot_session.CopilotClient")
+async def test_returns_last_message(
+    mock_client_class: MagicMock, mock_discover: MagicMock, _run: Any,
+) -> None:
+    mock_discover.return_value = RepoConfig()
+    mock_client = _setup_mock_session(mock_client_class, [
+        _make_event("assistant.message", "First"),
+        _make_event("assistant.message", "Last"),
+        _make_event("session.idle"),
+    ])
+
+    assert await _run() == "Last"
+    mock_client.start.assert_awaited_once()
+    mock_client.stop.assert_awaited_once()
+
+
+@patch("gitlab_copilot_agent.copilot_session.discover_repo_config")
+@patch("gitlab_copilot_agent.copilot_session.CopilotClient")
+async def test_empty_messages_returns_empty_string(
+    mock_client_class: MagicMock, mock_discover: MagicMock, _run: Any,
+) -> None:
+    mock_discover.return_value = RepoConfig()
+    _setup_mock_session(mock_client_class, [_make_event("session.idle")])
+
+    assert await _run() == ""
+
+
+@patch("gitlab_copilot_agent.copilot_session.discover_repo_config")
+@patch("gitlab_copilot_agent.copilot_session.CopilotClient")
+async def test_passes_repo_config_to_session(
+    mock_client_class: MagicMock, mock_discover: MagicMock, _run: Any,
+) -> None:
+    mock_discover.return_value = RepoConfig(
+        skill_directories=["/tmp/skills"],
+        custom_agents=[{"name": "coder", "prompt": "Write code."}],
+        instructions="Use strict typing.",
+    )
+    mock_client = _setup_mock_session(mock_client_class, [
+        _make_event("assistant.message", "done"),
+        _make_event("session.idle"),
+    ])
+
+    await _run()
+
+    session_opts = mock_client.create_session.call_args[0][0]
+    assert session_opts["skill_directories"] == ["/tmp/skills"]
+    assert len(session_opts["custom_agents"]) == 1
+    assert "Use strict typing." in session_opts["system_message"]["content"]

--- a/tests/test_review_engine.py
+++ b/tests/test_review_engine.py
@@ -1,8 +1,6 @@
 """Tests for the review engine prompt construction and run_review."""
 
-from pathlib import Path
-from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 from gitlab_copilot_agent.review_engine import (
     SYSTEM_PROMPT,
@@ -22,24 +20,10 @@ def _make_request() -> ReviewRequest:
     )
 
 
-def test_system_prompt_contains_review_guidance() -> None:
-    assert "security" in SYSTEM_PROMPT.lower()
-    assert "json" in SYSTEM_PROMPT.lower()
-    assert "severity" in SYSTEM_PROMPT.lower()
-
-
-def test_build_review_prompt_includes_title() -> None:
-    prompt = build_review_prompt(_make_request())
-    assert "Add feature X" in prompt
-
-
-def test_build_review_prompt_includes_git_diff_command() -> None:
+def test_build_review_prompt_constructs_git_diff_command() -> None:
     prompt = build_review_prompt(_make_request())
     assert "git diff main...feature/x" in prompt
-
-
-def test_build_review_prompt_includes_description() -> None:
-    prompt = build_review_prompt(_make_request())
+    assert "Add feature X" in prompt
     assert "Implements feature X" in prompt
 
 
@@ -54,133 +38,18 @@ def test_build_review_prompt_handles_no_description() -> None:
     assert "(none)" in prompt
 
 
-def _make_event(event_type: str, content: str = "") -> SimpleNamespace:
-    """Create a mock SDK event."""
-    return SimpleNamespace(
-        type=SimpleNamespace(value=event_type),
-        data=SimpleNamespace(content=content),
-    )
-
-
-@patch("gitlab_copilot_agent.review_engine.discover_repo_config")
-@patch("gitlab_copilot_agent.review_engine.CopilotClient")
-async def test_run_review_returns_last_message(
-    mock_client_class: MagicMock,
-    mock_discover: MagicMock,
-    tmp_path: Path,
+@patch("gitlab_copilot_agent.review_engine.run_copilot_session")
+async def test_run_review_delegates_to_copilot_session(
+    mock_run_session: AsyncMock,
 ) -> None:
-    from gitlab_copilot_agent.repo_config import RepoConfig
-
-    mock_discover.return_value = RepoConfig()
-
-    mock_client = AsyncMock()
-    mock_client_class.return_value = mock_client
-
-    mock_session = AsyncMock()
-    mock_session.on = MagicMock()
-    mock_client.create_session.return_value = mock_session
-
-    captured_handler = None
-
-    def capture_on(handler: object) -> None:
-        nonlocal captured_handler
-        captured_handler = handler
-
-    mock_session.on.side_effect = capture_on
-
-    async def fake_send(msg: object) -> None:
-        assert captured_handler is not None
-        captured_handler(_make_event("assistant.message", "I'll review..."))
-        captured_handler(_make_event("assistant.message", "[{\"file\": \"a.py\"}]"))
-        captured_handler(_make_event("session.idle"))
-
-    mock_session.send.side_effect = fake_send
+    mock_run_session.return_value = "Review result"
 
     settings = make_settings()
-    result = await run_review(settings, str(tmp_path), _make_request())
+    req = _make_request()
+    result = await run_review(settings, "/tmp/repo", req)
 
-    assert "[{\"file\": \"a.py\"}]" in result
-    mock_client.start.assert_awaited_once()
-    mock_client.stop.assert_awaited_once()
-    mock_session.destroy.assert_awaited_once()
-
-
-@patch("gitlab_copilot_agent.review_engine.discover_repo_config")
-@patch("gitlab_copilot_agent.review_engine.CopilotClient")
-async def test_run_review_empty_messages(
-    mock_client_class: MagicMock,
-    mock_discover: MagicMock,
-    tmp_path: Path,
-) -> None:
-    from gitlab_copilot_agent.repo_config import RepoConfig
-
-    mock_discover.return_value = RepoConfig()
-
-    mock_client = AsyncMock()
-    mock_client_class.return_value = mock_client
-    mock_session = AsyncMock()
-    mock_session.on = MagicMock()
-    mock_client.create_session.return_value = mock_session
-
-    captured_handler = None
-
-    def capture_on(handler: object) -> None:
-        nonlocal captured_handler
-        captured_handler = handler
-
-    mock_session.on.side_effect = capture_on
-
-    async def fake_send(msg: object) -> None:
-        assert captured_handler is not None
-        captured_handler(_make_event("session.idle"))
-
-    mock_session.send.side_effect = fake_send
-
-    settings = make_settings()
-    result = await run_review(settings, str(tmp_path), _make_request())
-    assert result == ""
-
-
-@patch("gitlab_copilot_agent.review_engine.discover_repo_config")
-@patch("gitlab_copilot_agent.review_engine.CopilotClient")
-async def test_run_review_passes_repo_config(
-    mock_client_class: MagicMock,
-    mock_discover: MagicMock,
-    tmp_path: Path,
-) -> None:
-    from gitlab_copilot_agent.repo_config import RepoConfig
-
-    mock_discover.return_value = RepoConfig(
-        skill_directories=["/tmp/skills"],
-        custom_agents=[{"name": "reviewer", "prompt": "Review code."}],
-        instructions="Use type hints.",
-    )
-
-    mock_client = AsyncMock()
-    mock_client_class.return_value = mock_client
-    mock_session = AsyncMock()
-    mock_session.on = MagicMock()
-    mock_client.create_session.return_value = mock_session
-
-    captured_handler = None
-
-    def capture_on(handler: object) -> None:
-        nonlocal captured_handler
-        captured_handler = handler
-
-    mock_session.on.side_effect = capture_on
-
-    async def fake_send(msg: object) -> None:
-        assert captured_handler is not None
-        captured_handler(_make_event("assistant.message", "review done"))
-        captured_handler(_make_event("session.idle"))
-
-    mock_session.send.side_effect = fake_send
-
-    settings = make_settings()
-    await run_review(settings, str(tmp_path), _make_request())
-
-    session_opts = mock_client.create_session.call_args[0][0]
-    assert session_opts["skill_directories"] == ["/tmp/skills"]
-    assert len(session_opts["custom_agents"]) == 1
-    assert "Use type hints." in session_opts["system_message"]["content"]
+    assert result == "Review result"
+    call_args = mock_run_session.call_args[1]
+    assert call_args["system_prompt"] == SYSTEM_PROMPT
+    assert "Add feature X" in call_args["user_prompt"]
+    assert "git diff main...feature/x" in call_args["user_prompt"]


### PR DESCRIPTION
## What

Extract common Copilot SDK lifecycle from `review_engine.py` into a shared `copilot_session.py` module. Both the review engine and new coding engine call `run_copilot_session()` with different system/user prompts.

Closes #8

## Changes

- **`copilot_session.py`**: Shared `run_copilot_session()` with all SDK wiring (client init, repo config discovery, session assembly, event collection, cleanup)
- **`review_engine.py`**: Refactored to thin wrapper — retains `SYSTEM_PROMPT`, `ReviewRequest`, `build_review_prompt()`, delegates to shared runner
- **`coding_engine.py`**: New module with coding-specific `SYSTEM_PROMPT` + `build_coding_prompt()`, delegates to shared runner
- Tests reorganized: SDK-level tests moved to `test_copilot_session.py`, engine tests verify delegation

## Testing

- 99 tests pass, 94% coverage
- Live tested: session runner correctly discovers repo config (skills, agents, instructions)
- E2E tested: coding engine cloned calculator-test repo, implemented subtract function from Jira issue KAN-1, wrote and ran tests

## Diff Note

Diff is 351+217 lines due to code-move refactor. Net new code is ~114 lines (coding_engine.py + test_coding_engine.py). The rest is relocated from review_engine.py.