### PR TITLE
feat(helm): wire OTEL telemetry to cluster and app

### DIFF
--- a/.env.k3d.example
+++ b/.env.k3d.example
@@ -9,3 +9,6 @@ GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
 # COPILOT_PROVIDER_TYPE=openai
 # COPILOT_PROVIDER_BASE_URL=https://api.openai.com/v1
 # COPILOT_PROVIDER_API_KEY=sk-xxxxxxxxxxxxxxxxxxxx
+# OpenTelemetry (uncomment to enable telemetry export)
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+# DEPLOYMENT_ENV=development

--- a/helm/gitlab-copilot-agent/templates/configmap.yaml
+++ b/helm/gitlab-copilot-agent/templates/configmap.yaml
@@ -23,3 +23,9 @@ data:
   {{- with .Values.controller.copilotProviderBaseUrl }}
   COPILOT_PROVIDER_BASE_URL: {{ . | quote }}
   {{- end }}
+  {{- with .Values.telemetry.otlpEndpoint }}
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.telemetry.environment }}
+  DEPLOYMENT_ENV: {{ . | quote }}
+  {{- end }}

--- a/helm/gitlab-copilot-agent/templates/deployment.yaml
+++ b/helm/gitlab-copilot-agent/templates/deployment.yaml
@@ -24,6 +24,17 @@ spec:
           envFrom:
             - configMapRef: { name: {{ include "app.fullname" . }} }
             - secretRef: { name: {{ include "app.fullname" . }} }
+          {{- if .Values.telemetry.otlpEndpoint }}
+          env:
+            - name: POD_NAME
+              valueFrom: { fieldRef: { fieldPath: metadata.name } }
+            - name: POD_NAMESPACE
+              valueFrom: { fieldRef: { fieldPath: metadata.namespace } }
+            - name: NODE_NAME
+              valueFrom: { fieldRef: { fieldPath: spec.nodeName } }
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(POD_NAMESPACE),k8s.node.name=$(NODE_NAME)"
+          {{- end }}
           resources: {{- toYaml .Values.controller.resources | nindent 12 }}
           livenessProbe: { httpGet: { path: /health, port: {{ .Values.controller.port }} }, initialDelaySeconds: 10 }
           readinessProbe: { httpGet: { path: /health, port: {{ .Values.controller.port }} } }

