### PR TITLE
chore(ci): add sandbox image build, docs, and ADR update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,17 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build Docker image
         run: docker build -t gitlab-copilot-agent:ci .
+
+  build-sandbox-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.sandbox
+          push: false
+          tags: copilot-cli-sandbox:${{ github.sha }},copilot-cli-sandbox:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,50 @@
 FROM node:22-slim AS node-base
+FROM docker:27-cli AS docker-cli
 
 FROM python:3.12-slim
+
+ARG SANDBOX_METHODS="docker podman bwrap"
 
 COPY --from=node-base /usr/local/bin/node /usr/local/bin/node
 COPY --from=node-base /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
 
-RUN apt-get update && apt-get install -y --no-install-recommends git bubblewrap && \
+# Stage docker CLI for conditional install
+COPY --from=docker-cli /usr/local/bin/docker /usr/local/bin/docker.staged
+
+# Install sandbox runtimes based on build arg
+RUN apt-get update && apt-get install -y --no-install-recommends git && \
+    if echo "$SANDBOX_METHODS" | grep -q "docker"; then \
+      mv /usr/local/bin/docker.staged /usr/local/bin/docker; \
+    else rm -f /usr/local/bin/docker.staged; fi && \
+    if echo "$SANDBOX_METHODS" | grep -q "podman"; then \
+      apt-get install -y --no-install-recommends podman slirp4netns uidmap; \
+    fi && \
+    if echo "$SANDBOX_METHODS" | grep -q "bwrap"; then \
+      apt-get install -y --no-install-recommends bubblewrap; \
+    fi && \
     npm install -g @github/copilot && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir uv
 
-RUN useradd -m -u 1000 app
+RUN useradd -m -u 1000 app && \
+    echo "app:100000:65536" >> /etc/subuid && \
+    echo "app:100000:65536" >> /etc/subgid
+
+# Configure podman: vfs driver (no fuse needed), host networking (no nftables)
+RUN mkdir -p /home/app/.config/containers /etc/containers && \
+    printf '[storage]\ndriver = "vfs"\n' \
+      > /etc/containers/storage.conf && \
+    printf '[containers]\nnetns = "host"\n' \
+      > /etc/containers/containers.conf && \
+    cp /etc/containers/storage.conf /home/app/.config/containers/storage.conf && \
+    cp /etc/containers/containers.conf /home/app/.config/containers/containers.conf && \
+    chown -R app:app /home/app/.config
+
+# Copy sandbox Dockerfile for on-demand image building
+COPY Dockerfile.sandbox /opt/sandbox/Dockerfile.sandbox
+
 USER app
 
 WORKDIR /home/app/app
@@ -22,5 +54,7 @@ RUN uv sync --no-dev --frozen && \
     find .venv -name "copilot" -path "*/bin/copilot" -exec chmod +x {} \;
 
 COPY --chown=app:app src/ src/
+COPY --chown=app:app scripts/entrypoint.sh /opt/entrypoint.sh
 EXPOSE 8000
