### PR TITLE
fix(reliability): add memory bounds for in-memory trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,19 @@ docker run -p 8000:8000 \
   gitlab-copilot-agent
 ```
 
+## Operations
+
+### Memory Bounds
+
+The service uses in-memory structures that are bounded to prevent growth during long uptimes:
+
+| Structure | Purpose | Default Limit | Eviction Strategy |
+|---|---|---|---|
+| `RepoLockManager` | Serializes concurrent operations on the same repo | 1,024 entries | LRU — evicts oldest idle (unlocked) lock |
+| `ProcessedIssueTracker` | Prevents re-processing Jira issues within a run | 10,000 entries | Drops oldest 50% when limit is reached |
+
+Active locks are never evicted — the lock manager allows temporary over-capacity rather than dropping in-use locks. Both limits are configurable via constructor arguments but not currently exposed as environment variables.
+
 ## Development
 
 ```bash

--- a/src/gitlab_copilot_agent/concurrency.py
+++ b/src/gitlab_copilot_agent/concurrency.py
@@ -3,32 +3,104 @@
 from __future__ import annotations
 
 import asyncio
+from collections import OrderedDict
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
+import structlog
+
+log = structlog.get_logger()
+
+_DEFAULT_MAX_LOCKS = 1024
+_DEFAULT_MAX_PROCESSED = 10_000
+
 
 class RepoLockManager:
-    """Async lock per repo URL — serializes operations on the same repo."""
+    """Async lock per repo URL — serializes operations on the same repo.
 
-    def __init__(self) -> None:
-        self._locks: dict[str, asyncio.Lock] = {}
+    Uses LRU eviction to prevent unbounded memory growth when max_size is exceeded.
+    Locked entries are never evicted.
+    """
+
+    def __init__(self, max_size: int = _DEFAULT_MAX_LOCKS) -> None:
+        self._locks: OrderedDict[str, asyncio.Lock] = OrderedDict()
+        self._max_size = max_size
+
+    def _evict_unlocked(self) -> None:
+        """Evict oldest unlocked entries until within max_size."""
+        if len(self._locks) <= self._max_size:
+            return
+
+        to_evict = []
+        for repo_url, lock in self._locks.items():
+            if len(self._locks) - len(to_evict) <= self._max_size:
+                break
+            if not lock.locked():
+                to_evict.append(repo_url)
+
+        for repo_url in to_evict:
+            del self._locks[repo_url]
+
+        if to_evict:
+            log.warning(
+                "repo_lock_eviction",
+                evicted_count=len(to_evict),
+                max_size=self._max_size,
+                current_size=len(self._locks),
+            )
 
     @asynccontextmanager
     async def acquire(self, repo_url: str) -> AsyncIterator[None]:
         if repo_url not in self._locks:
             self._locks[repo_url] = asyncio.Lock()
+        else:
+            # Move to end (LRU)
+            self._locks.move_to_end(repo_url)
+
         async with self._locks[repo_url]:
             yield
 
+        # Evict after release
+        self._evict_unlocked()
+
+    def __len__(self) -> int:
+        return len(self._locks)
+
 
 class ProcessedIssueTracker:
-    """Track processed Jira issue keys to avoid re-processing within a run."""
+    """Track processed Jira issue keys to avoid re-processing within a run.
 
-    def __init__(self) -> None:
-        self._processed: set[str] = set()
+    Uses size-based eviction to prevent unbounded memory growth when max_size is exceeded.
+    """
+
+    def __init__(self, max_size: int = _DEFAULT_MAX_PROCESSED) -> None:
+        self._processed: OrderedDict[str, None] = OrderedDict()
+        self._max_size = max_size
+
+    def _evict_if_needed(self) -> None:
+        """Clear oldest half of entries when max_size is exceeded."""
+        if len(self._processed) <= self._max_size:
+            return
+
+        target_size = self._max_size // 2
+        evict_count = len(self._processed) - target_size
+
+        for _ in range(evict_count):
+            self._processed.popitem(last=False)
+
+        log.warning(
+            "processed_issue_eviction",
+            evicted_count=evict_count,
+            max_size=self._max_size,
+            current_size=len(self._processed),
+        )
 
     def is_processed(self, key: str) -> bool:
         return key in self._processed
 
     def mark(self, key: str) -> None:
