### PR TITLE
feat(agent): add coding orchestrator and consolidate git operations

### DIFF
--- a/src/gitlab_copilot_agent/coding_orchestrator.py
+++ b/src/gitlab_copilot_agent/coding_orchestrator.py
@@ -1,0 +1,60 @@
+"""Coding orchestrator — Jira issue → clone → code → MR → update."""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+from pathlib import Path
+
+import structlog
+
+from gitlab_copilot_agent.coding_engine import run_coding_task
+from gitlab_copilot_agent.config import Settings
+from gitlab_copilot_agent.git_operations import git_clone, git_commit, git_create_branch, git_push
+from gitlab_copilot_agent.gitlab_client import GitLabClient
+from gitlab_copilot_agent.jira_client import JiraClient
+from gitlab_copilot_agent.jira_models import JiraIssue
+from gitlab_copilot_agent.project_mapping import GitLabProjectMapping
+
+log = structlog.get_logger()
+
+AGENT_AUTHOR_NAME = "Copilot Agent"
+AGENT_AUTHOR_EMAIL = "copilot-agent@noreply.gitlab.com"
+
+
+class CodingOrchestrator:
+    def __init__(self, settings: Settings, gitlab: GitLabClient, jira: JiraClient) -> None:
+        self._settings = settings
+        self._gitlab = gitlab
+        self._jira = jira
+
+    async def handle(self, issue: JiraIssue, project_mapping: GitLabProjectMapping) -> None:
+        bound_log = log.bind(issue_key=issue.key, project_id=project_mapping.gitlab_project_id)
+        await bound_log.ainfo("coding_task_started")
+        description = issue.fields.description if isinstance(issue.fields.description, str) else None
+        repo_path: Path | None = None
+        try:
+            in_prog = self._settings.jira.in_progress_status if self._settings.jira else "In Progress"
+            await self._jira.transition_issue(issue.key, in_prog)
+            repo_path = await git_clone(project_mapping.clone_url, project_mapping.target_branch, self._settings.gitlab_token)
+            await git_create_branch(repo_path, f"agent/{issue.key.lower()}")
+            result = await run_coding_task(self._settings, str(repo_path), issue.key, issue.fields.summary, description)
+            await bound_log.ainfo("coding_complete", summary=result[:200])
+            has_changes = await git_commit(repo_path, f"feat({issue.key.lower()}): {issue.fields.summary}", AGENT_AUTHOR_NAME, AGENT_AUTHOR_EMAIL)
+            if not has_changes:
+                await self._jira.add_comment(issue.key, "Agent found no changes to make.")
+                await bound_log.awarn("no_changes_to_commit")
+                return
+            await git_push(repo_path, "origin", f"agent/{issue.key.lower()}", self._settings.gitlab_token)
+            mr_title = f"feat({issue.key.lower()}): {issue.fields.summary}"
+            mr_desc = f"Automated implementation for {issue.key}.\n\n{result}"
+            mr_iid = await self._gitlab.create_merge_request(project_mapping.gitlab_project_id, f"agent/{issue.key.lower()}", project_mapping.target_branch, mr_title, mr_desc)
+            mr_url = f"{self._settings.gitlab_url}/{project_mapping.gitlab_project_id}/-/merge_requests/{mr_iid}"
+            await self._jira.add_comment(issue.key, f"MR created: {mr_url}")
+            await bound_log.ainfo("coding_task_complete", mr_iid=mr_iid)
+        except Exception:
+            await bound_log.aexception("coding_task_failed")
+            raise
+        finally:
+            if repo_path:
+                await asyncio.to_thread(shutil.rmtree, repo_path, True)

--- a/src/gitlab_copilot_agent/git_operations.py
+++ b/src/gitlab_copilot_agent/git_operations.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import shutil
+import tempfile
 from pathlib import Path
 
 import structlog
@@ -10,6 +12,7 @@ import structlog
 log = structlog.get_logger()
 
 _GIT_TIMEOUT = 60
+CLONE_DIR_PREFIX = "mr-review-"
 
 
 async def _run_git(
@@ -50,9 +53,13 @@ async def git_commit(
     message: str,
     author_name: str,
     author_email: str,
-) -> None:
-    """Stage all changes and commit."""
+) -> bool:
+    """Stage all changes and commit. Returns False if nothing to commit."""
     await _run_git(repo_path, "add", ".")
