### PR TITLE
feat(agent): add /copilot MR comment handler

### DIFF
--- a/src/gitlab_copilot_agent/coding_engine.py
+++ b/src/gitlab_copilot_agent/coding_engine.py
@@ -1,22 +1,22 @@
-"""Copilot coding engine — implements changes from a Jira issue."""
+"""Shared coding system prompt and Jira-specific prompt builder."""
 
 from gitlab_copilot_agent.config import Settings
 from gitlab_copilot_agent.copilot_session import run_copilot_session
 
-SYSTEM_PROMPT = """\
-You are a senior software engineer implementing changes described in a Jira issue.
+CODING_SYSTEM_PROMPT = """\
+You are a senior software engineer implementing requested changes.
 
 Your workflow:
-1. Read the issue description carefully to understand requirements
+1. Read the task description carefully to understand requirements
 2. Explore the existing codebase using file tools to understand structure and conventions
-3. Make minimal, focused changes that address the issue
+3. Make minimal, focused changes that address the task
 4. Follow existing project conventions (code style, patterns, architecture)
 5. Run tests if available to verify your changes
 6. Output a summary of changes made
 
 Guidelines:
 - Make the smallest change that solves the problem
-- Preserve existing behavior unless the issue explicitly requires changes
+- Preserve existing behavior unless explicitly required to change it
 - Follow SOLID principles and existing patterns
 - Add tests for new functionality
 - Update documentation if needed