-        self._processed.add(key)
+        self._processed[key] = None
+        self._evict_if_needed()
+
+    def __len__(self) -> int:
+        return len(self._processed)

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -32,9 +32,130 @@ async def test_repo_lock_allows_parallel_different_repos() -> None:
     assert len(started) == 2
 
 
+async def test_repo_lock_evicts_when_max_size_exceeded() -> None:
+    """Test that RepoLockManager evicts oldest unlocked entries when max_size exceeded."""
+    locks = RepoLockManager(max_size=3)
+
+    # Add 3 repos (at max_size)
+    async with locks.acquire("https://repo1.git"):
+        pass
+    async with locks.acquire("https://repo2.git"):
+        pass
+    async with locks.acquire("https://repo3.git"):
+        pass
+
+    assert len(locks) == 3
+
+    # Add a 4th repo - should trigger eviction of oldest (repo1)
+    async with locks.acquire("https://repo4.git"):
+        pass
+
+    assert len(locks) == 3
+    assert "https://repo1.git" not in locks._locks
+    assert "https://repo4.git" in locks._locks
+
+
+async def test_repo_lock_does_not_evict_locked_entries() -> None:
+    """Test that locked entries are never evicted, even when max_size exceeded."""
+    locks = RepoLockManager(max_size=2)
+
+    # Acquire repo1 and hold it
+    async with locks.acquire("https://repo1.git"):
+        # Add repo2
+        async with locks.acquire("https://repo2.git"):
+            pass
+
+        # Add repo3 - should evict repo2 (unlocked), not repo1 (locked)
+        async with locks.acquire("https://repo3.git"):
+            pass
+
+        # repo1 should still be present (it's locked)
+        assert "https://repo1.git" in locks._locks
+        # repo2 should be evicted
+        assert "https://repo2.git" not in locks._locks
+        # repo3 should be present
+        assert "https://repo3.git" in locks._locks
+
+
+async def test_repo_lock_lru_behavior() -> None:
+    """Test that RepoLockManager uses LRU (moves accessed items to end)."""
+    locks = RepoLockManager(max_size=3)
+
+    # Add 3 repos
+    async with locks.acquire("https://repo1.git"):
+        pass
+    async with locks.acquire("https://repo2.git"):
+        pass
+    async with locks.acquire("https://repo3.git"):
+        pass
+
+    # Access repo1 again (moves it to end)
+    async with locks.acquire("https://repo1.git"):
+        pass
+
+    # Add repo4 - should evict repo2 (oldest), not repo1 (recently used)
+    async with locks.acquire("https://repo4.git"):
+        pass
+
+    assert "https://repo1.git" in locks._locks
+    assert "https://repo2.git" not in locks._locks
+    assert "https://repo3.git" in locks._locks
+    assert "https://repo4.git" in locks._locks
+
+
 async def test_processed_issue_tracker() -> None:
     tracker = ProcessedIssueTracker()
     assert not tracker.is_processed("KAN-1")
     tracker.mark("KAN-1")
     assert tracker.is_processed("KAN-1")
     assert not tracker.is_processed("KAN-2")
