### PR TITLE
chore(governance): add simplicity budget, pre-commit checks, and worktree isolation docs

### DIFF
--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -65,6 +65,17 @@ Before finishing any implementation:
 - Would a senior dev say "why didn't you just..."?
 - Prefer boring, obvious solutions — cleverness is expensive.
 
+### Simplicity Budget
+
+Hard limits on diff size by commit type. If you exceed the limit, **stop and report** before continuing — do not try to trim after the fact.
+
+| Type | Max diff lines | Action if exceeded |
+|------|---------------|--------------------|
+| `fix` / `chore` | 100 | Stop. Re-evaluate approach — you are likely overengineering. |
+| `feat` / `refactor` | 200 | Split into stacked PRs. |
+
+These are additions + deletions combined. Test files count.
+
 ### Scope Discipline
 
 Surgical precision only:
@@ -99,10 +110,27 @@ Only clean up dead/obsolete code when specifically directed. Never as a side eff
 | C++ | C++ Core Guidelines | clang-format + clang-tidy | cppcheck, `-Wall -Wextra -Werror` |
 | Rust | Rust API Guidelines | rustfmt | clippy (deny warnings) |
 
+## Pre-Commit Verification
+
+**Run BOTH the linter AND the formatter in check mode before every commit.** These are separate tools with separate failure modes. Running one does not guarantee the other passes.
+
+```bash
+# Example (Python — adapt for your stack):
+ruff check .
+ruff format --check .
+
+# Example (TypeScript):
+eslint .
+prettier --check .
+```
+
+If either fails, fix before committing. Do not rely on CI to catch formatting issues.
+
 ## Definition of Done
 
 - [ ] Code builds with zero errors and zero warnings
-- [ ] Linters and formatters pass
+- [ ] Linter passes (zero errors, zero warnings)
+- [ ] Formatter passes in check mode (zero reformatting needed)
 - [ ] Unit tests written and passing (≥90% coverage on project)
 - [ ] No magic strings in tests — all test data uses named constants or shared fixtures
 - [ ] Integration tests written and passing
@@ -110,6 +138,6 @@ Only clean up dead/obsolete code when specifically directed. Never as a side eff
 - [ ] Documentation updated
 - [ ] PR opened with conventional commit messages
 - [ ] PR description includes: what, why, and how to test
-- [ ] PR ≤200 diff lines
+- [ ] PR ≤200 diff lines (fix/chore ≤100 lines)
 - [ ] OWASP self-review completed
 - [ ] No new dependencies without justification

--- a/.github/instructions/devcontainer.instructions.md
+++ b/.github/instructions/devcontainer.instructions.md
@@ -32,3 +32,16 @@ If `devcontainer exec` fails:
 1. Run `devcontainer up --workspace-folder .`
 2. Retry with `devcontainer exec`
 3. Never fall back to host execution
+
+## Worktree Isolation
+
+**Inside the devcontainer** (VS Code, Codespaces, or any container-native context): worktrees are local directories. Use them directly — no `docker` or `devcontainer` commands needed. Run lint, test, and build from the worktree path as normal.
+
+**On the host**: each worktree should ideally have its own devcontainer instance (`devcontainer up --workspace-folder <worktree-path>`). This provides full isolation.
+
+If multiple worktrees share a single devcontainer on the host (e.g., to save resources):
+
+1. The container only mounts one workspace. Use `docker cp` to transfer files in for lint/test.
+2. **Always restore the container's workspace after running commands**: `git checkout -- <files>` inside the container, or `docker cp` the originals back.
+3. Never leave modified files from a worktree inside a shared container — subsequent agents will see stale or conflicting state.
+4. Prefer dedicated containers when parallelizing agents to avoid this complexity entirely.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -37,3 +37,11 @@ Real examples from production sessions:
 - Skipping review for "small" changes (small changes cause big outages)
 - Treating all findings as blocking (Medium findings can be follow-up issues)
 - Reviewing style instead of substance (formatters handle style)
+
+## Pre-Review Gate
+
+Before reviewing logic, verify the author ran both linter and formatter:
+
+1. Check the diff for formatting-only changes (inconsistent whitespace, import ordering). If present, reject — the author didn't run the formatter.
+2. If you can run commands, execute the project's lint and format-check commands on the changed files. Report any failures as **High** severity (broken CI pipeline).
+3. Only proceed to logic review after lint/format is clean.

--- a/.github/skills/pre-implementation/SKILL.md
+++ b/.github/skills/pre-implementation/SKILL.md
@@ -59,3 +59,11 @@ For infrastructure, security, or integration-heavy tasks:
 - **Single-line fixes** (typos, config tweaks): skip entirely.
 - **Documentation-only changes** (README updates, comment fixes): skip steps 2 and 3. Note: new skills, instructions, or agent files are NOT documentation-only — they define process and require product/architecture review.
 - **Exploratory/spike work**: skip, but re-run before converting to a real PR.
+
+## Fast Path
+
+For issues that already have testable acceptance criteria in the GitHub Issue AND the expected diff is ≤100 lines:
+
+- Skip steps 1–3 (requirements, design, and UX are already validated).
+- Start at step 4 (Work Tracked).
+- Still complete steps 5 and 6.

--- a/.github/skills/worktree-setup/SKILL.md
+++ b/.github/skills/worktree-setup/SKILL.md
@@ -64,3 +64,13 @@ git branch -d <branch-name>
 - One worktree = one task = one agent = one devcontainer.
 - Worktrees share the same repo objects but have independent working directories.
 - Multiple worktrees can run concurrently — monitor machine resources.
+
+## Shared Devcontainer Warning
+
+If resource constraints prevent one-devcontainer-per-worktree, a single devcontainer can be shared. This introduces friction:
+
+- Files must be `docker cp`'d into the container for lint/test runs.
+- The container workspace must be restored after each run (`git checkout -- .` inside the container).
+- Agents can accidentally pollute each other's state if restoration is skipped.
+
+**Prefer dedicated containers.** Only share when machine resources (RAM, CPU) make it necessary. If sharing, document which container ID is shared and add restoration steps to every agent's workflow.


### PR DESCRIPTION
## What

Refine agent governance docs with stricter guardrails and clearer workflows.

## Why

Lessons from recent sessions: agents exceeded diff budgets, skipped formatter checks, and had worktree state pollution when sharing devcontainers. These additions codify the fixes.

## Changes

- **Developer agent**: Add simplicity budget (fix/chore ≤100 lines, feat/refactor ≤200 lines), pre-commit verification requiring both linter and formatter, tighten Definition of Done
- **Devcontainer instructions**: Add worktree isolation section covering shared-container pitfalls
- **Code-review skill**: Add pre-review gate checking lint/format before logic review
- **Pre-implementation skill**: Add fast path for small issues with existing acceptance criteria
- **Worktree-setup skill**: Add shared devcontainer warning with restoration steps

## How to Test

1. Review the markdown changes for clarity and consistency
2. Verify the rules are actionable and unambiguous