### PR TITLE
feat(k8s): add Helm chart for controller, Redis, and RBAC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,14 @@ jobs:
       - name: Run tests
         run: uv run pytest tests/ -q --cov-fail-under=90
 
+  helm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+      - name: Helm lint
+        run: helm lint helm/gitlab-copilot-agent/ --set gitlab.url=https://ci.test --set gitlab.token=ci --set gitlab.webhookSecret=ci
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/helm/gitlab-copilot-agent/Chart.yaml
+++ b/helm/gitlab-copilot-agent/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: gitlab-copilot-agent
+description: GitLab Copilot Agent — AI code review and task execution
+version: 0.1.0
+appVersion: "0.1.0"
+type: application

--- a/helm/gitlab-copilot-agent/templates/_helpers.tpl
+++ b/helm/gitlab-copilot-agent/templates/_helpers.tpl
@@ -1,0 +1,17 @@
+{{- define "app.fullname" -}}{{ .Release.Name }}-{{ .Chart.Name }}{{- end }}
+{{- define "app.labels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- define "app.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+{{- define "app.redisUrl" -}}redis://{{ include "app.fullname" . }}-redis:{{ .Values.redis.port }}{{- end }}
+{{- define "app.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}{{ default (include "app.fullname" .) .Values.serviceAccount.name }}{{- else }}{{ default "default" .Values.serviceAccount.name }}{{- end }}
+{{- end }}
+{{- define "app.jobImage" -}}
+{{- if .Values.jobRunner.image }}{{ .Values.jobRunner.image }}{{- else }}{{ .Values.image.repository }}:{{ .Values.image.tag }}{{- end }}
+{{- end }}

--- a/helm/gitlab-copilot-agent/templates/configmap.yaml
+++ b/helm/gitlab-copilot-agent/templates/configmap.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels: {{- include "app.labels" . | nindent 4 }}
+data:
+  GITLAB_URL: {{ required "gitlab.url is required" .Values.gitlab.url | quote }}
+  HOST: "0.0.0.0"
+  PORT: {{ .Values.controller.port | quote }}
+  LOG_LEVEL: {{ .Values.controller.logLevel | quote }}
+  TASK_EXECUTOR: {{ .Values.controller.taskExecutor | quote }}
+  STATE_BACKEND: {{ .Values.controller.stateBackend | quote }}
+  REDIS_URL: {{ include "app.redisUrl" . | quote }}
+  COPILOT_MODEL: {{ .Values.controller.copilotModel | quote }}
+  K8S_NAMESPACE: {{ .Release.Namespace | quote }}
+  K8S_JOB_IMAGE: {{ include "app.jobImage" . | quote }}
+  K8S_JOB_CPU_LIMIT: {{ .Values.jobRunner.cpuLimit | quote }}
+  K8S_JOB_MEMORY_LIMIT: {{ .Values.jobRunner.memoryLimit | quote }}
+  K8S_JOB_TIMEOUT: {{ .Values.jobRunner.timeout | quote }}
+  {{- with .Values.controller.copilotProviderType }}
+  COPILOT_PROVIDER_TYPE: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.controller.copilotProviderBaseUrl }}
+  COPILOT_PROVIDER_BASE_URL: {{ . | quote }}
+  {{- end }}

--- a/helm/gitlab-copilot-agent/templates/deployment.yaml
+++ b/helm/gitlab-copilot-agent/templates/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels: {{- include "app.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "app.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: controller
+  template:
+    metadata:
+      labels:
+        {{- include "app.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: controller
+    spec:
+      serviceAccountName: {{ include "app.serviceAccountName" . }}
+      containers:
+        - name: controller
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports: [{ containerPort: {{ .Values.controller.port }} }]
+          envFrom:
+            - configMapRef: { name: {{ include "app.fullname" . }} }
+            - secretRef: { name: {{ include "app.fullname" . }} }
+          resources: {{- toYaml .Values.controller.resources | nindent 12 }}
+          livenessProbe: { httpGet: { path: /health, port: {{ .Values.controller.port }} }, initialDelaySeconds: 10 }
+          readinessProbe: { httpGet: { path: /health, port: {{ .Values.controller.port }} } }

--- a/helm/gitlab-copilot-agent/templates/rbac.yaml
+++ b/helm/gitlab-copilot-agent/templates/rbac.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "app.fullname" . }}
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "app.fullname" . }}
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: Role, name: {{ include "app.fullname" . }} }
+subjects: [{ kind: ServiceAccount, name: {{ include "app.serviceAccountName" . }} }]

--- a/helm/gitlab-copilot-agent/templates/redis.yaml
+++ b/helm/gitlab-copilot-agent/templates/redis.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "app.fullname" . }}-redis
+  labels: {{- include "app.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "app.fullname" . }}-redis
+  replicas: 1
+  selector:
+    matchLabels: {{- include "app.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels: {{- include "app.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          ports: [{ containerPort: {{ .Values.redis.port }} }]
+          args: ["--appendonly", "yes"]
+          resources: {{- toYaml .Values.redis.resources | nindent 12 }}
+          volumeMounts: [{ name: data, mountPath: /data }]
+  volumeClaimTemplates:
+    - metadata: { name: data }
+      spec: { accessModes: ["ReadWriteOnce"], resources: { requests: { storage: {{ .Values.redis.storage }} } } }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "app.fullname" . }}-redis
+spec:
+  clusterIP: None
+  ports: [{ port: {{ .Values.redis.port }} }]
+  selector: {{- include "app.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+{{- end }}

--- a/helm/gitlab-copilot-agent/templates/secret.yaml
+++ b/helm/gitlab-copilot-agent/templates/secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels: {{- include "app.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  GITLAB_TOKEN: {{ required "gitlab.token is required" .Values.gitlab.token | quote }}
+  GITLAB_WEBHOOK_SECRET: {{ required "gitlab.webhookSecret is required" .Values.gitlab.webhookSecret | quote }}
+  {{- with .Values.github.token }}
+  GITHUB_TOKEN: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.controller.copilotProviderApiKey }}
+  COPILOT_PROVIDER_API_KEY: {{ . | quote }}
+  {{- end }}

--- a/helm/gitlab-copilot-agent/templates/service.yaml
+++ b/helm/gitlab-copilot-agent/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels: {{- include "app.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports: [{ port: {{ .Values.controller.port }}, targetPort: {{ .Values.controller.port }} }]
+  selector:
+    {{- include "app.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: controller

--- a/helm/gitlab-copilot-agent/templates/serviceaccount.yaml
+++ b/helm/gitlab-copilot-agent/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "app.serviceAccountName" . }}
+  labels: {{- include "app.labels" . | nindent 4 }}
+{{- end }}

--- a/helm/gitlab-copilot-agent/values-local.yaml
+++ b/helm/gitlab-copilot-agent/values-local.yaml
@@ -1,0 +1,8 @@
+image:
+  pullPolicy: Never
+controller:
+  resources:
+    limits: { cpu: 250m, memory: 256Mi }
+redis:
+  storage: 256Mi
+jobRunner: { cpuLimit: "500m", memoryLimit: 512Mi }

--- a/helm/gitlab-copilot-agent/values.yaml
+++ b/helm/gitlab-copilot-agent/values.yaml
@@ -1,0 +1,26 @@
+replicaCount: 1
+image: { repository: ghcr.io/peteroden/gitlab-copilot-agent, tag: latest, pullPolicy: IfNotPresent }
+controller:
+  port: 8000
+  logLevel: info
+  taskExecutor: kubernetes
+  stateBackend: redis
+  copilotModel: gpt-4
+  copilotProviderType: ""
+  copilotProviderBaseUrl: ""
+  copilotProviderApiKey: ""
+  resources:
+    limits: { cpu: 500m, memory: 512Mi }
+    requests: { cpu: 100m, memory: 256Mi }
+redis:
+  enabled: true
+  image: { repository: redis, tag: "7-alpine" }
+  port: 6379
+  resources:
+    limits: { cpu: 250m, memory: 256Mi }
+    requests: { cpu: 50m, memory: 64Mi }
+  storage: 1Gi
+jobRunner: { image: "", cpuLimit: "1", memoryLimit: 1Gi, timeout: 600 }
+serviceAccount: { create: true, name: "" }
+gitlab: { url: "", token: "", webhookSecret: "" }
+github: { token: "" }


### PR DESCRIPTION
## What

Adds a minimal Helm chart (`helm/gitlab-copilot-agent/`) that deploys the full GitLab Copilot Agent stack to Kubernetes:

- **Controller Deployment** — FastAPI webhook server with liveness/readiness probes, envFrom ConfigMap + Secret
- **Redis StatefulSet** — single-replica with AOF persistence via PVC
- **RBAC** — namespace-scoped Role + RoleBinding for Job lifecycle + pod logs
- **ServiceAccount, Service, ConfigMap, Secret** — all parameterized via `values.yaml`
- **`values-local.yaml`** — k3d overlay with reduced resource limits
- **BYOK provider support** — optional `copilotProviderType`, `copilotProviderBaseUrl`, `copilotProviderApiKey`

Closes #82

## Validation

| Check | Result |
|-------|--------|
| `helm lint` | ✅ Pass (1 INFO: icon recommended) |
| `helm template` (production values) | ✅ Valid YAML rendered |
| `helm template` (local overlay + BYOK) | ✅ Provider env vars rendered correctly |
| Diff size | ✅ 200 lines (11 files) |

## Code Review (GPT-5.3-Codex)

| Severity | Finding | Action |
|----------|---------|--------|
| HIGH | Controller Service selector overlaps Redis pods | ✅ Fixed: added `app.kubernetes.io/component: controller` to Deployment + Service selector |
| HIGH | Missing COPILOT_PROVIDER_TYPE for BYOK auth path | ✅ Fixed: added copilotProviderType/BaseUrl to ConfigMap, copilotProviderApiKey to Secret |
| MEDIUM | `serviceAccount.create=false` with empty name breaks pods | ✅ Fixed: `app.serviceAccountName` helper falls back to `"default"` |

## Templates

| File | Lines | Purpose |
|------|-------|---------|
| `Chart.yaml` | 6 | Chart metadata v0.1.0 |
| `values.yaml` | 26 | Production defaults |
| `values-local.yaml` | 8 | k3d overlay |
| `_helpers.tpl` | 18 | fullname, labels, selectors, redisUrl, jobImage, serviceAccountName |
| `deployment.yaml` | 30 | Controller with probes, envFrom |
| `redis.yaml` | 38 | StatefulSet (AOF, PVC) + headless Service |
| `rbac.yaml` | 19 | Role (Jobs CRUD, pods/logs read) + RoleBinding |
| `configmap.yaml` | 25 | All non-secret env vars incl. K8S job config + BYOK |
| `secret.yaml` | 15 | GitLab token, webhook secret, optional GitHub token + BYOK API key |
| `service.yaml` | 11 | ClusterIP for controller |
| `serviceaccount.yaml` | 7 | Conditional SA |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>