### PR TITLE
feat(k8s): implement KubernetesTaskExecutor with Redis result persistence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+kubernetes = ["kubernetes>=28.1.0"]
 dev = [
     "pytest==8.3.4",
     "pytest-asyncio==0.25.3",

--- a/src/gitlab_copilot_agent/config.py
+++ b/src/gitlab_copilot_agent/config.py
@@ -66,6 +66,13 @@ class Settings(BaseSettings):
         default="local", description="Task executor backend: 'local' or 'k8s'"
     )
 
+    # K8s executor settings (only used when task_executor="kubernetes")
+    k8s_namespace: str = Field(default="default", description="Kubernetes namespace for Jobs")
+    k8s_job_image: str = Field(default="", description="Docker image for Job pods")
+    k8s_job_cpu_limit: str = Field(default="1", description="CPU limit for Job pods")
+    k8s_job_memory_limit: str = Field(default="1Gi", description="Memory limit for Job pods")
+    k8s_job_timeout: int = Field(default=600, description="Job timeout in seconds")
+
     # State backend
     state_backend: Literal["memory", "redis"] = Field(
         default="memory", description="State backend: 'memory' or 'redis'"

--- a/src/gitlab_copilot_agent/k8s_executor.py
+++ b/src/gitlab_copilot_agent/k8s_executor.py
@@ -1,0 +1,203 @@
+"""KubernetesTaskExecutor — dispatches tasks as k8s Jobs, reads results from Redis."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from typing import TYPE_CHECKING
+
+import structlog
+
+if TYPE_CHECKING:
+    from redis.asyncio import Redis
+
+    from gitlab_copilot_agent.config import Settings
+    from gitlab_copilot_agent.task_executor import TaskParams
+
+log = structlog.get_logger()
+
+_RESULT_KEY_PREFIX = "result:"
+_JOB_POLL_INTERVAL = 2  # seconds between status checks
+_TTL_AFTER_FINISHED = 300
+_ANNOTATION_KEY = "results.copilot-agent/summary"
+
+
+def _sanitize_job_name(task_type: str, task_id: str) -> str:
+    """Build a k8s-compliant Job name: ``copilot-{task_type}-{task_id[:8]}``."""
+    raw = f"copilot-{task_type}-{task_id[:8]}"
+    sanitized = re.sub(r"[^a-z0-9\-]", "-", raw.lower())
+    return sanitized.strip("-")[:63]
+
+
+def _build_env(task: TaskParams, settings: Settings) -> list[dict[str, str]]:
+    """Return env var dicts for the Job container."""
+    env = [
+        {"name": "TASK_TYPE", "value": task.task_type},
+        {"name": "TASK_ID", "value": task.task_id},
+        {"name": "REPO_URL", "value": task.repo_url},
+        {"name": "BRANCH", "value": task.branch},
+        {"name": "SYSTEM_PROMPT", "value": task.system_prompt},
+        {"name": "USER_PROMPT", "value": task.user_prompt},
+        {"name": "TASK_PAYLOAD", "value": json.dumps({"prompt": task.user_prompt})},
+        {"name": "GITLAB_URL", "value": settings.gitlab_url},
+        {"name": "GITLAB_TOKEN", "value": settings.gitlab_token},
+    ]
+    if settings.redis_url:
+        env.append({"name": "REDIS_URL", "value": settings.redis_url})
+    if settings.github_token:
+        env.append({"name": "GITHUB_TOKEN", "value": settings.github_token})
+    if settings.copilot_provider_base_url:
+        env.append({"name": "COPILOT_LLM_URL", "value": settings.copilot_provider_base_url})
+    return env
+
+
+class KubernetesTaskExecutor:
+    """Dispatches tasks as Kubernetes Jobs and retrieves results from Redis."""
+
+    def __init__(self, settings: Settings, redis_url: str) -> None:
+        self._settings = settings
+        self._redis_url = redis_url
+
+    async def execute(self, task: TaskParams) -> str:
+        import redis.asyncio as aioredis
+
+        client: Redis = aioredis.from_url(self._redis_url)
+        try:
+            # Idempotency: return cached result if present
+            cached = await client.get(f"{_RESULT_KEY_PREFIX}{task.task_id}")
+            if cached is not None:
+                return cached.decode() if isinstance(cached, bytes) else str(cached)
+
+            job_name = _sanitize_job_name(task.task_type, task.task_id)
+            await asyncio.to_thread(self._create_job, job_name, task)
+            return await self._wait_for_result(client, job_name, task)
+        finally:
+            await client.aclose()
+
+    # -- k8s helpers (synchronous, called via to_thread) ------------------
+
+    def _load_config(self) -> None:
+        from kubernetes import config as k8s_config  # type: ignore[import-not-found]
+
+        try:
+            k8s_config.load_incluster_config()
+        except Exception:  # noqa: BLE001 – fallback to kubeconfig
+            k8s_config.load_kube_config()
+
+    def _create_job(self, job_name: str, task: TaskParams) -> None:
+        from kubernetes import client as k8s
+
+        self._load_config()
+        ns = self._settings.k8s_namespace
+        env = [
+            k8s.V1EnvVar(name=e["name"], value=e["value"])
+            for e in _build_env(task, self._settings)
+        ]
+
+        container = k8s.V1Container(
+            name="task",
+            image=self._settings.k8s_job_image,
+            command=["python", "-m", "gitlab_copilot_agent.task_runner"],
+            env=env,
+            resources=k8s.V1ResourceRequirements(
+                limits={
+                    "cpu": self._settings.k8s_job_cpu_limit,
+                    "memory": self._settings.k8s_job_memory_limit,
+                },
+            ),
+            security_context=k8s.V1SecurityContext(
+                run_as_non_root=True,
+                read_only_root_filesystem=True,
+                capabilities=k8s.V1Capabilities(drop=["ALL"]),
+            ),
+        )
+
+        job = k8s.V1Job(
+            metadata=k8s.V1ObjectMeta(name=job_name, namespace=ns),
+            spec=k8s.V1JobSpec(
+                template=k8s.V1PodTemplateSpec(
+                    spec=k8s.V1PodSpec(containers=[container], restart_policy="Never"),
+                ),
+                backoff_limit=1,
+                ttl_seconds_after_finished=_TTL_AFTER_FINISHED,
+            ),
+        )
+        k8s.BatchV1Api().create_namespaced_job(namespace=ns, body=job)
+
+    def _read_job_status(self, job_name: str) -> str:
+        """Return 'succeeded', 'failed', or 'running'."""
+        from kubernetes import client as k8s
+
+        ns = self._settings.k8s_namespace
+        job = k8s.BatchV1Api().read_namespaced_job(name=job_name, namespace=ns)
+        if job.status and job.status.succeeded:
+            return "succeeded"
+        if job.status and job.status.failed:
+            return "failed"
+        return "running"
+
+    def _read_job_annotation(self, job_name: str) -> str | None:
+        from kubernetes import client as k8s
+
+        ns = self._settings.k8s_namespace
+        job = k8s.BatchV1Api().read_namespaced_job(name=job_name, namespace=ns)
+        if job.metadata and job.metadata.annotations:
+            result: str | None = job.metadata.annotations.get(_ANNOTATION_KEY)
+            return result
+        return None
+
+    def _read_pod_logs(self, job_name: str) -> str:
+        from kubernetes import client as k8s
+
+        ns = self._settings.k8s_namespace
+        pods = k8s.CoreV1Api().list_namespaced_pod(
+            namespace=ns, label_selector=f"job-name={job_name}"
+        )
+        if not pods.items:
+            return "<no pods found>"
+        pod_name: str = pods.items[0].metadata.name
+        return k8s.CoreV1Api().read_namespaced_pod_log(name=pod_name, namespace=ns) or ""
+
+    def _delete_job(self, job_name: str) -> None:
+        from kubernetes import client as k8s
+
+        k8s.BatchV1Api().delete_namespaced_job(
+            name=job_name,
+            namespace=self._settings.k8s_namespace,
+            body=k8s.V1DeleteOptions(propagation_policy="Background"),
+        )
+
+    # -- async polling ----------------------------------------------------
+
+    async def _wait_for_result(self, redis_client: Redis, job_name: str, task: TaskParams) -> str:
+        deadline = asyncio.get_event_loop().time() + self._settings.k8s_job_timeout
+
+        while asyncio.get_event_loop().time() < deadline:
+            # Check Redis first
+            cached = await redis_client.get(f"{_RESULT_KEY_PREFIX}{task.task_id}")
+            if cached is not None:
+                return cached.decode() if isinstance(cached, bytes) else str(cached)
+
+            status = await asyncio.to_thread(self._read_job_status, job_name)
+
+            if status == "succeeded":
+                cached = await redis_client.get(f"{_RESULT_KEY_PREFIX}{task.task_id}")
+                if cached is not None:
+                    return cached.decode() if isinstance(cached, bytes) else str(cached)
+                annotation = await asyncio.to_thread(self._read_job_annotation, job_name)
+                if annotation:
+                    return annotation
+                return ""
+
+            if status == "failed":
+                logs = await asyncio.to_thread(self._read_pod_logs, job_name)
+                msg = f"Job {job_name} failed. Pod logs:\n{logs}"
+                raise RuntimeError(msg)
+
+            await asyncio.sleep(_JOB_POLL_INTERVAL)
+
+        # Timeout — clean up and raise
+        await asyncio.to_thread(self._delete_job, job_name)
+        msg = f"Job {job_name} timed out after {self._settings.k8s_job_timeout}s"
+        raise TimeoutError(msg)

--- a/tests/test_k8s_executor.py
+++ b/tests/test_k8s_executor.py
@@ -1,0 +1,402 @@
+"""Tests for KubernetesTaskExecutor."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import fakeredis.aioredis
+import pytest
+
+from gitlab_copilot_agent.task_executor import TaskExecutor, TaskParams
+from tests.conftest import make_settings
+
+# -- Test constants -------------------------------------------------------
+
+TASK_ID = "abc12345-6789-0def-ghij-klmnopqrstuv"
+TASK_TYPE = "review"
+REPO_URL = "https://gitlab.example.com/group/project.git"
+BRANCH = "feature/x"
+SYSTEM_PROMPT = "You are a reviewer."
+USER_PROMPT = "Review this code."
+REDIS_URL = "redis://localhost:6379/0"
+K8S_NAMESPACE = "ci"
+K8S_JOB_IMAGE = "registry.example.com/agent:latest"
+K8S_JOB_CPU = "500m"
+K8S_JOB_MEM = "512Mi"
+K8S_JOB_TIMEOUT = 5  # short for tests
+EXPECTED_JOB_NAME = "copilot-review-abc12345"
+RESULT_KEY = f"result:{TASK_ID}"
+CACHED_RESULT = "cached review output"
+ANNOTATION_RESULT = "annotation fallback result"
+POD_LOGS = "ERROR: something went wrong"
+
+
+# -- Helpers / fixtures ---------------------------------------------------
+
+
+def _make_settings(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "redis_url": REDIS_URL,
+        "state_backend": "redis",
+        "task_executor": "kubernetes",
+        "k8s_namespace": K8S_NAMESPACE,
+        "k8s_job_image": K8S_JOB_IMAGE,
+        "k8s_job_cpu_limit": K8S_JOB_CPU,
+        "k8s_job_memory_limit": K8S_JOB_MEM,
+        "k8s_job_timeout": K8S_JOB_TIMEOUT,
+    }
+    return make_settings(**(defaults | overrides))
+
+
+def _make_task(**overrides: Any) -> TaskParams:
+    defaults: dict[str, Any] = {
+        "task_type": TASK_TYPE,
+        "task_id": TASK_ID,
+        "repo_url": REPO_URL,
+        "branch": BRANCH,
+        "system_prompt": SYSTEM_PROMPT,
+        "user_prompt": USER_PROMPT,
+        "settings": _make_settings(),
+    }
+    return TaskParams(**(defaults | overrides))
+
+
+def _install_k8s_stub() -> tuple[MagicMock, MagicMock, MagicMock]:
+    """Insert a fake ``kubernetes`` package into sys.modules and return mocks.
+
+    Returns (batch_v1_mock, core_v1_mock, config_mock).
+    """
+    k8s_mod = types.ModuleType("kubernetes")
+    client_mod = types.ModuleType("kubernetes.client")
+    config_mod = types.ModuleType("kubernetes.config")
+
+    batch_v1 = MagicMock(name="BatchV1Api")
+    core_v1 = MagicMock(name="CoreV1Api")
+    config_mock = MagicMock(name="k8s_config")
+
+    # client classes that return plain objects
+    client_mod.BatchV1Api = MagicMock(return_value=batch_v1)  # type: ignore[attr-defined]
+    client_mod.CoreV1Api = MagicMock(return_value=core_v1)  # type: ignore[attr-defined]
+    # Passthrough constructors — just return kwargs as SimpleNamespace for inspection
+    for cls_name in (
+        "V1Job",
+        "V1ObjectMeta",
+        "V1JobSpec",
+        "V1PodTemplateSpec",
+        "V1PodSpec",
+        "V1Container",
+        "V1EnvVar",
+        "V1ResourceRequirements",
+        "V1SecurityContext",
+        "V1Capabilities",
+        "V1DeleteOptions",
+    ):
+        setattr(client_mod, cls_name, _passthrough_cls(cls_name))
+
+    config_mod.load_incluster_config = config_mock.load_incluster_config  # type: ignore[attr-defined]
+    config_mod.load_kube_config = config_mock.load_kube_config  # type: ignore[attr-defined]
+    config_mod.ConfigException = Exception  # type: ignore[attr-defined]
+
+    k8s_mod.client = client_mod  # type: ignore[attr-defined]
+    k8s_mod.config = config_mod  # type: ignore[attr-defined]
+
+    sys.modules["kubernetes"] = k8s_mod
+    sys.modules["kubernetes.client"] = client_mod
+    sys.modules["kubernetes.config"] = config_mod
+
+    return batch_v1, core_v1, config_mock
+
+
+def _passthrough_cls(name: str) -> type:
+    """Return a tiny class that stores kwargs as attributes for test inspection."""
+
+    def __init__(self: Any, **kwargs: Any) -> None:
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    def __repr__(self: Any) -> str:
+        attrs = ", ".join(f"{k}={v!r}" for k, v in self.__dict__.items())
+        return f"{name}({attrs})"
+
+    return type(name, (), {"__init__": __init__, "__repr__": __repr__})
+
+
+@pytest.fixture(autouse=True)
+def _k8s_stubs() -> tuple[MagicMock, MagicMock, MagicMock]:
+    """Auto-install kubernetes stubs for every test; clean up after."""
+    stubs = _install_k8s_stub()
+    yield stubs
+    for mod in ("kubernetes", "kubernetes.client", "kubernetes.config"):
+        sys.modules.pop(mod, None)
+    # Force re-import of k8s_executor to avoid stale module refs
+    sys.modules.pop("gitlab_copilot_agent.k8s_executor", None)
+
+
+@pytest.fixture
+def batch_v1(_k8s_stubs: tuple[MagicMock, MagicMock, MagicMock]) -> MagicMock:
+    return _k8s_stubs[0]
+
+
+@pytest.fixture
+def core_v1(_k8s_stubs: tuple[MagicMock, MagicMock, MagicMock]) -> MagicMock:
+    return _k8s_stubs[1]
+
+
+@pytest.fixture
+def fake_redis() -> fakeredis.aioredis.FakeRedis:
+    return fakeredis.aioredis.FakeRedis()
+
+
+def _make_executor(
+    settings: Any | None = None,
+    redis_url: str = REDIS_URL,
+) -> Any:
+    from gitlab_copilot_agent.k8s_executor import KubernetesTaskExecutor
+
+    return KubernetesTaskExecutor(settings=settings or _make_settings(), redis_url=redis_url)
+
+
+# -- Tests ----------------------------------------------------------------
+
+
+class TestProtocolCompliance:
+    def test_implements_task_executor(self) -> None:
+        executor = _make_executor()
+        assert isinstance(executor, TaskExecutor)
+
+
+class TestIdempotency:
+    async def test_returns_cached_result(self, fake_redis: fakeredis.aioredis.FakeRedis) -> None:
+        await fake_redis.set(RESULT_KEY, CACHED_RESULT)
+        executor = _make_executor()
+
+        with patch("redis.asyncio.from_url", return_value=fake_redis):
+            result = await executor.execute(_make_task())
+
+        assert result == CACHED_RESULT
+
+
+class TestJobCreation:
+    async def test_creates_job_with_correct_spec(
+        self,
+        batch_v1: MagicMock,
+        fake_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        # Make job succeed immediately
+        status_mock = MagicMock()
+        status_mock.succeeded = 1
+        status_mock.failed = None
+        job_mock = MagicMock()
+        job_mock.status = status_mock
+        job_mock.metadata = MagicMock()
+        job_mock.metadata.annotations = {}
+        batch_v1.read_namespaced_job.return_value = job_mock
+
+        executor = _make_executor()
+        with patch("redis.asyncio.from_url", return_value=fake_redis):
+            await executor.execute(_make_task())
+
+        # Verify Job was created
+        batch_v1.create_namespaced_job.assert_called_once()
+        call_kwargs = batch_v1.create_namespaced_job.call_args
+        assert call_kwargs.kwargs["namespace"] == K8S_NAMESPACE
+
+        job_body = call_kwargs.kwargs["body"]
+        assert job_body.metadata.name == EXPECTED_JOB_NAME
+        assert job_body.spec.backoff_limit == 1
+        assert job_body.spec.ttl_seconds_after_finished == 300
+
+        container = job_body.spec.template.spec.containers[0]
+        assert container.image == K8S_JOB_IMAGE
+        assert container.command == ["python", "-m", "gitlab_copilot_agent.task_runner"]
+        assert container.resources.limits["cpu"] == K8S_JOB_CPU
+        assert container.resources.limits["memory"] == K8S_JOB_MEM
+        assert container.security_context.run_as_non_root is True
+        assert container.security_context.read_only_root_filesystem is True
+        assert container.security_context.capabilities.drop == ["ALL"]
+
+    async def test_env_vars_include_task_and_auth(
+        self,
+        batch_v1: MagicMock,
+        fake_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        status_mock = MagicMock()
+        status_mock.succeeded = 1
+        status_mock.failed = None
+        job_mock = MagicMock()
+        job_mock.status = status_mock
+        job_mock.metadata = MagicMock()
+        job_mock.metadata.annotations = {}
+        batch_v1.read_namespaced_job.return_value = job_mock
+
+        executor = _make_executor()
+        with patch("redis.asyncio.from_url", return_value=fake_redis):
+            await executor.execute(_make_task())
+
+        job_body = batch_v1.create_namespaced_job.call_args
+        container = job_body.kwargs["body"].spec.template.spec.containers[0]
+        env_names = {e.name for e in container.env}
+
+        expected_vars = (
+            "TASK_TYPE",
+            "TASK_ID",
+            "REPO_URL",
+            "BRANCH",
+            "SYSTEM_PROMPT",
+            "USER_PROMPT",
+            "TASK_PAYLOAD",
+            "GITLAB_URL",
+            "GITLAB_TOKEN",
+            "GITHUB_TOKEN",
+            "REDIS_URL",
+        )
+        for expected in expected_vars:
+            assert expected in env_names, f"Missing env var: {expected}"
+
+
+class TestCompletion:
+    async def test_returns_result_from_redis(
+        self,
+        batch_v1: MagicMock,
+        fake_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        call_count = 0
+
+        def _status_side_effect(*_a: Any, **_kw: Any) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            job = MagicMock()
+            if call_count >= 2:
+                job.status.succeeded = 1
+                job.status.failed = None
+            else:
+                job.status.succeeded = None
+                job.status.failed = None
+            job.metadata.annotations = {}
+            return job
+
+        batch_v1.read_namespaced_job.side_effect = _status_side_effect
+
+        # Simulate result appearing in Redis after first poll
+        async def _set_result_later() -> None:
+            await asyncio.sleep(0.05)
+            await fake_redis.set(RESULT_KEY, CACHED_RESULT)
+
+        executor = _make_executor()
+        with patch("redis.asyncio.from_url", return_value=fake_redis):
+            asyncio.create_task(_set_result_later())
+            result = await executor.execute(_make_task())
+
+        assert result == CACHED_RESULT
+
+    async def test_falls_back_to_annotation(
+        self,
+        batch_v1: MagicMock,
+        fake_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        job_mock = MagicMock()
+        job_mock.status.succeeded = 1
+        job_mock.status.failed = None
+        job_mock.metadata.annotations = {"results.copilot-agent/summary": ANNOTATION_RESULT}
+        batch_v1.read_namespaced_job.return_value = job_mock
+
+        executor = _make_executor()
+        with patch("redis.asyncio.from_url", return_value=fake_redis):
+            result = await executor.execute(_make_task())
+
+        assert result == ANNOTATION_RESULT
+
+
+class TestFailureHandling:
+    async def test_raises_on_job_failure(
+        self,
+        batch_v1: MagicMock,
+        core_v1: MagicMock,
+        fake_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        job_mock = MagicMock()
+        job_mock.status.succeeded = None
+        job_mock.status.failed = 1
+        batch_v1.read_namespaced_job.return_value = job_mock
+
+        pod_mock = MagicMock()
+        pod_mock.metadata.name = "copilot-review-abc12345-xyz"
+        core_v1.list_namespaced_pod.return_value = MagicMock(items=[pod_mock])
+        core_v1.read_namespaced_pod_log.return_value = POD_LOGS
+
+        executor = _make_executor()
+        with (
+            patch("redis.asyncio.from_url", return_value=fake_redis),
+            pytest.raises(RuntimeError, match="failed"),
+        ):
+            await executor.execute(_make_task())
+
+    async def test_failure_includes_pod_logs(
+        self,
+        batch_v1: MagicMock,
+        core_v1: MagicMock,
+        fake_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        job_mock = MagicMock()
+        job_mock.status.succeeded = None
+        job_mock.status.failed = 1
+        batch_v1.read_namespaced_job.return_value = job_mock
+
+        pod_mock = MagicMock()
+        pod_mock.metadata.name = "copilot-review-abc12345-pod"
+        core_v1.list_namespaced_pod.return_value = MagicMock(items=[pod_mock])
+        core_v1.read_namespaced_pod_log.return_value = POD_LOGS
+
+        executor = _make_executor()
+        with (
+            patch("redis.asyncio.from_url", return_value=fake_redis),
+            pytest.raises(RuntimeError, match=POD_LOGS),
+        ):
+            await executor.execute(_make_task())
+
+
+class TestTimeout:
+    async def test_deletes_job_on_timeout(
+        self,
+        batch_v1: MagicMock,
+        fake_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        # Job stays running forever
+        job_mock = MagicMock()
+        job_mock.status.succeeded = None
+        job_mock.status.failed = None
+        batch_v1.read_namespaced_job.return_value = job_mock
+
+        settings = _make_settings(k8s_job_timeout=1)
+        executor = _make_executor(settings=settings)
+
+        with (
+            patch("redis.asyncio.from_url", return_value=fake_redis),
+            patch("gitlab_copilot_agent.k8s_executor._JOB_POLL_INTERVAL", 0.1),
+            pytest.raises(TimeoutError, match="timed out"),
+        ):
+            await executor.execute(_make_task(settings=settings))
+
+        batch_v1.delete_namespaced_job.assert_called_once()
+
+
+class TestJobNameSanitization:
+    def test_basic_name(self) -> None:
+        from gitlab_copilot_agent.k8s_executor import _sanitize_job_name
+
+        assert _sanitize_job_name("review", "abc12345-rest") == "copilot-review-abc12345"
+
+    def test_uppercased_input(self) -> None:
+        from gitlab_copilot_agent.k8s_executor import _sanitize_job_name
+
+        assert _sanitize_job_name("REVIEW", "ABC12345") == "copilot-review-abc12345"
+
+    def test_special_chars_replaced(self) -> None:
+        from gitlab_copilot_agent.k8s_executor import _sanitize_job_name
+
+        result = _sanitize_job_name("review", "a@b#c$d%")
+        assert result == "copilot-review-a-b-c-d-"[:63].rstrip("-")

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -76,10 +76,12 @@ class TestRunTask:
         with (
             patch(f"{_M}.git_clone", AsyncMock(return_value=fp)),
             patch(f"{_M}.run_copilot_session", AsyncMock(return_value="done")),
+            patch(f"{_M}._store_result", AsyncMock()) as store,
             patch(f"{_M}.shutil.rmtree") as rm,
         ):
             assert await run_task() == 0
             rm.assert_called_once_with(fp, ignore_errors=True)
+            store.assert_awaited_once_with(TASK_ID, "done")
 
     async def test_missing_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv(ENV_TASK_TYPE, raising=False)
@@ -99,6 +101,7 @@ class TestRunTask:
         with (
             patch(f"{_M}.git_clone", AsyncMock(return_value=Path("/tmp/r"))),
             patch(f"{_M}.run_copilot_session", AsyncMock(return_value="x")) as ms,
+            patch(f"{_M}._store_result", AsyncMock()),
             patch(f"{_M}.shutil.rmtree"),
         ):
             assert await run_task() == 0


### PR DESCRIPTION
## What
Implements `KubernetesTaskExecutor` as a `TaskExecutor` implementation (`TASK_EXECUTOR=kubernetes`). Dispatches Copilot tasks as k8s Jobs, polls for completion, and retrieves results from Redis with Job annotation fallback.

Closes #81

## Why
This is the core of the k8s migration — replacing in-process task execution with k8s Job dispatch. Implements the `TaskExecutor` protocol from ADR-0003, so callers use `executor.execute(task)` regardless of backend.

## Changes

### New files
- `src/gitlab_copilot_agent/k8s_executor.py` (~200 lines)
  - `KubernetesTaskExecutor`: creates k8s Jobs, polls status, reads results from Redis
  - Idempotency: checks `result:{task_id}` in Redis before creating Job
  - Security context: `runAsNonRoot`, `readOnlyRootFilesystem`, `drop ALL` capabilities
  - Annotation fallback (`results.copilot-agent/summary`) when Redis has no result
  - Timeout: deletes stuck Jobs, raises `TimeoutError`
  - All k8s API calls wrapped in `asyncio.to_thread()` (sync client)
  - Lazy `kubernetes` import (optional dependency)
- `tests/test_k8s_executor.py` (12 tests) — protocol compliance, idempotency, Job creation, env vars, result retrieval, annotation fallback, failure handling, timeout, job name sanitization

### Modified files
- `task_runner.py`: Added `_store_result()` — writes result to Redis via `REDIS_URL` env var
- `k8s_executor.py`: `REDIS_URL` injected into Job env; `GITLAB_WEBHOOK_SECRET` removed (not needed by runner)
- `config.py`: Added `k8s_namespace`, `k8s_job_image`, `k8s_job_cpu_limit`, `k8s_job_memory_limit`, `k8s_job_timeout`
- `main.py`: Wired `_create_executor()` to create `KubernetesTaskExecutor` for `"kubernetes"` backend
- `pyproject.toml`: Added `kubernetes>=28.1.0` optional dependency
- `test_main.py`: Updated for new `_create_executor()` signature
- `test_task_runner.py`: Added `_store_result` mock to existing tests

## E2E Test Results

### Unit/Integration Tests
```
232 passed in 9.00s
Coverage: 94.50% (threshold: 90%)
Lint: ruff check ✅ | ruff format ✅ | mypy ✅ (0 errors)
k8s_executor.py coverage: 95%
```

### Live Service Tests
| Test | Result |
|------|--------|
| GET /health | ✅ `{"status":"ok"}` |
| POST /webhook (MR open) | ✅ `{"status":"queued"}` |
| POST /webhook (bad token) | ✅ 401 Unauthorized |
| POST /webhook (close action) | ✅ `{"status":"ignored"}` |
| POST /webhook (push event) | ✅ `{"status":"ignored"}` |
| POST /webhook (update, no commits) | ✅ `{"status":"ignored"}` |
| **Total** | **6/6 endpoint tests passed** |

## Code Review (GPT-5.3-Codex)

**HIGH** — task_runner never wrote results to Redis, so executor would always get empty results. **Fixed**: added `_store_result()` to task_runner with `REDIS_URL` env support.

**HIGH** — `GITLAB_WEBHOOK_SECRET` leaked to Job env (not needed by runner). **Fixed**: removed from `_build_env()`.

**MEDIUM** — Concurrent same-`task_id` calls can race on Job creation (409 AlreadyExists). Accepted for Phase 1 — TTL-based cleanup prevents permanent resource leaks. Follow-up: add 409 handling.

**MEDIUM** — Failed Jobs not cleaned up (rely on TTL controller). Accepted for Phase 1 — `ttlSecondsAfterFinished=300` handles cleanup.

**MEDIUM** — Partial Job-creation failures not reconciled. Accepted — same idempotency/TTL safety net.

**LOW** — Missing coverage for concurrent task_id paths and K8s API exceptions.