### PR TITLE
feat(sandbox): implement ContainerSandbox for Docker/Podman isolation

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -1,0 +1,8 @@
+FROM node:22-slim
+
+# Install Copilot CLI — version must match the CLI bundled by github-copilot-sdk
+RUN npm install -g @github/copilot@0.0.410 && npm cache clean --force
+
+USER 1000
+WORKDIR /workspace
+ENTRYPOINT ["copilot"]

--- a/scripts/build-sandbox-image.sh
+++ b/scripts/build-sandbox-image.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Extract CLI version from Dockerfile.sandbox
+CLI_VERSION=$(grep '@github/copilot@' "$REPO_ROOT/Dockerfile.sandbox" | sed 's/.*@github\/copilot@\([^ ]*\).*/\1/')
+
+echo "Building sandbox image (CLI ${CLI_VERSION})"
+docker build \
+  -t "copilot-cli-sandbox:${CLI_VERSION}" \
+  -t "copilot-cli-sandbox:latest" \
+  -f "$REPO_ROOT/Dockerfile.sandbox" "$REPO_ROOT"
+echo "Tagged: copilot-cli-sandbox:${CLI_VERSION}, copilot-cli-sandbox:latest"

--- a/src/gitlab_copilot_agent/config.py
+++ b/src/gitlab_copilot_agent/config.py
@@ -60,6 +60,10 @@ class Settings(BaseSettings):
         default="bwrap",
         description="Process sandbox method: bwrap, docker, podman, or noop",
     )
+    sandbox_image: str = Field(
+        default="copilot-cli-sandbox:latest",
+        description="Container image for docker/podman sandbox",
+    )
 
     # Jira (all optional — service runs review-only without these)
     jira_url: str | None = Field(default=None, description="Jira instance URL")


### PR DESCRIPTION
## What

Replace the `ContainerSandbox` stub with a real implementation. Adds Docker/Podman-based isolation for Copilot CLI sessions with security hardening, resource limits, and a minimal sandbox image.

Closes #45
Part of #27

## Changes

- **process_sandbox.py**: Full `ContainerSandbox` — `preflight()` validates runtime + image, `create_cli_wrapper()` generates hardened `docker run` script, `cleanup()` removes script
- **Dockerfile.sandbox**: Minimal `node:22-slim` + `@github/copilot@0.0.410`, non-root (USER 1000)
- **scripts/build-sandbox-image.sh**: Build script extracts CLI version from Dockerfile
- **tests/test_process_sandbox.py**: 8 new tests replacing 2 stub tests

## Security Hardening

Container runs with:
- `--pull=never` (prevents unintended remote image pulls)
- `--read-only` filesystem + `--tmpfs /tmp`
- `--cap-drop=ALL --security-opt=no-new-privileges`
- `--user <host-uid>:<host-gid>` (matches invoking user, not hardcoded)
- `--network=bridge`
- `--cpus=1 --memory=2g --pids-limit=256`
- Only `GITHUB_TOKEN` env var passed in

## GPT-5.3-Codex Review

Caught two issues, both fixed:
1. **UID mismatch**: Originally hardcoded `--user 1000:1000` — would fail on hosts with different UIDs. Fixed to use `os.getuid():os.getgid()`.
2. **Unintended image pull**: Without `--pull=never`, Docker could pull an uncontrolled remote image if local image was deleted after preflight. Fixed by adding `--pull=never`.

## E2E Test Results

```
✅ Sandbox image builds: copilot-cli-sandbox:0.0.410
✅ Service image builds
✅ Health check: {"status": "ok"}
✅ Startup log: sandbox_method_configured method=noop
✅ MR webhook: 500 (expected — no real GitLab)
✅ Invalid token: 401 rejected
```

## Unit Tests

```
174 passed in 3.40s
Coverage: 94.67% (process_sandbox.py: 100%)
ruff/mypy/format: all clean
```

## Diff

4 files, 181 insertions, 26 deletions (207 total)

## OWASP Self-Review

- [x] Broken Access Control — container runs as invoking user, not root
- [x] Injection — repo_path shell-quoted via shlex.quote
- [x] Insecure Design — --pull=never prevents supply chain attack via unqualified image name
- [x] Security Misconfiguration — --cap-drop=ALL, --read-only, --no-new-privileges
- [x] Vulnerable Components — CLI version pinned in Dockerfile
- [x] Logging — sandbox method logged at creation (DEBUG)