@@ -31,12 +31,8 @@ Provide a summary of:
 """
 
 
-def build_coding_prompt(
-    issue_key: str,
-    summary: str,
-    description: str | None,
-) -> str:
-    """Build the user prompt for a coding task."""
+def build_jira_coding_prompt(issue_key: str, summary: str, description: str | None) -> str:
+    """Build the user prompt for a Jira coding task."""
     desc_text = description if description else "(no description provided)"
     return (
         f"## Jira Issue: {issue_key}\n"
@@ -59,6 +55,6 @@ async def run_coding_task(
     return await run_copilot_session(
         settings=settings,
         repo_path=repo_path,
-        system_prompt=SYSTEM_PROMPT,
-        user_prompt=build_coding_prompt(issue_key, summary, description),
+        system_prompt=CODING_SYSTEM_PROMPT,
+        user_prompt=build_jira_coding_prompt(issue_key, summary, description),
     )

--- a/src/gitlab_copilot_agent/config.py
+++ b/src/gitlab_copilot_agent/config.py
@@ -53,6 +53,7 @@ class Settings(BaseSettings):
     host: str = Field(default="0.0.0.0", description="Server bind host")
     port: int = Field(default=8000, description="Server bind port")
     log_level: str = Field(default="info", description="Log level")
+    agent_gitlab_username: str | None = Field(default=None, description="Agent's GitLab username for loop prevention")
 
     # Jira (all optional — service runs review-only without these)
     jira_url: str | None = Field(default=None, description="Jira instance URL")

--- a/src/gitlab_copilot_agent/gitlab_client.py
+++ b/src/gitlab_copilot_agent/gitlab_client.py
@@ -41,6 +41,7 @@ class GitLabClientProtocol(Protocol):
     async def clone_repo(self, clone_url: str, branch: str, token: str) -> Path: ...
     async def cleanup(self, repo_path: Path) -> None: ...
     async def create_merge_request(self, project_id: int, source_branch: str, target_branch: str, title: str, description: str) -> int: ...
+    async def post_mr_comment(self, project_id: int, mr_iid: int, body: str) -> None: ...
 
 
 class GitLabClient:
@@ -106,3 +107,11 @@ class GitLabClient:
             })
             return mr.iid
         return await asyncio.to_thread(_create)
+
+    async def post_mr_comment(self, project_id: int, mr_iid: int, body: str) -> None:
+        """Post a comment on a merge request."""
+        def _post() -> None:
+            project = self._gl.projects.get(project_id)
+            mr = project.mergerequests.get(mr_iid)
+            mr.notes.create({"body": body})
+        await asyncio.to_thread(_post)

--- a/src/gitlab_copilot_agent/models.py
+++ b/src/gitlab_copilot_agent/models.py
@@ -47,3 +47,27 @@ class MergeRequestWebhookPayload(BaseModel):
     user: WebhookUser
     project: WebhookProject
     object_attributes: MRObjectAttributes
+
+
+class NoteObjectAttributes(BaseModel):
+    model_config = ConfigDict(strict=True)
+    note: str = Field(description="Comment body text")
+    noteable_type: str = Field(description="Type of noteable: MergeRequest, Issue, etc.")
+
+
+class NoteMergeRequest(BaseModel):
+    model_config = ConfigDict(strict=True)
+    iid: int
+    title: str
+    source_branch: str
+    target_branch: str
+
+
+class NoteWebhookPayload(BaseModel):
+    """GitLab note webhook payload for MR comments."""
+    model_config = ConfigDict(strict=True)
+    object_kind: str
+    user: WebhookUser
+    project: WebhookProject
+    object_attributes: NoteObjectAttributes
+    merge_request: NoteMergeRequest

--- a/src/gitlab_copilot_agent/mr_comment_handler.py
+++ b/src/gitlab_copilot_agent/mr_comment_handler.py
@@ -1,0 +1,85 @@
+"""Handle /copilot commands on GitLab MR comments."""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+from pathlib import Path
+
+import structlog
+
+from gitlab_copilot_agent.coding_engine import CODING_SYSTEM_PROMPT
+from gitlab_copilot_agent.config import Settings
+from gitlab_copilot_agent.copilot_session import run_copilot_session
+from gitlab_copilot_agent.git_operations import git_clone, git_commit, git_push
+from gitlab_copilot_agent.gitlab_client import GitLabClient
+from gitlab_copilot_agent.models import NoteWebhookPayload
+
+log = structlog.get_logger()
+
+COPILOT_PREFIX = "/copilot "
+AGENT_AUTHOR_NAME = "Copilot Agent"
+AGENT_AUTHOR_EMAIL = "copilot-agent@noreply.gitlab.com"
+
+
+def parse_copilot_command(note: str) -> str | None:
+    """Extract instruction from a /copilot command. Returns None if not a command."""
+    stripped = note.strip()
+    if stripped.lower().startswith(COPILOT_PREFIX):
+        return stripped[len(COPILOT_PREFIX):].strip() or None
+    return None
+
+
+def build_mr_coding_prompt(instruction: str, mr_title: str, source_branch: str, target_branch: str) -> str:
+    """Build user prompt for an MR comment coding task."""
+    return (
+        f"## MR: {mr_title}\n"
+        f"**Branch:** {source_branch} → {target_branch}\n"
+        f"**Instruction:** {instruction}\n\n"
+        f"Implement the requested changes on this merge request. "
+        f"Explore the repository, make the changes, run tests, "
+        f"and provide a summary of what you did."
+    )
+
+
+async def handle_copilot_comment(settings: Settings, payload: NoteWebhookPayload) -> None:
+    """Handle a /copilot command from an MR comment."""
+    mr = payload.merge_request
+    project = payload.project
+    instruction = parse_copilot_command(payload.object_attributes.note)
+    if not instruction:
+        return
+
+    bound_log = log.bind(project_id=project.id, mr_iid=mr.iid)
+    await bound_log.ainfo("copilot_command_received", instruction=instruction[:100])
+
+    gl_client = GitLabClient(settings.gitlab_url, settings.gitlab_token)
+    repo_path: Path | None = None
+
+    try:
+        repo_path = await git_clone(project.git_http_url, mr.source_branch, settings.gitlab_token)
+        result = await run_copilot_session(
+            settings=settings, repo_path=str(repo_path),
+            system_prompt=CODING_SYSTEM_PROMPT,
+            user_prompt=build_mr_coding_prompt(instruction, mr.title, mr.source_branch, mr.target_branch),
+        )
+        await bound_log.ainfo("copilot_coding_complete", summary=result[:200])
+
+        has_changes = await git_commit(repo_path, f"fix: {instruction[:50]}", AGENT_AUTHOR_NAME, AGENT_AUTHOR_EMAIL)
+        if has_changes:
+            await git_push(repo_path, "origin", mr.source_branch, settings.gitlab_token)
+            await gl_client.post_mr_comment(project.id, mr.iid, f"✅ Changes pushed.\n\n{result}")
+        else:
+            await gl_client.post_mr_comment(project.id, mr.iid, f"ℹ️ No file changes needed.\n\n{result}")
+
+        await bound_log.ainfo("copilot_command_complete")
+    except Exception:
+        await bound_log.aexception("copilot_command_failed")
+        try:
+            await gl_client.post_mr_comment(project.id, mr.iid, "❌ Agent encountered an error processing your request.")
+        except Exception:
+            await bound_log.aexception("error_comment_failed")
+        raise
+    finally:
+        if repo_path:
+            await asyncio.to_thread(shutil.rmtree, repo_path, True)

--- a/src/gitlab_copilot_agent/webhook.py
+++ b/src/gitlab_copilot_agent/webhook.py
@@ -5,7 +5,8 @@ import hmac
 import structlog
 from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, Request
 
-from gitlab_copilot_agent.models import MergeRequestWebhookPayload
+from gitlab_copilot_agent.models import MergeRequestWebhookPayload, NoteWebhookPayload
+from gitlab_copilot_agent.mr_comment_handler import handle_copilot_comment, parse_copilot_command
 from gitlab_copilot_agent.orchestrator import handle_review
 
 log = structlog.get_logger()
@@ -29,6 +30,14 @@ async def _process_review(request: Request, payload: MergeRequestWebhookPayload)
         await log.aexception("background_review_failed")
 
 
+async def _process_copilot_comment(request: Request, payload: NoteWebhookPayload) -> None:
+    settings = request.app.state.settings
+    try:
+        await handle_copilot_comment(settings, payload)
+    except Exception:
+        await log.aexception("background_copilot_comment_failed")
+
+
 @router.post("/webhook", status_code=200)
 async def webhook(
     request: Request,
@@ -40,16 +49,25 @@ async def webhook(
     _validate_webhook_token(x_gitlab_token, settings.gitlab_webhook_secret)
 
     body = await request.json()
+    object_kind = body.get("object_kind")
 
-    if body.get("object_kind") != "merge_request":
-        return {"status": "ignored", "reason": "not a merge request event"}
+    if object_kind == "merge_request":
+        payload = MergeRequestWebhookPayload.model_validate(body)
+        action = payload.object_attributes.action
+        if action not in HANDLED_ACTIONS:
+            return {"status": "ignored", "reason": f"action '{action}' not handled"}
+        background_tasks.add_task(_process_review, request, payload)
+        return {"status": "queued"}
 
-    payload = MergeRequestWebhookPayload.model_validate(body)
-    action = payload.object_attributes.action
+    if object_kind == "note":
+        note_payload = NoteWebhookPayload.model_validate(body)
+        if note_payload.object_attributes.noteable_type != "MergeRequest":
+            return {"status": "ignored", "reason": "not an MR note"}
+        if not parse_copilot_command(note_payload.object_attributes.note):
+            return {"status": "ignored", "reason": "not a /copilot command"}
+        if settings.agent_gitlab_username and note_payload.user.username == settings.agent_gitlab_username:
+            return {"status": "ignored", "reason": "self-comment"}
+        background_tasks.add_task(_process_copilot_comment, request, note_payload)
+        return {"status": "queued"}
 
-    if action not in HANDLED_ACTIONS:
-        return {"status": "ignored", "reason": f"action '{action}' not handled"}
-
-    background_tasks.add_task(_process_review, request, payload)
-
-    return {"status": "queued"}
+    return {"status": "ignored", "reason": f"unhandled event: {object_kind}"}

--- a/tests/test_coding_engine.py
+++ b/tests/test_coding_engine.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock, patch
 
-from gitlab_copilot_agent.coding_engine import SYSTEM_PROMPT, run_coding_task
+from gitlab_copilot_agent.coding_engine import CODING_SYSTEM_PROMPT, run_coding_task
 from tests.conftest import make_settings
 
 
@@ -22,6 +22,6 @@ async def test_run_coding_task_delegates_to_copilot_session(
 
     assert result == "Changes completed"
     call_args = mock_run_session.call_args[1]
-    assert call_args["system_prompt"] == SYSTEM_PROMPT
+    assert call_args["system_prompt"] == CODING_SYSTEM_PROMPT
     assert "PROJ-789" in call_args["user_prompt"]
     assert "Implement feature X" in call_args["user_prompt"]

--- a/tests/test_mr_comment_handler.py
+++ b/tests/test_mr_comment_handler.py
@@ -1,0 +1,60 @@
+"""Tests for the MR /copilot comment handler."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from gitlab_copilot_agent.mr_comment_handler import handle_copilot_comment, parse_copilot_command
+from gitlab_copilot_agent.models import (
+    NoteWebhookPayload, NoteObjectAttributes, NoteMergeRequest,
+    WebhookProject, WebhookUser,
+)
+from tests.conftest import make_settings
+
+
+def test_parse_copilot_command_valid() -> None:
+    assert parse_copilot_command("/copilot fix the null check") == "fix the null check"
+
+
+def test_parse_copilot_command_case_insensitive() -> None:
+    assert parse_copilot_command("/Copilot add tests") == "add tests"
+
+
+def test_parse_copilot_command_not_a_command() -> None:
+    assert parse_copilot_command("just a regular comment") is None
+
+
+def test_parse_copilot_command_empty_instruction() -> None:
+    assert parse_copilot_command("/copilot ") is None
+
+
+def _make_note_payload(note: str = "/copilot fix bug") -> NoteWebhookPayload:
+    return NoteWebhookPayload(
+        object_kind="note",
+        user=WebhookUser(id=1, username="reviewer"),
+        project=WebhookProject(id=42, path_with_namespace="g/p", git_http_url="https://gl.example.com/g/p.git"),
+        object_attributes=NoteObjectAttributes(note=note, noteable_type="MergeRequest"),
+        merge_request=NoteMergeRequest(iid=7, title="Fix", source_branch="feature/x", target_branch="main"),
+    )
+
+
+@patch("gitlab_copilot_agent.mr_comment_handler.GitLabClient")
+@patch("gitlab_copilot_agent.mr_comment_handler.run_copilot_session")
+@patch("gitlab_copilot_agent.mr_comment_handler.git_push")
+@patch("gitlab_copilot_agent.mr_comment_handler.git_commit")
+@patch("gitlab_copilot_agent.mr_comment_handler.git_clone")
+async def test_handle_full_pipeline(
+    mock_clone: AsyncMock, mock_commit: AsyncMock, mock_push: AsyncMock,
+    mock_session: AsyncMock, mock_gl_class: AsyncMock, tmp_path: Path,
+) -> None:
+    mock_clone.return_value = tmp_path
+    mock_session.return_value = "Fixed the bug"
+    mock_commit.return_value = True
+    mock_gl = AsyncMock()
+    mock_gl_class.return_value = mock_gl
+
+    await handle_copilot_comment(make_settings(), _make_note_payload())
+
+    mock_clone.assert_awaited_once()
+    mock_session.assert_awaited_once()
+    mock_push.assert_awaited_once()
+    mock_gl.post_mr_comment.assert_awaited_once()


### PR DESCRIPTION
## What
Adds /copilot command support on GitLab MR comments. Agent clones source branch, runs Copilot SDK session, commits, pushes, and replies.

## Why
Closes #10

## Changes
- coding_engine.py: generalized system prompt
- models.py: NoteWebhookPayload models  
- gitlab_client.py: post_mr_comment()
- config.py: agent_gitlab_username for loop prevention
- mr_comment_handler.py: full pipeline (new)
- webhook.py: note event routing

## Testing
101 tests, 91.67% coverage. Live E2E passed.

Closes #10