### PR TITLE
chore(k8s): add k3d local development setup and Makefile targets

### DIFF
--- a/.env.k3d.example
+++ b/.env.k3d.example
@@ -1,0 +1,11 @@
+# Copy to .env.k3d and fill in real values
+# Required
+GITLAB_URL=https://gitlab.example.com
+GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
+GITLAB_WEBHOOK_SECRET=your-webhook-secret
+# Auth: set GITHUB_TOKEN for Copilot, or COPILOT_PROVIDER_TYPE for BYOK
+GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
+# BYOK alternative (uncomment and clear GITHUB_TOKEN above):
+# COPILOT_PROVIDER_TYPE=openai
+# COPILOT_PROVIDER_BASE_URL=https://api.openai.com/v1
+# COPILOT_PROVIDER_API_KEY=sk-xxxxxxxxxxxxxxxxxxxx

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build/
 .pytest_cache/
 .ruff_cache/
 .coverage
+.env.k3d

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,54 @@ build:
 
 sandbox-image:
 	./scripts/build-sandbox-image.sh
+
+# --- k3d local development ---
+K3D_CLUSTER    := copilot-agent-dev
+K3D_IMAGE      := gitlab-copilot-agent:local
+K3D_HOST_PORT  := 8080
+HELM_RELEASE   := copilot-agent
+HELM_CHART     := helm/gitlab-copilot-agent
+HELM_NS        := default
+K3D_ENV_FILE   := .env.k3d
+
+.PHONY: k3d-up k3d-down k3d-build k3d-deploy k3d-redeploy k3d-logs k3d-status
+
+k3d-up:
+	k3d cluster create $(K3D_CLUSTER) -p "$(K3D_HOST_PORT):8000@loadbalancer" --wait
+
+k3d-down:
+	k3d cluster delete $(K3D_CLUSTER)
+
+k3d-build:
+	docker build -t $(K3D_IMAGE) .
+	k3d image import $(K3D_IMAGE) -c $(K3D_CLUSTER)
+
+k3d-deploy:
+	@test -f $(K3D_ENV_FILE) || { echo "Create $(K3D_ENV_FILE) from .env.k3d.example first"; exit 1; }
+	@. ./$(K3D_ENV_FILE) && printf '\
+	image: {repository: gitlab-copilot-agent, tag: local}\n\
+	gitlab: {url: "%s", token: "%s", webhookSecret: "%s"}\n\
+	github: {token: "%s"}\n\
+	controller: {copilotProviderType: "%s", copilotProviderBaseUrl: "%s", copilotProviderApiKey: "%s"}\n' \
+		"$$GITLAB_URL" "$$GITLAB_TOKEN" "$$GITLAB_WEBHOOK_SECRET" \
+		"$$GITHUB_TOKEN" \
+		"$$COPILOT_PROVIDER_TYPE" "$$COPILOT_PROVIDER_BASE_URL" "$$COPILOT_PROVIDER_API_KEY" \
+		> /tmp/k3d-values.yaml
+	helm upgrade --install $(HELM_RELEASE) $(HELM_CHART) \
+		-f $(HELM_CHART)/values-local.yaml \
+		-f /tmp/k3d-values.yaml \
+		-n $(HELM_NS) --wait --timeout 60s
+	@rm -f /tmp/k3d-values.yaml
+
+k3d-redeploy: k3d-build k3d-deploy
+
+k3d-logs:
+	kubectl logs -l app.kubernetes.io/name=gitlab-copilot-agent -f --tail=100
+
+k3d-status:
+	@echo "=== Pods ==="
+	@kubectl get pods -n $(HELM_NS) -l app.kubernetes.io/instance=$(HELM_RELEASE)
+	@echo "\n=== Jobs ==="
+	@kubectl get jobs -n $(HELM_NS) --sort-by=.metadata.creationTimestamp
+	@echo "\n=== Services ==="
+	@kubectl get svc -n $(HELM_NS) -l app.kubernetes.io/instance=$(HELM_RELEASE)

--- a/README.md
+++ b/README.md
@@ -296,3 +296,41 @@ See `docs/PLAN.md` for full implementation plan and `docs/adr/` for architecture
 ```
 GitLab Webhook → FastAPI /webhook → Clone repo → Copilot agent review → Parse output → Post inline comments + summary
 ```
