### PR TITLE
fix(coding): guard .gitignore against symlink writes

### DIFF
--- a/src/gitlab_copilot_agent/coding_engine.py
+++ b/src/gitlab_copilot_agent/coding_engine.py
@@ -65,8 +65,12 @@ def ensure_gitignore(repo_root: str) -> bool:
     """Ensure .gitignore at *repo_root* contains standard Python ignore patterns.
 
     Returns True if the file was created or modified.
+    Refuses to write if .gitignore is a symlink or resolves outside repo_root.
     """
     path = Path(repo_root) / ".gitignore"
+    root_resolved = Path(repo_root).resolve()
+    if path.is_symlink() or (path.exists() and not path.resolve().is_relative_to(root_resolved)):
+        return False
     content = path.read_text() if path.exists() else ""
     existing = set(content.splitlines())
     missing = [p for p in _PYTHON_GITIGNORE_PATTERNS if p not in existing]

--- a/tests/test_coding_engine.py
+++ b/tests/test_coding_engine.py
@@ -36,6 +36,13 @@ class TestEnsureGitignore:
         for pattern in _PYTHON_GITIGNORE_PATTERNS:
             assert pattern in content
 
+    def test_refuses_symlink(self, tmp_path: Path) -> None:
+        target = tmp_path / "elsewhere.txt"
+        target.write_text("original")
+        (tmp_path / ".gitignore").symlink_to(target)
+        assert ensure_gitignore(str(tmp_path)) is False
+        assert target.read_text() == "original"
+
 
 async def test_run_coding_task_delegates_to_executor(tmp_path: Path) -> None:
     mock_executor = AsyncMock()


### PR DESCRIPTION
## What
Adds a symlink and path-traversal guard to `ensure_gitignore()`.

## Why
GPT-5.3-Codex cross-model review found a **HIGH** vulnerability: if a cloned repo contains a `.gitignore` symlink pointing outside the repo root, `ensure_gitignore()` would follow it and write to an attacker-controlled path.

## How
- Check `path.is_symlink()` and `path.resolve().is_relative_to(repo_root)` before writing
- Return `False` (no-op) if either guard triggers
- Added `test_refuses_symlink` test

Closes #63 (follow-up hardening)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>