### PR TITLE
chore: add learnings from container isolation epic

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -62,6 +62,7 @@ Yolo agents: document assumptions in commit messages and PR descriptions.
 
 - ≤200 diff lines (additions + deletions). If larger, split into stacked PRs.
 - Each stacked PR must be fully functional and standalone.
+- **Code review before push**: invoke a code review agent (ideally a different model than the one that wrote the code) on every PR. Fix all High/Critical findings before merge. Create follow-up issues for Medium findings.
 - PR description format:
   ```
   ## What

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: code-review
+description: Cross-model code review before every PR. Use this after code is written and before pushing.
+---
+
+## When to Review
+
+Every PR gets a code review before push. No exceptions.
+
+## How to Review
+
+1. Use a **different model** than the one that wrote the code. Cross-model review consistently catches bugs that self-review misses.
+2. Review the branch diff against the base branch, not individual files.
+3. Focus on: bugs, security issues, logic errors, missing edge cases. Ignore style and formatting.
+
+## Handling Findings
+
+| Severity | Action |
+|----------|--------|
+| **Critical/High** | Fix before merge. No exceptions. |
+| **Medium** | Fix if within scope. Otherwise create a follow-up issue. |
+| **Low/Info** | Note in PR description. Fix if trivial. |
+
+## What Good Reviews Catch
+
+Real examples from production sessions:
+
+- **Idempotency bugs**: init function leaks threads when called twice
+- **Env var leakage**: `DOCKER_HOST` forwarded to all sandbox methods, enabling container escape from bwrap
+- **Missing validation**: config allows invalid state (e.g., DinD without shared volume)
+- **Drift bugs**: counter incremented before the thing it counts actually happens
+- **Uncounted paths**: error handling that skips metric recording
+
+## Anti-Patterns
+
+- Reviewing your own code with the same model that wrote it (blind spots are shared)
+- Skipping review for "small" changes (small changes cause big outages)
+- Treating all findings as blocking (Medium findings can be follow-up issues)
+- Reviewing style instead of substance (formatters handle style)

--- a/.github/skills/container-hardening/SKILL.md
+++ b/.github/skills/container-hardening/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: container-hardening
+description: Production Dockerfile and container runtime security checklist. Use this when building Docker/Podman images or configuring container deployments.
+---
+
+## Production Dockerfile Checklist
+
+- [ ] Multi-stage build (build deps don't ship in final image)
+- [ ] Base image pinned to digest or specific version (not `latest`)
+- [ ] `ca-certificates` installed (slim/minimal images often lack them — HTTPS fails silently)
+- [ ] Non-root user created and set with `USER`
+- [ ] `apt-get clean && rm -rf /var/lib/apt/lists/*` after installs
+- [ ] `--no-install-recommends` on all `apt-get install` commands
+- [ ] No secrets in build args or layers (use runtime env vars or mounted secrets)
+
+## Runtime Hardening Flags
+
+Apply defense-in-depth when running containers:
+
+| Flag | Purpose |
+|------|---------|
+| `--read-only` | Immutable root filesystem — prevents writes outside designated paths |
+| `--tmpfs /tmp` | Writable temp space on an otherwise read-only container |
+| `--cap-drop=ALL` | Drop all Linux capabilities — add back only what's needed |
+| `--security-opt=no-new-privileges` | Prevent privilege escalation via setuid/setgid |
+| `--cpus=N --memory=Xg` | Resource limits — prevent noisy neighbors and runaway processes |
+| `--pids-limit=N` | Fork bomb protection |
+| `--pull=never` | Only use pre-built images — no surprise pulls in production |
+
+## Common Gotchas
+
+These are easy to miss and hard to debug:
+
+| Problem | Symptom | Fix |
+|---------|---------|-----|
+| `--read-only` blocks app writes | App crashes at startup writing to home/cache dir | Add targeted `--tmpfs /path` for specific writable paths |
+| `--tmpfs` defaults to `noexec` | Native binaries or shared objects fail to load from tmpfs | Use `--tmpfs /path:exec` to allow execution |
+| Missing `-i` flag on `docker run` | stdin closed — any pipe-based IPC (JSON-RPC, language servers) hangs | Always add `-i` when the container process reads from stdin |
+| Slim base image missing `ca-certificates` | HTTPS/TLS connections fail with certificate errors | Install `ca-certificates` package in Dockerfile |
+| Env vars propagated to child containers | Service secrets (API keys, tokens) leak to sandboxed processes | Maintain an explicit allowlist of env vars passed to child processes |
+
+## Nested Containers (Docker-in-Docker)
+
+When you need containers inside containers (CI/CD, sandboxing, testing):
+
+### Approaches
+
+| Approach | How | Tradeoff |
+|----------|-----|----------|
+| **DinD sidecar** | Run `docker:dind` as a separate container, connect via `DOCKER_HOST` | `--privileged` required on sidecar; service and sidecar have separate filesystems |
+| **Podman-in-Podman** | Install podman in the service container, runs children directly | `--privileged` required; paths are local (no filesystem divergence) |
+| **Socket mount** | Mount host's `/var/run/docker.sock` | Simplest, but **grants host root access** — not suitable for untrusted workloads |
+
+**Both DinD and Podman-in-Podman require `--privileged`.** This is a fundamental constraint of nested containerization, not a workaround.
+
+### Filesystem Path Divergence (DinD)
+
+When using a DinD sidecar, the service container and the sandbox container run on **different Docker daemons**. A bind-mount path like `-v /tmp/work:/workspace` resolves on the daemon's filesystem, not the caller's. If the file only exists in the service container, the sandbox gets an empty directory.
+
+**Fix**: Use a shared Docker volume mounted at the same path in both containers.
+
+### Platform Compatibility
+
+| Host runtime | Docker DinD | Podman-in-Podman |
+|-------------|-------------|-----------------|
+| Docker Desktop (LinuxKit VM) | ✅ | ❌ No nested user namespaces |
+| Podman Machine (Fedora CoreOS) | ✅ | ✅ |
+| Linux host (native) | ✅ | ✅ |
+
+Document these constraints early — debugging nested container failures on an unsupported platform wastes significant time.

--- a/.github/skills/owasp-review/SKILL.md
+++ b/.github/skills/owasp-review/SKILL.md
@@ -58,6 +58,15 @@ Before submitting a PR, review the code against each OWASP Top 10 category. Flag
 - [ ] Is user input ever used to construct URLs for server-side requests?
 - [ ] Are internal network addresses blocked from user-supplied URLs?
 
+### 11. Container Security (if applicable)
+- [ ] Is the Docker socket mounted? (equivalent to root access on host — document justification)
+- [ ] Is `--privileged` used? (document why and whether it can be scoped down)
+- [ ] Are environment variables propagated to child containers? (no service secrets to sandboxed processes)
+- [ ] Are base images pinned to digests, not mutable tags like `latest`?
+- [ ] Is the container filesystem read-only where possible? (`--read-only` + targeted `--tmpfs`)
+- [ ] Are capabilities dropped? (`--cap-drop=ALL`, add back only what's needed)
+- [ ] Are resource limits set? (`--cpus`, `--memory`, `--pids-limit`)
+
 ## Output
 
 Add a section to the PR description:

--- a/.github/skills/pre-implementation/SKILL.md
+++ b/.github/skills/pre-implementation/SKILL.md
@@ -47,6 +47,13 @@ Confirm:
 - [ ] Task is ≤200 diff lines (split into stacked PRs if larger)
 - [ ] Devcontainer is running and commands will execute inside it
 
+## 6. Verification Strategy (if applicable)
+
+For infrastructure, security, or integration-heavy tasks:
+- [ ] E2E test approach defined (manual, automated, or gate issue)
+- [ ] Required infrastructure identified (tunnels, sidecars, test accounts)
+- [ ] Platform constraints documented (e.g., Docker Desktop vs Linux differences)
+
 ## When to Skip
 
 - **Single-line fixes** (typos, config tweaks): skip entirely.


### PR DESCRIPTION
## Summary

Applies retrospective learnings from epic #27 (container isolation) to our skills, instructions, and agents.

### New skills
- **code-review**: Cross-model code review before every PR (GPT-5.3-Codex caught real bugs reviewing Claude's code)
- **container-hardening**: Dockerfile checklist, runtime flags, DinD/PinP patterns

### Updated skills
- **test-quality**: E2E gate pattern, 'testing the library' anti-pattern
- **pre-implementation**: Verification strategy step for infra-heavy tasks
- **owasp-review**: Container security section (socket mounts, env var leakage, capabilities)

### Updated instructions
- **copilot-instructions**: Code review requirement in PR Requirements section

### Context
These learnings come from 10 PRs and 5 live E2E bugs that 174 unit tests missed during the container isolation epic. The same changes are being contributed upstream to copilot-bootstrap.

## OWASP Self-Review
- [x] Broken Access Control — N/A (docs only)
- [x] Cryptographic Failures — N/A
- [x] Injection — N/A
- [x] Insecure Design — N/A
- [x] Security Misconfiguration — N/A
- [x] Vulnerable Components — N/A
- [x] Auth Failures — N/A
- [x] Data Integrity — N/A
- [x] Logging/Monitoring — N/A
- [x] SSRF — N/A