+
+## Local Kubernetes Development
+
+Run the full stack locally using [k3d](https://k3d.io) (k3s-in-Docker).
+
+### Prerequisites
+
+Docker, [k3d](https://k3d.io), kubectl, Helm 3.
+
+### Quick start
+
+```bash
+cp .env.k3d.example .env.k3d   # fill in real values
+make k3d-up                     # create k3d cluster
+make k3d-build                  # build & import image
+make k3d-deploy                 # deploy via Helm
+```
+
+### Commands
+
+| Command            | Description                        |
+|--------------------|------------------------------------|
+| `make k3d-up`      | Create k3d cluster                |
+| `make k3d-down`    | Delete k3d cluster                |
+| `make k3d-build`   | Build image & import into cluster |
+| `make k3d-deploy`  | Deploy/upgrade via Helm           |
+| `make k3d-redeploy`| Rebuild + redeploy (one step)     |
+| `make k3d-logs`    | Tail controller logs              |
+| `make k3d-status`  | Show pods, jobs, and services     |
+
+### Webhook testing
+
+The controller is exposed on `localhost:8080` via the k3d loadbalancer (override with `K3D_HOST_PORT=9000 make k3d-up`).
+For direct port-forward:
+
+```bash
+kubectl port-forward svc/copilot-agent 8000:8000
+```


### PR DESCRIPTION
## What

Adds Makefile targets and documentation for running the full GitLab Copilot Agent stack locally using k3d (k3s-in-Docker).

Closes #83

## Changes

- **Makefile**: 7 new targets (`k3d-up`, `k3d-down`, `k3d-build`, `k3d-deploy`, `k3d-redeploy`, `k3d-logs`, `k3d-status`)
- **.env.k3d.example**: Template with required secrets + BYOK provider settings
- **.gitignore**: Excludes `.env.k3d`
- **README.md**: "Local Kubernetes Development" section with prerequisites, quick start, commands table

## Design Decisions

- **Configurable host port** (`K3D_HOST_PORT=8080` default) — avoids conflict with devcontainer on 8000
- **Temp values file** for secrets — avoids Helm `--set` comma parsing issues
- **BYOK provider support** — `COPILOT_PROVIDER_TYPE`, `COPILOT_PROVIDER_BASE_URL`, `COPILOT_PROVIDER_API_KEY` forwarded to Helm

## Code Review (GPT-5.3-Codex)

| Severity | Finding | Action |
|----------|---------|--------|
| HIGH | BYOK provider path not wired into deploy | ✅ Fixed: all 3 BYOK env vars forwarded |
| MEDIUM | `--set` breaks on commas in secrets | ✅ Fixed: switched to temp values file |

## k3d Live E2E Test Results

Full cluster lifecycle tested: `k3d-up` → `k3d-build` → `k3d-deploy` → endpoint tests → `k3d-down`

### Makefile Targets

| Target | Result |
|--------|--------|
| `make k3d-up` | ✅ Cluster created, port 8080→8000 |
| `make k3d-build` | ✅ Image built + imported |
| `make k3d-deploy` | ✅ Helm install, both pods Running |
| `make k3d-status` | ✅ Controller 1/1, Redis 1/1 |
| `make k3d-logs` | ✅ Combined controller + Redis output |
| `make k3d-redeploy` | ✅ Helm upgrade revision 2 |
| `make k3d-down` | ✅ Cluster deleted cleanly |

### Service Endpoint Tests (via kubectl port-forward)

| # | Test | HTTP | Response | Status |
|---|------|------|----------|--------|
| 1 | `GET /health` | 200 | `{"status":"ok"}` | ✅ |
| 2 | Webhook bad token | 401 | `Invalid webhook token` | ✅ |
| 3 | Webhook no token | 401 | `Invalid webhook token` | ✅ |
| 4 | MR open event | 200 | `{"status":"queued"}` — background review fired (DNS error on fake URL as expected) | ✅ |
| 5 | MR close (ignored action) | 200 | `action 'close' not handled` | ✅ |
| 6 | Push event (unhandled) | 200 | `unhandled event: push` | ✅ |
| 7 | MR update no oldrev | 200 | `no new commits` | ✅ |
| 8 | Non-MR note | 200 | `not an MR note` | ✅ |
| 9 | MR copilot note | 200 | `not a /copilot command` (correct — format is `/copilot` not `@copilot`) | ✅ |

### Additional Verifications

- ✅ Comma-containing secrets (`glpat-test,with,commas`) preserved correctly via temp values file
- ✅ Temp file `/tmp/k3d-values.yaml` cleaned up after deploy
- ✅ Background review task executed end-to-end (failed at git clone on fake URL — expected)
- ✅ Redis StatefulSet running with AOF persistence

## Stats

101 added lines across 4 files.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>