### PR TITLE
feat(observability): add OTel metrics infrastructure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "opentelemetry-sdk==1.30.0",
     "opentelemetry-exporter-otlp-proto-grpc==1.30.0",
     "opentelemetry-instrumentation-fastapi==0.51b0",
+    "opentelemetry-instrumentation-httpx==0.51b0",
 ]
 
 [project.optional-dependencies]

--- a/src/gitlab_copilot_agent/__init__.py
+++ b/src/gitlab_copilot_agent/__init__.py
@@ -1,3 +1,3 @@
 """GitLab Copilot Agent — Automated MR reviews powered by GitHub Copilot SDK."""
 
-__all__: list[str] = []
+__all__: list[str] = ["metrics"]

--- a/src/gitlab_copilot_agent/metrics.py
+++ b/src/gitlab_copilot_agent/metrics.py
@@ -1,0 +1,51 @@
+"""Shared OTel metrics instruments for the service."""
+
+from opentelemetry import metrics
+
+METER_NAME = "gitlab_copilot_agent"
+
+meter = metrics.get_meter(METER_NAME)
+
+# Service metrics
+reviews_total = meter.create_counter(
+    name="reviews_total",
+    description="Total MR reviews processed",
+    unit="1",
+)
+
+reviews_duration = meter.create_histogram(
+    name="reviews_duration_seconds",
+    description="Duration of MR review processing",
+    unit="s",
+)
+
+coding_tasks_total = meter.create_counter(
+    name="coding_tasks_total",
+    description="Total coding tasks processed",
+    unit="1",
+)
+
+coding_tasks_duration = meter.create_histogram(
+    name="coding_tasks_duration_seconds",
+    description="Duration of coding task processing",
+    unit="s",
+)
+
+webhook_received_total = meter.create_counter(
+    name="webhook_received_total",
+    description="Total webhooks received",
+    unit="1",
+)
+
+# Sandbox metrics
+sandbox_duration = meter.create_histogram(
+    name="sandbox_duration_seconds",
+    description="Duration of sandbox CLI execution",
+    unit="s",
+)
+
+sandbox_active = meter.create_up_down_counter(
+    name="sandbox_active",
+    description="Currently active sandbox sessions",
+    unit="1",
+)

--- a/uv.lock
+++ b/uv.lock
@@ -259,6 +259,7 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
     { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-httpx" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -292,6 +293,7 @@ requires-dist = [
     { name = "opentelemetry-api", specifier = "==1.30.0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = "==1.30.0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = "==0.51b0" },
+    { name = "opentelemetry-instrumentation-httpx", specifier = "==0.51b0" },
     { name = "opentelemetry-sdk", specifier = "==1.30.0" },
     { name = "pydantic", specifier = "==2.10.6" },
     { name = "pydantic-settings", specifier = "==2.7.1" },
@@ -579,6 +581,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2d/dc/8db4422b5084177d1ef6c7855c69bf2e9e689f595a4a9b59e60588e0d427/opentelemetry_instrumentation_fastapi-0.51b0.tar.gz", hash = "sha256:1624e70f2f4d12ceb792d8a0c331244cd6723190ccee01336273b4559bc13abc", size = 19249, upload-time = "2025-02-04T18:21:28.379Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/1c/ec2d816b78edf2404d7b3df6d09eefb690b70bfd191b7da06f76634f1bdc/opentelemetry_instrumentation_fastapi-0.51b0-py3-none-any.whl", hash = "sha256:10513bbc11a1188adb9c1d2c520695f7a8f2b5f4de14e8162098035901cd6493", size = 12117, upload-time = "2025-02-04T18:20:15.267Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-httpx"
+version = "0.51b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/d5/4a3990c461ae7e55212115e0f8f3aa412b5ce6493579e85c292245ac69ea/opentelemetry_instrumentation_httpx-0.51b0.tar.gz", hash = "sha256:061d426a04bf5215a859fea46662e5074f920e5cbde7e6ad6825a0a1b595802c", size = 17700, upload-time = "2025-02-04T18:21:31.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/ba/23d4ab6402408c01f1c3f32e0c04ea6dae575bf19bcb9a0049c9e768c983/opentelemetry_instrumentation_httpx-0.51b0-py3-none-any.whl", hash = "sha256:2e3fdf755ba6ead6ab43031497c3d55d4c796d0368eccc0ce48d304b7ec6486a", size = 14109, upload-time = "2025-02-04T18:20:19.947Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Add OTel MeterProvider infrastructure alongside existing TracerProvider, and a shared `metrics.py` module with pre-defined instruments.

Closes #57
Part of #46, epic #27.

## Changes

- **telemetry.py**: Add MeterProvider + OTLP gRPC exporter (same endpoint as traces). Idempotency guard prevents leaked threads on repeated init.
- **metrics.py**: New shared module with 7 instruments — counters for reviews/coding_tasks/webhooks, histograms for durations, UpDownCounter for active sandbox sessions.
- **pyproject.toml**: Add `opentelemetry-instrumentation-httpx` dependency for next PR.
- **__init__.py**: Export metrics module.

## Testing

```
$ pytest tests/ -q --tb=short --cov-fail-under=90
174 passed in 3.01s
Coverage: 93.93% (threshold: 90%)
```

### E2E
```
$ curl -s http://localhost:8000/health
{"status":"ok"}

$ curl -s -w "\nHTTP %{http_code}" -X POST /webhook -H "X-Gitlab-Token: wrong" ...
HTTP 401

$ python -c "from gitlab_copilot_agent.metrics import reviews_total, METER_NAME; print(f\"meter={METER_NAME}, OK\")"
meter=gitlab_copilot_agent, OK
```

Service starts cleanly, metrics import without OTLP endpoint (graceful no-op).

## GPT-5.3-Codex Review

Caught: `init_telemetry()` could leak metric export threads if called multiple times (tests, reloads). Fixed with `_initialized` idempotency guard + reset in `shutdown_telemetry()`.

## Diff

94 lines (additions + deletions)