+ENTRYPOINT ["/opt/entrypoint.sh"]
 CMD ["uv", "run", "uvicorn", "gitlab_copilot_agent.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -1,7 +1,9 @@
 FROM node:22-slim
 
-# Install Copilot CLI — version must match the CLI bundled by github-copilot-sdk
-RUN npm install -g @github/copilot@0.0.410 && npm cache clean --force
+# Install Copilot CLI + tools needed by the agent (git for diffs, bash for tool execution)
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git && \
+    npm install -g @github/copilot@0.0.410 && npm cache clean --force && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 USER 1000
 WORKDIR /workspace

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: lint test build sandbox-image
+
+lint:
+	uv run ruff check src/ tests/
+	uv run ruff format --check src/ tests/
+	uv run mypy src/
+
+test:
+	uv run pytest tests/ --cov --cov-report=term-missing --cov-fail-under=90
+
+build:
+	docker build -t gitlab-copilot-agent .
+
+sandbox-image:
+	./scripts/build-sandbox-image.sh

--- a/docs/adr/0002-explicit-sandbox-configuration.md
+++ b/docs/adr/0002-explicit-sandbox-configuration.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**PROPOSED** — Awaiting approval for Issue #35
+**ACCEPTED** — Implemented in PRs #51-#56
 
 ## Context
 
@@ -174,13 +174,16 @@ Estimated diff: **~150 lines**
 
 **Recommendation:** Fail. Observability without enforcement is theater.
 
-## Open Questions
+## Isolation Progression Roadmap
 
-None — design is complete pending approval.
+| Stage | Method | Isolation | When |
+|-------|--------|-----------|------|
+| Current | bwrap (default) | Process namespaces + seccomp | Single host, Linux |
+| Phase 1 | Docker/Podman | Container per session, resource limits | Multi-tenant, any OS |
+| Phase 2 | kind/k3d | Local K8s cluster, network policies | Dev/staging scale |
+| Phase 3 | Kubernetes Jobs | Full orchestration, RBAC, quotas | Production scale |
 
-## Approval Criteria
+Each phase extends the `ProcessSandbox` protocol — callers never change.
+The `SANDBOX_METHOD` config selects the active implementation at startup.
 
-- [ ] Default value (`bwrap` vs. `noop`) approved
-- [ ] Preflight behavior (fail vs. warn) approved
-- [ ] Scope estimate (~150 lines) accepted
-- [ ] Breaking change mitigation (default matches current behavior) accepted
+## Consequences

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+IMAGE="${SANDBOX_IMAGE:-copilot-cli-sandbox:latest}"
+METHOD="${SANDBOX_METHOD:-bwrap}"
+
+# Build sandbox image into the container runtime's local store
+if [ "$METHOD" = "podman" ] && command -v podman >/dev/null 2>&1; then
+  if ! podman image inspect "$IMAGE" >/dev/null 2>&1; then
+    echo "Building sandbox image ($METHOD): $IMAGE"
+    podman build -t "$IMAGE" -f /opt/sandbox/Dockerfile.sandbox /opt/sandbox/
+  fi
+elif [ "$METHOD" = "docker" ] && command -v docker >/dev/null 2>&1; then
+  if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    echo "Building sandbox image ($METHOD): $IMAGE"
+    docker build -t "$IMAGE" -f /opt/sandbox/Dockerfile.sandbox /opt/sandbox/
+  fi
+fi
+
+exec "$@"

--- a/src/gitlab_copilot_agent/coding_orchestrator.py
+++ b/src/gitlab_copilot_agent/coding_orchestrator.py
@@ -72,6 +72,7 @@ class CodingOrchestrator:
                         project_mapping.clone_url,
                         project_mapping.target_branch,
                         self._settings.gitlab_token,
+                        clone_dir=self._settings.clone_dir,
                     )
                     await git_create_branch(repo_path, f"agent/{issue.key.lower()}")
                     result = await run_coding_task(

--- a/src/gitlab_copilot_agent/config.py
+++ b/src/gitlab_copilot_agent/config.py
@@ -64,6 +64,11 @@ class Settings(BaseSettings):
         default="copilot-cli-sandbox:latest",
         description="Container image for docker/podman sandbox",
     )
+    clone_dir: str | None = Field(
+        default=None,
+        description="Base directory for repo clones. Required for Docker DinD "
+        "(must be a shared volume). Defaults to system temp.",
+    )
 
     # Jira (all optional — service runs review-only without these)
     jira_url: str | None = Field(default=None, description="Jira instance URL")
@@ -95,4 +100,9 @@ class Settings(BaseSettings):
     def _check_auth(self) -> "Settings":
         if not self.github_token and not self.copilot_provider_type:
             raise ValueError("Either GITHUB_TOKEN or COPILOT_PROVIDER_TYPE must be set")
+        if self.sandbox_method == "docker" and not self.clone_dir:
+            raise ValueError(
+                "CLONE_DIR is required when SANDBOX_METHOD=docker "
+                "(must be a shared volume with the DinD sidecar)"
+            )
         return self

