### PR TITLE
feat(gitlab): add list_project_mrs, list_mr_notes, and resolve_project

### DIFF
--- a/src/gitlab_copilot_agent/gitlab_client.py
+++ b/src/gitlab_copilot_agent/gitlab_client.py
@@ -5,12 +5,48 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Protocol
 
 import gitlab
 import structlog
+from pydantic import BaseModel, ConfigDict
 
 log = structlog.get_logger()
+
+
+class MRAuthor(BaseModel):
+    """MR author from GitLab API list response."""
+
+    model_config = ConfigDict(extra="ignore")
+    id: int
+    username: str
+
+
+class MRListItem(BaseModel):
+    """Subset of fields from GitLab MR list API response."""
+
+    model_config = ConfigDict(extra="ignore")
+    iid: int
+    title: str
+    description: str | None = None
+    source_branch: str
+    target_branch: str
+    sha: str
+    web_url: str
+    state: str
+    author: MRAuthor
+    updated_at: str
+
+
+class NoteListItem(BaseModel):
+    """Subset of fields from GitLab MR notes API response."""
+
+    model_config = ConfigDict(extra="ignore")
+    id: int
+    body: str
+    author: MRAuthor
+    system: bool = False
+    created_at: str
 
 
 @dataclass(frozen=True)
@@ -48,10 +84,10 @@ class GitLabClientProtocol(Protocol):
     async def post_mr_comment(self, project_id: int, mr_iid: int, body: str) -> None: ...
     async def list_project_mrs(
         self, project_id: int, state: str = "opened", updated_after: str | None = None
-    ) -> list[dict[str, Any]]: ...
+    ) -> list[MRListItem]: ...
     async def list_mr_notes(
         self, project_id: int, mr_iid: int, created_after: str | None = None
-    ) -> list[dict[str, Any]]: ...
+    ) -> list[NoteListItem]: ...
     async def resolve_project(self, id_or_path: str | int) -> int: ...
 
 
@@ -143,30 +179,32 @@ class GitLabClient:
 
     async def list_project_mrs(
         self, project_id: int, state: str = "opened", updated_after: str | None = None
-    ) -> list[dict[str, Any]]:
+    ) -> list[MRListItem]:
         """List merge requests for a project."""
 
-        def _list() -> list[dict[str, Any]]:
+        def _list() -> list[MRListItem]:
             project = self._gl.projects.get(project_id)
-            kwargs: dict[str, Any] = {"state": state, "get_all": True}
+            kwargs: dict[str, object] = {"state": state, "get_all": True}
             if updated_after is not None:
                 kwargs["updated_after"] = updated_after
-            return [mr.attributes for mr in project.mergerequests.list(**kwargs)]
+            mrs = project.mergerequests.list(**kwargs)
+            return [MRListItem.model_validate(mr.attributes) for mr in mrs]
 
         return await asyncio.to_thread(_list)
 
     async def list_mr_notes(
         self, project_id: int, mr_iid: int, created_after: str | None = None
-    ) -> list[dict[str, Any]]:
+    ) -> list[NoteListItem]:
         """List notes (comments) on a merge request."""
 
-        def _list() -> list[dict[str, Any]]:
+        def _list() -> list[NoteListItem]:
             project = self._gl.projects.get(project_id)
             mr = project.mergerequests.get(mr_iid)
-            kwargs: dict[str, Any] = {"get_all": True}
+            kwargs: dict[str, object] = {"get_all": True}
             if created_after is not None:
                 kwargs["created_after"] = created_after
-            return [note.attributes for note in mr.notes.list(**kwargs)]
+            notes = mr.notes.list(**kwargs)
+            return [NoteListItem.model_validate(n.attributes) for n in notes]
 
         return await asyncio.to_thread(_list)
 

--- a/tests/test_gitlab_client.py
+++ b/tests/test_gitlab_client.py
@@ -6,8 +6,31 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from gitlab_copilot_agent.gitlab_client import GitLabClient, MRChange, MRDetails, MRDiffRef
-from tests.conftest import MR_IID, PROJECT_ID
+from gitlab_copilot_agent.gitlab_client import (
+    GitLabClient,
+    MRAuthor,
+    MRChange,
+    MRDetails,
+    MRDiffRef,
+    MRListItem,
+    NoteListItem,
+)
+from tests.conftest import GITLAB_TOKEN, GITLAB_URL, MR_IID, PROJECT_ID
+
+MR_TITLE = "Test MR"
+MR_DESCRIPTION = "A test merge request"
+BASE_SHA = "aaa111"
+START_SHA = "ccc333"
+HEAD_SHA = "bbb222"
+OLD_PATH = "src/main.py"
+DIFF_CONTENT = "@@ -1,3 +1,4 @@\n+new line\n"
+NOTE_BODY = "LGTM"
+NOTE_ID = 1
+PROJECT_PATH = "group/my-project"
+ISO_TIMESTAMP = "2024-01-01T00:00:00Z"
+SECRET_TOKEN = "glpat-secret-token-value"
+AUTHOR_ATTRS = {"id": 1, "username": "testuser"}
+MR_WEB_URL = f"{GITLAB_URL}/{PROJECT_PATH}/-/merge_requests/{MR_IID}"
 
 
 @pytest.fixture
