### PR TITLE
fix(webhook): deduplicate MR review webhooks by head SHA

### DIFF
--- a/src/gitlab_copilot_agent/main.py
+++ b/src/gitlab_copilot_agent/main.py
@@ -11,7 +11,11 @@ from fastapi import FastAPI
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
 from gitlab_copilot_agent.coding_orchestrator import CodingOrchestrator
-from gitlab_copilot_agent.concurrency import ProcessedIssueTracker, RepoLockManager
+from gitlab_copilot_agent.concurrency import (
+    ProcessedIssueTracker,
+    RepoLockManager,
+    ReviewedMRTracker,
+)
 from gitlab_copilot_agent.config import Settings
 from gitlab_copilot_agent.git_operations import CLONE_DIR_PREFIX
 from gitlab_copilot_agent.gitlab_client import GitLabClient
@@ -64,6 +68,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Shared lock manager for both webhook and Jira flows
     repo_locks = RepoLockManager()
     app.state.repo_locks = repo_locks
+    app.state.review_tracker = ReviewedMRTracker()
 
     poller: JiraPoller | None = None
     jira_client: JiraClient | None = None

--- a/src/gitlab_copilot_agent/models.py
+++ b/src/gitlab_copilot_agent/models.py
@@ -36,6 +36,10 @@ class MRObjectAttributes(BaseModel):
     target_branch: str
     last_commit: MRLastCommit
     url: str
+    oldrev: str | None = Field(
+        default=None,
+        description="Previous head SHA; present on 'update' only when commits changed",
+    )
 
 
 class MergeRequestWebhookPayload(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,10 +132,11 @@ def env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture
 async def client(env_vars: None) -> AsyncIterator[AsyncClient]:
     """AsyncClient wired to the FastAPI app with test settings."""
-    from gitlab_copilot_agent.concurrency import RepoLockManager
+    from gitlab_copilot_agent.concurrency import RepoLockManager, ReviewedMRTracker
 
     app.state.settings = make_settings()
     app.state.repo_locks = RepoLockManager()
+    app.state.review_tracker = ReviewedMRTracker()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         yield c


### PR DESCRIPTION
## Summary

Closes #62. Prevents duplicate reviews when GitLab sends multiple webhook events for the same MR commit.

### Changes
- **`ReviewedMRTracker`** in `concurrency.py`: tracks `(project_id, mr_iid, head_sha)` tuples in memory with LRU eviction
- **`oldrev` field** on `MRObjectAttributes`: GitLab only sends this when commits change — lets us detect title/description-only updates
- **Webhook dedup** in `webhook.py`: checks tracker before queuing, marks SHA only after successful review
- **Failure retry**: SHA is NOT marked if `handle_review` raises, so the next webhook retries

### Behavior
| Event | Result |
|-------|--------|
| First webhook for a SHA | `queued` |
| Same SHA, review succeeded | `skipped: already reviewed` |
| Same SHA, review failed | `queued` (retry) |
| `update` without `oldrev` (title change) | `ignored: no new commits` |
| `update` with `oldrev` (new push) | `queued` |

### E2E Verification
All 4 scenarios verified against running service with `SANDBOX_METHOD=noop`.

### Tests
182 passing (8 new: 2 concurrency + 6 webhook dedup)

## OWASP Self-Review
- [x] Broken Access Control — N/A (no auth changes)
- [x] Injection — N/A (no user input in queries)
- [x] Insecure Design — in-memory tracker has bounded size (LRU eviction)
- [x] Security Misconfiguration — N/A
- [x] Logging/Monitoring — `review_skipped` logged with project_id, mr_iid, head_sha