### PR TITLE
feat(gitlab): add unified project allowlist for webhook and poller

### DIFF
--- a/src/gitlab_copilot_agent/config.py
+++ b/src/gitlab_copilot_agent/config.py
@@ -81,6 +81,12 @@ class Settings(BaseSettings):
         default=None, description="Redis URL (required when STATE_BACKEND=redis)"
     )
 
+    # Project allowlist (optional — scopes webhook and poller)
+    gitlab_projects: str | None = Field(
+        default=None,
+        description="Comma-separated GitLab project paths or IDs to scope webhook and poller",
+    )
+
     # Jira (all optional — service runs review-only without these)
     jira_url: str | None = Field(default=None, description="Jira instance URL")
     jira_email: str | None = Field(default=None, description="Jira user email")

--- a/src/gitlab_copilot_agent/webhook.py
+++ b/src/gitlab_copilot_agent/webhook.py
@@ -61,6 +61,14 @@ async def webhook(
     _validate_webhook_token(x_gitlab_token, settings.gitlab_webhook_secret)
 
     body = await request.json()
+
+    # Project allowlist check
+    allowed = request.app.state.allowed_project_ids
+    if allowed is not None:
+        project_id = body.get("project", {}).get("id")
+        if project_id not in allowed:
+            return {"status": "ignored", "reason": "project not in allowlist"}
+
     object_kind = body.get("object_kind")
     webhook_received_total.add(1, {"object_kind": object_kind or "unknown"})
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,6 +139,7 @@ async def client(env_vars: None) -> AsyncIterator[AsyncClient]:
     app.state.repo_locks = RepoLockManager()
     app.state.dedup_store = MemoryDedup()
     app.state.review_tracker = ReviewedMRTracker()
+    app.state.allowed_project_ids = None
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         yield c


### PR DESCRIPTION
## What

Add `GITLAB_PROJECTS` config that scopes both webhook and poller to specific GitLab projects. Accepts project paths or numeric IDs, comma-separated.

## Why

Issue #12 — group-level webhooks would trigger reviews on every project. The poller also needs an explicit project list. This adds a unified allowlist shared by both code paths. Omitting the config preserves backward compatibility (all projects accepted).

## Changes (94 diff lines)

### `config.py` (+6 lines)
- Add `gitlab_projects: str | None` field — comma-separated paths or IDs

### `main.py` (+17 lines)
- Resolve `GITLAB_PROJECTS` to `set[int]` at startup via `resolve_project()`
- Store as `app.state.allowed_project_ids: set[int] | None` (None = allow all)
- Log resolved project list at startup

### `webhook.py` (+8 lines)
- Check incoming webhook project ID against allowlist after token validation
- Return 200 "project not in allowlist" for unlisted projects (not 403 — event is valid, just filtered)

### `conftest.py` (+1 line)
- Add `GITLAB_PROJECTS` to shared test constants

### `test_main.py` (+29 lines)
- `test_lifespan_resolves_project_allowlist`: verify startup resolves paths to IDs
- `test_lifespan_no_allowlist`: verify None when GITLAB_PROJECTS not set

### `test_webhook.py` (+33 lines)
- `test_mr_webhook_project_not_in_allowlist`: filtered project returns 200 skip
- `test_mr_webhook_no_allowlist_allows_all`: None allowlist passes all through

## Verification

```
28 passed in 3.50s
```

✅ Ruff lint + format clean

## Code Review (GPT-5.3-Codex)

| Severity | Finding | Action |
|----------|---------|--------|
| HIGH | Allowlist not enforced for Jira flow | Out of scope — Jira has its own project scoping via `JIRA_PROJECT_MAP` |

Part 3 of 5 for #12. Stacked on #113.

Closes #12 (partial)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>