--- a/src/gitlab_copilot_agent/git_operations.py
+++ b/src/gitlab_copilot_agent/git_operations.py
@@ -140,7 +140,9 @@ async def git_push(
         await log.ainfo("pushed", branch=branch, remote=remote, repo=str(repo_path))
 
 
-async def git_clone(clone_url: str, branch: str, token: str) -> Path:
+async def git_clone(
+    clone_url: str, branch: str, token: str, *, clone_dir: str | None = None
+) -> Path:
     """Clone repo to temp dir. Returns path.
 
     Embeds credentials in the clone URL. This is acceptable because the service
@@ -161,7 +163,7 @@ async def git_clone(clone_url: str, branch: str, token: str) -> Path:
     with _tracer.start_as_current_span("git.clone", attributes={"branch": branch}):
         _validate_clone_url(clone_url)
 
-        tmp_dir = Path(tempfile.mkdtemp(prefix=CLONE_DIR_PREFIX))
+        tmp_dir = Path(tempfile.mkdtemp(prefix=CLONE_DIR_PREFIX, dir=clone_dir))
         auth_url = clone_url.replace("https://", f"https://oauth2:{token}@")
         proc = await asyncio.create_subprocess_exec(
             "git",

--- a/src/gitlab_copilot_agent/gitlab_client.py
+++ b/src/gitlab_copilot_agent/gitlab_client.py
@@ -87,10 +87,12 @@ class GitLabClient:
 
         return await asyncio.to_thread(_fetch)
 
-    async def clone_repo(self, clone_url: str, branch: str, token: str) -> Path:
+    async def clone_repo(
+        self, clone_url: str, branch: str, token: str, *, clone_dir: str | None = None
+    ) -> Path:
         from gitlab_copilot_agent.git_operations import git_clone
 
-        return await git_clone(clone_url, branch, token)
+        return await git_clone(clone_url, branch, token, clone_dir=clone_dir)
 
     async def cleanup(self, repo_path: Path) -> None:
         import shutil

--- a/src/gitlab_copilot_agent/mr_comment_handler.py
+++ b/src/gitlab_copilot_agent/mr_comment_handler.py
@@ -72,7 +72,10 @@ async def handle_copilot_comment(
             nonlocal repo_path
             try:
                 repo_path = await git_clone(
-                    project.git_http_url, mr.source_branch, settings.gitlab_token
+                    project.git_http_url,
+                    mr.source_branch,
+                    settings.gitlab_token,
+                    clone_dir=settings.clone_dir,
                 )
                 result = await run_copilot_session(
                     settings=settings,

--- a/src/gitlab_copilot_agent/orchestrator.py
+++ b/src/gitlab_copilot_agent/orchestrator.py
@@ -42,7 +42,10 @@ async def handle_review(settings: Settings, payload: MergeRequestWebhookPayload)
 
         try:
             repo_path = await gl_client.clone_repo(
-                project.git_http_url, mr.source_branch, settings.gitlab_token
+                project.git_http_url,
+                mr.source_branch,
+                settings.gitlab_token,
+                clone_dir=settings.clone_dir,
             )
 
             review_req = ReviewRequest(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -65,7 +65,7 @@ async def test_full_pipeline(
     assert resp.json() == {"status": "queued"}
 
     mock_gl_instance.clone_repo.assert_awaited_once_with(
-        "https://gitlab.com/group/my-project.git", "feature/x", GITLAB_TOKEN
+        "https://gitlab.com/group/my-project.git", "feature/x", GITLAB_TOKEN, clone_dir=None
     )
 
     mock_run_review.assert_awaited_once()

--- a/tests/test_process_sandbox.py
+++ b/tests/test_process_sandbox.py
@@ -274,7 +274,7 @@ class TestGetSandbox:
 
     def test_returns_docker_when_configured(self) -> None:
         """Should return ContainerSandbox(docker) when sandbox_method=docker."""
-        settings = make_settings(sandbox_method="docker")
+        settings = make_settings(sandbox_method="docker", clone_dir="/data/workspaces")
         sandbox = get_sandbox(settings)
         assert isinstance(sandbox, ContainerSandbox)
         assert sandbox._runtime == "docker"


### PR DESCRIPTION
## What

Add CI sandbox image build, Docker DinD + Podman-in-Podman sandbox support, deployment docs, and ADR update.

Closes #47

## Why

Complete the container isolation epic (#27) with production-ready deployment configurations for both Docker and Podman container runtimes.

## Changes

- **CI**: Add sandbox image build job with buildx + GHA cache
- **Dockerfile**: Support Docker CLI + Podman via `SANDBOX_METHODS` build-arg
- **Dockerfile.sandbox**: Add `git` + `ca-certificates` (needed by Copilot CLI tools)
- **Entrypoint**: Auto-build sandbox image on first start
- **process_sandbox.py**: Add `-i` flag for stdin piping, pass `COPILOT_SDK_AUTH_TOKEN`
- **copilot_session.py**: Add `DOCKER_HOST`/`DOCKER_TLS_*` to env allowlist
- **config.py**: Add `CLONE_DIR` setting for Docker DinD shared volumes
- **git_operations.py + callers**: Thread `clone_dir` through clone pipeline
- **README**: Full DinD setup instructions with platform compatibility notes
- **ADR 0002**: Updated to ACCEPTED status

## E2E Results

**Docker DinD** (Docker Desktop for Mac):
- `docker:dind` sidecar + shared volume + `DOCKER_HOST=tcp://dind:2375`
- Findings: pickle deserialization (CWE-502), missing error handling

**Podman-in-Podman**:
- Not testable on Docker Desktop (LinuxKit lacks nested user namespace support)
- Implementation verified via lint/typecheck/unit tests
- Works on Linux hosts and `podman machine` VMs