+
+
+async def test_processed_issue_tracker_evicts_when_max_size_exceeded() -> None:
+    """Test that ProcessedIssueTracker evicts oldest half when max_size exceeded."""
+    tracker = ProcessedIssueTracker(max_size=10)
+
+    # Add 10 issues (at max_size)
+    for i in range(10):
+        tracker.mark(f"ISSUE-{i}")
+
+    assert len(tracker._processed) == 10
+
+    # Add one more - should trigger eviction of oldest entries down to max_size // 2 = 5
+    tracker.mark("ISSUE-10")
+
+    assert len(tracker) == 5
+
+    # First 6 should be evicted (10 - 5 + 1 = 6 evicted to get to 5)
+    for i in range(6):
+        assert not tracker.is_processed(f"ISSUE-{i}")
+
+    # Last 5 should remain
+    for i in range(6, 11):
+        assert tracker.is_processed(f"ISSUE-{i}")
+
+
+async def test_processed_issue_tracker_preserves_insertion_order() -> None:
+    """Test that ProcessedIssueTracker maintains insertion order for eviction."""
+    tracker = ProcessedIssueTracker(max_size=6)
+
+    # Add 6 issues
+    for i in range(6):
+        tracker.mark(f"ISSUE-{i}")
+
+    # Add one more to trigger eviction (target_size = 6 // 2 = 3)
+    tracker.mark("ISSUE-6")
+
+    # Should have 3 items remaining
+    assert len(tracker) == 3
+
+    # Should evict oldest 4 (ISSUE-0, ISSUE-1, ISSUE-2, ISSUE-3)
+    assert not tracker.is_processed("ISSUE-0")
+    assert not tracker.is_processed("ISSUE-1")
+    assert not tracker.is_processed("ISSUE-2")
+    assert not tracker.is_processed("ISSUE-3")
+
+    # Should keep newest 3 (ISSUE-4, ISSUE-5, ISSUE-6)
+    assert tracker.is_processed("ISSUE-4")
+    assert tracker.is_processed("ISSUE-5")
+    assert tracker.is_processed("ISSUE-6")


### PR DESCRIPTION
## What

Two data structures in `concurrency.py` grow unbounded during service lifetime:
1. **`RepoLockManager._locks`** — one entry per unique repo URL, never evicted
2. **`ProcessedIssueTracker._processed`** — one entry per processed Jira issue key, never evicted

For a long-running service processing many repos and issues, these will consume unbounded memory.

## Why

Production deployments running for days/weeks would accumulate thousands of entries:
- Large GitLab instances may process hundreds of unique repos
- Jira integrations process thousands of issue keys over time
- Without bounds, memory grows linearly with service uptime

## Approach

### RepoLockManager
- Use `OrderedDict` instead of `dict` to track insertion/access order
- Add `max_size` parameter (default 1024)
- Implement LRU eviction: move accessed entries to end, evict oldest
- **Never evict locked entries** — only idle locks are candidates for eviction
- Log warnings when eviction occurs

### ProcessedIssueTracker
- Use `OrderedDict` instead of `set` to maintain insertion order
- Add `max_size` parameter (default 10,000)
- When limit exceeded, evict oldest half (aggressive batch eviction)
- Log warnings when eviction occurs

## Changes

- `src/gitlab_copilot_agent/concurrency.py`: Add bounded data structures with eviction
- `tests/test_concurrency.py`: Add comprehensive eviction tests

## Testing

All tests pass with 100% coverage on `concurrency.py`:

```
tests/test_concurrency.py::test_repo_lock_serializes_same_repo PASSED    [ 12%]
tests/test_concurrency.py::test_repo_lock_allows_parallel_different_repos PASSED [ 25%]
tests/test_concurrency.py::test_repo_lock_evicts_when_max_size_exceeded PASSED [ 37%]
tests/test_concurrency.py::test_repo_lock_does_not_evict_locked_entries PASSED [ 50%]
tests/test_concurrency.py::test_repo_lock_lru_behavior PASSED            [ 62%]
tests/test_concurrency.py::test_processed_issue_tracker PASSED           [ 75%]
tests/test_concurrency.py::test_processed_issue_tracker_evicts_when_max_size_exceeded PASSED [ 87%]
tests/test_concurrency.py::test_processed_issue_tracker_preserves_insertion_order PASSED [100%]

src/gitlab_copilot_agent/concurrency.py: 100% coverage
```

### Test Coverage
- ✅ Lock manager eviction when max_size exceeded
- ✅ Locked entries are never evicted
- ✅ LRU behavior (recently accessed entries preserved)
- ✅ Processed tracker eviction when max_size exceeded
- ✅ Insertion order preserved during eviction