@@ -15,18 +38,18 @@ def mock_gl(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     mock = MagicMock()
     mr_mock = MagicMock()
     mr_mock.changes.return_value = {
-        "title": "Test MR",
-        "description": "A test merge request",
+        "title": MR_TITLE,
+        "description": MR_DESCRIPTION,
         "diff_refs": {
-            "base_sha": "aaa111",
-            "start_sha": "ccc333",
-            "head_sha": "bbb222",
+            "base_sha": BASE_SHA,
+            "start_sha": START_SHA,
+            "head_sha": HEAD_SHA,
         },
         "changes": [
             {
-                "old_path": "src/main.py",
-                "new_path": "src/main.py",
-                "diff": "@@ -1,3 +1,4 @@\n+new line\n",
+                "old_path": OLD_PATH,
+                "new_path": OLD_PATH,
+                "diff": DIFF_CONTENT,
                 "new_file": False,
                 "deleted_file": False,
                 "renamed_file": False,
@@ -39,18 +62,19 @@ def mock_gl(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
 
 
 async def test_get_mr_details(mock_gl: MagicMock) -> None:
-    client = GitLabClient("https://gitlab.com", "token")
+    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
     details = await client.get_mr_details(PROJECT_ID, MR_IID)
 
     assert isinstance(details, MRDetails)
-    assert details.title == "Test MR"
-    assert details.description == "A test merge request"
-    assert details.diff_refs == MRDiffRef(base_sha="aaa111", start_sha="ccc333", head_sha="bbb222")
+    assert details.title == MR_TITLE
+    assert details.description == MR_DESCRIPTION
+    expected_refs = MRDiffRef(base_sha=BASE_SHA, start_sha=START_SHA, head_sha=HEAD_SHA)
+    assert details.diff_refs == expected_refs
     assert len(details.changes) == 1
     assert details.changes[0] == MRChange(
-        old_path="src/main.py",
-        new_path="src/main.py",
-        diff="@@ -1,3 +1,4 @@\n+new line\n",
+        old_path=OLD_PATH,
+        new_path=OLD_PATH,
+        diff=DIFF_CONTENT,
     )
 
 
@@ -63,24 +87,37 @@ async def _run(*cmd: str) -> None:
 
 async def test_list_project_mrs(mock_gl: MagicMock) -> None:
     mr_obj = MagicMock()
-    mr_obj.attributes = {"iid": MR_IID, "title": "Test MR", "state": "opened"}
+    mr_obj.attributes = {
+        "iid": MR_IID,
+        "title": MR_TITLE,
+        "description": MR_DESCRIPTION,
+        "source_branch": "feature",
+        "target_branch": "main",
+        "sha": HEAD_SHA,
+        "web_url": MR_WEB_URL,
+        "state": "opened",
+        "author": AUTHOR_ATTRS,
+        "updated_at": ISO_TIMESTAMP,
+    }
     mock_gl.projects.get.return_value.mergerequests.list.return_value = [mr_obj]
 
-    client = GitLabClient("https://gitlab.com", "token")
-    result = await client.list_project_mrs(
-        PROJECT_ID, state="merged", updated_after="2024-01-01T00:00:00Z"
-    )
+    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
+    result = await client.list_project_mrs(PROJECT_ID, state="merged", updated_after=ISO_TIMESTAMP)
 
-    assert result == [{"iid": MR_IID, "title": "Test MR", "state": "opened"}]
+    assert len(result) == 1
+    assert isinstance(result[0], MRListItem)
+    assert result[0].iid == MR_IID
+    assert result[0].sha == HEAD_SHA
+    assert result[0].author == MRAuthor(id=1, username="testuser")
     mock_gl.projects.get.return_value.mergerequests.list.assert_called_once_with(
-        state="merged", get_all=True, updated_after="2024-01-01T00:00:00Z"
+        state="merged", get_all=True, updated_after=ISO_TIMESTAMP
     )
 
 
 async def test_list_project_mrs_defaults(mock_gl: MagicMock) -> None:
     mock_gl.projects.get.return_value.mergerequests.list.return_value = []
 
-    client = GitLabClient("https://gitlab.com", "token")
+    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
     result = await client.list_project_mrs(PROJECT_ID)
 
     assert result == []
@@ -91,24 +128,33 @@ async def test_list_project_mrs_defaults(mock_gl: MagicMock) -> None:
 
 async def test_list_mr_notes(mock_gl: MagicMock) -> None:
     note_obj = MagicMock()
-    note_obj.attributes = {"id": 1, "body": "LGTM"}
+    note_obj.attributes = {
+        "id": NOTE_ID,
+        "body": NOTE_BODY,
+        "author": AUTHOR_ATTRS,
+        "system": False,
+        "created_at": ISO_TIMESTAMP,
+    }
     mock_gl.projects.get.return_value.mergerequests.get.return_value.notes.list.return_value = [
         note_obj
     ]
 
-    client = GitLabClient("https://gitlab.com", "token")
-    result = await client.list_mr_notes(PROJECT_ID, MR_IID, created_after="2024-01-01T00:00:00Z")
+    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
+    result = await client.list_mr_notes(PROJECT_ID, MR_IID, created_after=ISO_TIMESTAMP)
 
-    assert result == [{"id": 1, "body": "LGTM"}]
+    assert len(result) == 1
+    assert isinstance(result[0], NoteListItem)
+    assert result[0].id == NOTE_ID
+    assert result[0].body == NOTE_BODY
     mock_gl.projects.get.return_value.mergerequests.get.return_value.notes.list.assert_called_once_with(
-        get_all=True, created_after="2024-01-01T00:00:00Z"
+        get_all=True, created_after=ISO_TIMESTAMP
     )
 
 
 async def test_list_mr_notes_defaults(mock_gl: MagicMock) -> None:
     mock_gl.projects.get.return_value.mergerequests.get.return_value.notes.list.return_value = []
 
-    client = GitLabClient("https://gitlab.com", "token")
+    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
     result = await client.list_mr_notes(PROJECT_ID, MR_IID)
 
     assert result == []
@@ -120,7 +166,7 @@ async def test_list_mr_notes_defaults(mock_gl: MagicMock) -> None:
 async def test_resolve_project_by_id(mock_gl: MagicMock) -> None:
     mock_gl.projects.get.return_value.id = PROJECT_ID
 
-    client = GitLabClient("https://gitlab.com", "token")
+    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
     result = await client.resolve_project(PROJECT_ID)
 
     assert result == PROJECT_ID
@@ -130,20 +176,17 @@ async def test_resolve_project_by_id(mock_gl: MagicMock) -> None:
 async def test_resolve_project_by_path(mock_gl: MagicMock) -> None:
     mock_gl.projects.get.return_value.id = PROJECT_ID
 
-    client = GitLabClient("https://gitlab.com", "token")
-    result = await client.resolve_project("group/my-project")
+    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
+    result = await client.resolve_project(PROJECT_PATH)
 
     assert result == PROJECT_ID
-    mock_gl.projects.get.assert_called_with("group/my-project")
+    mock_gl.projects.get.assert_called_with(PROJECT_PATH)
 
 
 async def test_clone_repo_sanitizes_token_in_error(tmp_path: Path) -> None:
     """Test that tokens are sanitized in clone error messages."""
-    client = GitLabClient("https://gitlab.com", "token")
-    secret = "glpat-secret-token-value"
+    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
 
-    # Token sanitization in error from non-existent repo
     with pytest.raises(RuntimeError, match="git clone failed") as exc_info:
-        await client.clone_repo("https://gitlab.com/nonexistent/repo.git", "main", secret)
-    # Ensure token is not leaked in error message
-    assert secret not in str(exc_info.value)
+        await client.clone_repo("https://gitlab.com/nonexistent/repo.git", "main", SECRET_TOKEN)
+    assert SECRET_TOKEN not in str(exc_info.value)


### PR DESCRIPTION
## What
Add 3 new methods to GitLab client for API polling support.

## Why
Issue #12 — GitLab API polling needs to list MRs, list MR notes, and resolve project paths to IDs.

## How to Test
```bash
uv run pytest tests/test_gitlab_client.py -v
```

Part 1 of 5 for #12.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>