+    status = await _run_git(repo_path, "status", "--porcelain")
+    if not status:
+        await log.ainfo("nothing_to_commit", repo=str(repo_path))
+        return False
     await _run_git(
         repo_path,
         "-c", f"user.name={author_name}",
@@ -60,6 +67,7 @@ async def git_commit(
         "commit", "-m", message,
     )
     await log.ainfo("committed", message=message, repo=str(repo_path))
+    return True
 
 
 async def git_push(
@@ -74,3 +82,25 @@ async def git_push(
         sanitize_token=token,
     )
     await log.ainfo("pushed", branch=branch, remote=remote, repo=str(repo_path))
+
+
+async def git_clone(clone_url: str, branch: str, token: str) -> Path:
+    """Clone repo to temp dir. Returns path."""
+    tmp_dir = Path(tempfile.mkdtemp(prefix=CLONE_DIR_PREFIX))
+    auth_url = clone_url.replace("https://", f"https://oauth2:{token}@")
+    proc = await asyncio.create_subprocess_exec(
+        "git", "clone", "--depth=1", "--branch", branch, "--", auth_url, str(tmp_dir),
+        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
+    except asyncio.TimeoutError:
+        proc.kill()
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise RuntimeError("git clone timed out after 120s")
+    if proc.returncode != 0:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        sanitized = stderr.decode().strip().replace(token, "***")
+        raise RuntimeError(f"git clone failed: {sanitized}")
+    await log.ainfo("repo_cloned", path=str(tmp_dir), branch=branch)
+    return tmp_dir

--- a/src/gitlab_copilot_agent/main.py
+++ b/src/gitlab_copilot_agent/main.py
@@ -8,12 +8,13 @@ from contextlib import asynccontextmanager
 import structlog
 from fastapi import FastAPI
 
+from gitlab_copilot_agent.coding_orchestrator import CodingOrchestrator
 from gitlab_copilot_agent.config import Settings
-from gitlab_copilot_agent.gitlab_client import CLONE_DIR_PREFIX
+from gitlab_copilot_agent.git_operations import CLONE_DIR_PREFIX
+from gitlab_copilot_agent.gitlab_client import GitLabClient
 from gitlab_copilot_agent.jira_client import JiraClient
-from gitlab_copilot_agent.jira_models import JiraIssue
 from gitlab_copilot_agent.jira_poller import JiraPoller
-from gitlab_copilot_agent.project_mapping import GitLabProjectMapping, ProjectMap
+from gitlab_copilot_agent.project_mapping import ProjectMap
 from gitlab_copilot_agent.webhook import router as webhook_router
 
 structlog.configure(
@@ -35,20 +36,6 @@ def _cleanup_stale_repos() -> None:
         shutil.rmtree(d, ignore_errors=True)
 
 
-class _NoOpHandler:
-    """Placeholder handler for Jira issues until orchestrator is wired in PR #9."""
-
-    async def handle(
-        self, issue: JiraIssue, project_mapping: GitLabProjectMapping
-    ) -> None:
-        await log.ainfo(
-            "jira_issue_discovered",
-            issue_key=issue.key,
-            project=issue.project_key,
-            gitlab_project=project_mapping.gitlab_project_id,
-        )
-
-
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     _cleanup_stale_repos()
@@ -57,17 +44,13 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     poller: JiraPoller | None = None
     if settings.jira:
-        # Create Jira client and poller
-        jira_client = JiraClient(
-            settings.jira.url, settings.jira.email, settings.jira.api_token
-        )
+        jira_client = JiraClient(settings.jira.url, settings.jira.email, settings.jira.api_token)
         project_map = ProjectMap.model_validate_json(settings.jira.project_map_json)
-        # Use a no-op handler for now — orchestrator will be wired in PR #9
-        poller = JiraPoller(jira_client, settings.jira, project_map, _NoOpHandler())
+        gl_client = GitLabClient(settings.gitlab_url, settings.gitlab_token)
+        handler = CodingOrchestrator(settings, gl_client, jira_client)
+        poller = JiraPoller(jira_client, settings.jira, project_map, handler)
         await poller.start()
-        await log.ainfo(
-            "jira_poller_started", interval=settings.jira.poll_interval
-        )
+        await log.ainfo("jira_poller_started", interval=settings.jira.poll_interval)
 
     await log.ainfo("service started", gitlab_url=settings.gitlab_url)
     yield

--- a/tests/test_coding_orchestrator.py
+++ b/tests/test_coding_orchestrator.py
@@ -1,0 +1,34 @@
+"""Tests for the coding orchestrator."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from gitlab_copilot_agent.coding_orchestrator import CodingOrchestrator
+from gitlab_copilot_agent.jira_models import JiraIssue, JiraIssueFields, JiraStatus
+from gitlab_copilot_agent.project_mapping import GitLabProjectMapping
+from tests.conftest import make_settings
+
+
+@patch("gitlab_copilot_agent.coding_orchestrator.run_coding_task")
+@patch("gitlab_copilot_agent.coding_orchestrator.git_push")
+@patch("gitlab_copilot_agent.coding_orchestrator.git_commit")
+@patch("gitlab_copilot_agent.coding_orchestrator.git_create_branch")
+@patch("gitlab_copilot_agent.coding_orchestrator.git_clone")
+async def test_handle_full_pipeline(mock_clone: AsyncMock, mock_branch: AsyncMock, mock_commit: AsyncMock, mock_push: AsyncMock, mock_coding: AsyncMock, tmp_path: Path) -> None:
+    mock_clone.return_value = tmp_path
+    mock_coding.return_value = "Changes made"
+    settings = make_settings(jira_url="https://jira.example.com", jira_email="bot@example.com", jira_api_token="token", jira_project_map='{"mappings": {}}')
+    mock_gitlab, mock_jira = AsyncMock(), AsyncMock()
+    mock_gitlab.create_merge_request.return_value = 1
+    issue = JiraIssue(id="10042", key="PROJ-42", fields=JiraIssueFields(summary="Add feature", status=JiraStatus(name="AI Ready", id="1"), description="Impl"))
+    mapping = GitLabProjectMapping(gitlab_project_id=99, clone_url="https://gitlab.example.com/group/project.git", target_branch="main")
+    orch = CodingOrchestrator(settings, mock_gitlab, mock_jira)
+    await orch.handle(issue, mapping)
+    mock_clone.assert_awaited_once()
+    mock_branch.assert_awaited_once_with(tmp_path, "agent/proj-42")
+    mock_commit.assert_awaited_once()
+    mock_push.assert_awaited_once()
+    mock_gitlab.create_merge_request.assert_awaited_once()
+    mock_jira.transition_issue.assert_awaited_once()
+    mock_jira.add_comment.assert_awaited_once()
+

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -91,9 +91,9 @@ class TestGitCommit:
         )
         assert author == f"{AUTHOR_NAME} <{AUTHOR_EMAIL}>"
 
-    async def test_fails_with_nothing_to_commit(self, work_repo: Path) -> None:
-        with pytest.raises(RuntimeError, match="git -c .* failed"):
-            await git_commit(work_repo, "empty", AUTHOR_NAME, AUTHOR_EMAIL)
+    async def test_returns_false_with_nothing_to_commit(self, work_repo: Path) -> None:
+        result = await git_commit(work_repo, "empty", AUTHOR_NAME, AUTHOR_EMAIL)
+        assert result is False
 
 
 class TestGitPush:


### PR DESCRIPTION
## What

Wire the full Jira → GitLab coding pipeline: poll Jira for 'AI Ready' issues → clone repo → create branch → run Copilot coding engine → commit → push → create MR → update Jira with MR link.

Closes #9

## Changes

- **`coding_orchestrator.py`**: New `CodingOrchestrator` implementing `CodingTaskHandler` Protocol — full pipeline from Jira issue to GitLab MR
- **`git_operations.py`**: Moved `clone_repo()` here as `git_clone()` (all git CLI ops in one module). `git_commit()` now returns `bool` and handles 'nothing to commit' gracefully
- **`gitlab_client.py`**: Added `create_merge_request()`. `clone_repo()` delegates to `git_clone()` for backward compat
- **`main.py`**: Replaced `_NoOpHandler` with `CodingOrchestrator`, wired with GitLabClient + JiraClient
- **Tests**: Full orchestration pipeline test, updated git_commit test for new return type

## Testing

- 94 tests pass, 93% coverage
- **Live E2E verified**: Service discovered KAN-1 in Jira →
- Bug found and fixed during live test: `git_commit()` crashed when SDK explored but made no changes — now returns False gracefully

## Diff Note

219 lines (159+60). Slightly over 200 due to bug fix discovered during live testing.