--- a/helm/gitlab-copilot-agent/templates/otel-collector.yaml
+++ b/helm/gitlab-copilot-agent/templates/otel-collector.yaml
@@ -1,0 +1,103 @@
+{{- if .Values.telemetry.otlpEndpoint }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "app.fullname" . }}-otel-collector
+  labels: {{- include "app.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+      kubeletstats:
+        collection_interval: 30s
+        auth_type: serviceAccount
+        endpoint: "https://${env:NODE_NAME}:10250"
+        insecure_skip_verify: true
+      filelog:
+        include: [/var/log/pods/*/*/*.log]
+        operators:
+          - type: container
+            id: container-parser
+    exporters:
+      otlp:
+        endpoint: {{ .Values.telemetry.otlpEndpoint | quote }}
+        tls:
+          insecure: {{ not (hasPrefix "https" .Values.telemetry.otlpEndpoint) }}
+    processors:
+      batch:
+        timeout: 10s
+      k8sattributes:
+        extract:
+          metadata: [k8s.pod.name, k8s.namespace.name, k8s.node.name]
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch, k8sattributes]
+          exporters: [otlp]
+        metrics:
+          receivers: [otlp, kubeletstats]
+          processors: [batch, k8sattributes]
+          exporters: [otlp]
+        logs:
+          receivers: [otlp, filelog]
+          processors: [batch, k8sattributes]
+          exporters: [otlp]
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "app.fullname" . }}-otel-collector
+  labels: {{- include "app.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: otel-collector
+      {{- include "app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: otel-collector
+        {{- include "app.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "app.fullname" . }}-otel-collector
+      containers:
+        - name: collector
+          image: "{{ .Values.telemetry.collector.image.repository }}:{{ .Values.telemetry.collector.image.tag }}"
+          args: ["--config=/etc/otelcol/config.yaml"]
+          ports: [{ containerPort: 4317, protocol: TCP }]
+          env:
+            - name: NODE_NAME
+              valueFrom: { fieldRef: { fieldPath: spec.nodeName } }
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otelcol
+            - name: varlogpods
+              mountPath: /var/log/pods
+              readOnly: true
+          resources: {{- toYaml .Values.telemetry.collector.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap: { name: {{ include "app.fullname" . }}-otel-collector }
+        - name: varlogpods
+          hostPath: { path: /var/log/pods }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "app.fullname" . }}-otel-collector
+  labels: {{- include "app.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 4317
+      targetPort: 4317
+      protocol: TCP
+      name: otlp-grpc
+  selector:
+    app.kubernetes.io/component: otel-collector
+    {{- include "app.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/gitlab-copilot-agent/templates/rbac.yaml
+++ b/helm/gitlab-copilot-agent/templates/rbac.yaml
@@ -16,3 +16,30 @@ metadata:
   name: {{ include "app.fullname" . }}
 roleRef: { apiGroup: rbac.authorization.k8s.io, kind: Role, name: {{ include "app.fullname" . }} }
 subjects: [{ kind: ServiceAccount, name: {{ include "app.serviceAccountName" . }} }]
+{{- if .Values.telemetry.otlpEndpoint }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "app.fullname" . }}-otel-collector
+  labels: {{- include "app.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "app.fullname" . }}-otel-collector
+rules:
+  - apiGroups: [""]
+    resources: ["nodes/stats", "nodes/proxy"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "app.fullname" . }}-otel-collector
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: {{ include "app.fullname" . }}-otel-collector }
+subjects: [{ kind: ServiceAccount, name: {{ include "app.fullname" . }}-otel-collector, namespace: {{ .Release.Namespace }} }]
+{{- end }}

--- a/helm/gitlab-copilot-agent/values.yaml
+++ b/helm/gitlab-copilot-agent/values.yaml
@@ -20,6 +20,16 @@ redis:
     limits: { cpu: 250m, memory: 256Mi }
     requests: { cpu: 50m, memory: 64Mi }
   storage: 1Gi
+telemetry:
+  # Set to enable OpenTelemetry export (e.g. "http://otel-collector:4317")
+  otlpEndpoint: ""
+  # Optional deployment environment label (e.g. "production", "staging")
+  environment: ""
+  collector:
+    image: { repository: otel/opentelemetry-collector-contrib, tag: "0.115.0" }
+    resources:
+      limits: { cpu: 200m, memory: 256Mi }
+      requests: { cpu: 50m, memory: 128Mi }
 jobRunner: { image: "", cpuLimit: "1", memoryLimit: 1Gi, timeout: 600 }
 serviceAccount: { create: true, name: "" }
 gitlab: { url: "", token: "", webhookSecret: "" }

--- a/scripts/otel_console_collector.py
+++ b/scripts/otel_console_collector.py
@@ -1,0 +1,126 @@
+"""Minimal OTEL collector that logs received telemetry to the console.
+
+Usage:
+    uv run python scripts/otel_console_collector.py [--port 4317]
+
+Starts a gRPC server on port 4317 that accepts OTLP traces, metrics,
+and logs, printing a summary line for each batch. Useful for local
+development and E2E testing without a real collector.
+"""
+
+from __future__ import annotations
+
+import argparse
+from concurrent import futures
+from datetime import UTC, datetime
+
+import grpc
+from google.protobuf.json_format import MessageToDict
+from opentelemetry.proto.collector.logs.v1 import (
+    logs_service_pb2,
+    logs_service_pb2_grpc,
+)
+from opentelemetry.proto.collector.metrics.v1 import (
+    metrics_service_pb2,
+    metrics_service_pb2_grpc,
+)
+from opentelemetry.proto.collector.trace.v1 import (
+    trace_service_pb2,
+    trace_service_pb2_grpc,
+)
+
+_CYAN = "\033[36m"
+_GREEN = "\033[32m"
+_YELLOW = "\033[33m"
+_RESET = "\033[0m"
+
+
+def _ts() -> str:
+    return datetime.now(UTC).strftime("%H:%M:%S.%f")[:-3]
+
+
+def _resource_name(resource_spans_or_metrics: object) -> str:
+    """Extract service.name from resource attributes."""
+    try:
+        d = MessageToDict(resource_spans_or_metrics)  # type: ignore[arg-type]
+        for attr in d.get("resource", {}).get("attributes", []):
+            if attr.get("key") == "service.name":
+                return attr["value"].get("stringValue", "unknown")
+    except Exception:
+        pass
+    return "unknown"
+
+
+class TraceService(trace_service_pb2_grpc.TraceServiceServicer):
+    def Export(self, request, context):  # type: ignore[override]
+        for rs in request.resource_spans:
+            svc = _resource_name(rs)
+            span_count = sum(len(ss.spans) for ss in rs.scope_spans)
+            names = []
+            for ss in rs.scope_spans:
+                for s in ss.spans:
+                    names.append(s.name)
+            preview = ", ".join(names[:5])
+            if len(names) > 5:
+                preview += f" (+{len(names) - 5} more)"
+            print(f"{_CYAN}[{_ts()}] TRACE{_RESET}  svc={svc}  spans={span_count}  [{preview}]")
+        return trace_service_pb2.ExportTraceServiceResponse()
+
+
+class MetricsService(metrics_service_pb2_grpc.MetricsServiceServicer):
+    def Export(self, request, context):  # type: ignore[override]
+        for rm in request.resource_metrics:
+            svc = _resource_name(rm)
+            metric_names = []
+            for sm in rm.scope_metrics:
+                for m in sm.metrics:
+                    metric_names.append(m.name)
+            preview = ", ".join(metric_names[:8])
+            if len(metric_names) > 8:
+                preview += f" (+{len(metric_names) - 8} more)"
+            print(
+                f"{_GREEN}[{_ts()}] METRIC{_RESET} "
+                f"svc={svc}  metrics={len(metric_names)}  [{preview}]"
+            )
+        return metrics_service_pb2.ExportMetricsServiceResponse()
+
+
+class LogsService(logs_service_pb2_grpc.LogsServiceServicer):
+    def Export(self, request, context):  # type: ignore[override]
+        for rl in request.resource_logs:
+            svc = _resource_name(rl)
+            for sl in rl.scope_logs:
+                for lr in sl.log_records:
+                    body = ""
+                    if lr.body.string_value:
+                        body = lr.body.string_value[:120]
+                    severity = lr.severity_text or "?"
+                    print(f"{_YELLOW}[{_ts()}] LOG{_RESET}    svc={svc}  level={severity}  {body}")
+        return logs_service_pb2.ExportLogsServiceResponse()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Console OTEL collector")
+    parser.add_argument("--port", type=int, default=4317, help="gRPC listen port")
+    args = parser.parse_args()
+
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=4))
+    trace_service_pb2_grpc.add_TraceServiceServicer_to_server(TraceService(), server)
+    metrics_service_pb2_grpc.add_MetricsServiceServicer_to_server(MetricsService(), server)
+    logs_service_pb2_grpc.add_LogsServiceServicer_to_server(LogsService(), server)
+    server.add_insecure_port(f"0.0.0.0:{args.port}")
+    server.start()
+
+    print(
+        f"\n📡 Console OTEL Collector listening on :{args.port}\n"
+        f"   Set OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:{args.port}\n"
+    )
+    try:
+        server.wait_for_termination()
+    except KeyboardInterrupt:
+        print("\nShutting down...")
+        server.stop(grace=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gitlab_copilot_agent/telemetry.py
+++ b/src/gitlab_copilot_agent/telemetry.py
@@ -36,7 +36,13 @@ def init_telemetry() -> None:
     from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
     from opentelemetry.sdk.resources import Resource
 
-    resource = Resource.create({"service.name": _SERVICE_NAME})
+    resource = Resource.create(
+        {
+            "service.name": _SERVICE_NAME,
+            "service.version": os.environ.get("SERVICE_VERSION", "0.1.0"),
+            "deployment.environment": os.environ.get("DEPLOYMENT_ENV", ""),
+        }
+    )
 
     # Traces
     tracer_provider = TracerProvider(resource=resource)


### PR DESCRIPTION
## What

Wire OpenTelemetry telemetry so both the app and k8s cluster infrastructure export to the same `OTEL_EXPORTER_OTLP_ENDPOINT`. When enabled, operators get correlated app traces/metrics/logs alongside k8s pod metrics and container logs in their existing backend (Datadog, Honeycomb, Grafana Cloud, etc.).

## Why

The app has full OTEL instrumentation (traces, metrics, logs) but the Helm chart never passed `OTEL_EXPORTER_OTLP_ENDPOINT` to the container. The cluster itself had no telemetry collection. App telemetry and infra telemetry lived in separate worlds.

## Changes

- **`helm/gitlab-copilot-agent/values.yaml`** (+10) — Add `telemetry.otlpEndpoint`, `telemetry.environment`, `telemetry.collector.image/resources`
- **`helm/gitlab-copilot-agent/templates/configmap.yaml`** (+6) — Inject `OTEL_EXPORTER_OTLP_ENDPOINT` and `DEPLOYMENT_ENV` when endpoint is set
- **`helm/gitlab-copilot-agent/templates/deployment.yaml`** (+10) — Add k8s downward API env vars (`POD_NAME`, `POD_NAMESPACE`, `NODE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`), gated by `telemetry.otlpEndpoint`
- **`helm/gitlab-copilot-agent/templates/otel-collector.yaml`** (+103) — New: OTEL Collector DaemonSet + ConfigMap + Service. Receives OTLP gRPC, scrapes kubeletstats + pod logs, exports to same endpoint
- **`helm/gitlab-copilot-agent/templates/rbac.yaml`** (+25) — Dedicated ServiceAccount + ClusterRole/ClusterRoleBinding for collector (nodes/stats, pods, namespaces)
- **`src/gitlab_copilot_agent/telemetry.py`** (+5 −1) — Enrich Resource with `service.version` and `deployment.environment`
- **`.env.k3d.example`** (+3) — Add commented OTEL vars
- **`scripts/otel_console_collector.py`** (+126) — New: minimal gRPC mock collector that logs to console for dev/testing

## Verification

### Helm template validation
```
# Disabled (default) — zero OTEL resources rendered
$ helm template test helm/... | grep -c otel
0

# Enabled — all resources rendered with dedicated collector SA
$ helm template test helm/... --set telemetry.otlpEndpoint=http://otel:4317
✅ Dedicated otel-collector ServiceAccount
✅ ClusterRole bound only to collector SA (not app controller)
✅ OTEL_EXPORTER_OTLP_ENDPOINT in ConfigMap
✅ OTEL_RESOURCE_ATTRIBUTES with k8s metadata in Deployment
✅ DaemonSet + Service for collector
```

### E2E Test (mock gRPC collector + real app)
```
🧪 E2E Test: Issue #121 — OTEL Telemetry Wiring
==================================================
  ✅ Health check: 200
  ✅ Webhook accepted: 200
  ✅ Traces received: 9 spans
  ✅ Metrics received: 24 datapoints
  ✅ Logs received: 5 records
==================================================
✅ All signals received at collector
```

### Unit tests
```
$ uv run pytest tests/test_telemetry.py -q
7 passed in 0.16s
```

## Code Review

Cross-model review (GPT-5.3-Codex):

| # | Severity | Finding | Action |
|---|----------|---------|--------|
| 1 | High | Collector ClusterRole bound to app SA — gives controller node-level perms | ✅ Fixed: dedicated `otel-collector` ServiceAccount |
| 2 | Medium | kubeletstats `insecure_skip_verify: true` | Noted: standard for in-cluster kubelet access without custom CA bundle; acceptable for initial release |
| 3 | Medium | Downward API env vars injected even when telemetry disabled | ✅ Fixed: gated behind `telemetry.otlpEndpoint` |

Closes #121