### PR TITLE
chore(security): drop SYS_ADMIN from devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "ghcr.io/devcontainers/features/node:1": {}
   },
   "postCreateCommand": "pipx install uv && uv sync --all-extras && npm install -g @github/copilot && sudo apt-get update && sudo apt-get install -y bubblewrap && uv --version",
-  "runArgs": ["--cap-add=SYS_ADMIN", "--security-opt", "seccomp=unconfined"],
+  "runArgs": ["--security-opt", "seccomp=unconfined"],
   "customizations": {
     "vscode": {
       "extensions": ["GitHub.copilot"]


### PR DESCRIPTION
## What

Remove unnecessary `--cap-add=SYS_ADMIN` from devcontainer.json. Testing confirmed bwrap works with `seccomp=unconfined` alone.

Closes #50
Part of #35, #27

## Diff

1 file, 1 insertion, 1 deletion

## Out of Scope

Custom seccomp profile deferred — the generated profile had 299 syscalls (basically Docker default + extras). Will do properly with strace audit later.