### PR TITLE
fix(reliability): reap timed-out git subprocesses

### DIFF
--- a/src/gitlab_copilot_agent/git_operations.py
+++ b/src/gitlab_copilot_agent/git_operations.py
@@ -77,6 +77,7 @@ async def _run_git(
         stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
     except TimeoutError as e:
         proc.kill()
+        await proc.wait()
         raise RuntimeError(f"git {' '.join(args)} timed out after {timeout}s") from e
 
     if proc.returncode != 0:
@@ -178,6 +179,7 @@ async def git_clone(clone_url: str, branch: str, token: str) -> Path:
             _, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
         except TimeoutError as e:
             proc.kill()
+            await proc.wait()
             shutil.rmtree(tmp_dir, ignore_errors=True)
             raise RuntimeError("git clone timed out after 120s") from e
         if proc.returncode != 0:


### PR DESCRIPTION
## What

Add `await proc.wait()` after `proc.kill()` in both timeout handlers in `git_operations.py` to properly reap terminated subprocesses.

## Why

When a git subprocess times out, sending SIGKILL without waiting leaves the process in the process table as a zombie until the parent exits. Over time with repeated timeouts, this leaks process table entries.

## Changes

- `_run_git()`: add `await proc.wait()` after termination (line 80)
- `git_clone()`: add `await proc.wait()` after termination (line 182)

## Testing

```
153 passed in 2.52s
coverage: 93.88% (>=90% threshold)
```

## OWASP Self-Review

- [x] All categories N/A — no auth, injection, crypto, or network changes
