### PR TITLE
fix(demo): create "AI Ready" workflow status in Jira provisioner

### DIFF
--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -31,6 +31,7 @@ uv run scripts/demo_provision.py \
 The script will:
 - Create a private GitLab project with a demo blog API (intentional issues included)
 - Create a Jira project with 3 demo stories
+- Create the **"AI Ready"** and **"In Review"** workflow statuses on the Jira board (workflow: To Do → AI Ready → In Progress → In Review → Done)
 - Auto-detect ngrok and configure the GitLab webhook (if running)
 - Output the `JIRA_PROJECT_MAP` configuration and next steps
 

--- a/docs/wiki/configuration-reference.md
+++ b/docs/wiki/configuration-reference.md
@@ -230,6 +230,7 @@ All optional — service runs review-only without these.
 - **Required**: ❌ No
 - **Default**: `"AI Ready"`
 - **Description**: Jira status that triggers the agent
+- **Note**: The demo provisioner (`scripts/demo_provision.py`) auto-creates this status on the Jira board
 
 ### `JIRA_IN_PROGRESS_STATUS`
 - **Type**: `str`

--- a/scripts/demo_provision.py
+++ b/scripts/demo_provision.py
@@ -58,6 +58,9 @@ from demo_provision.jira_provisioner import (
     create_project as jira_create_project,
 )
 from demo_provision.jira_provisioner import (
+    create_statuses as jira_create_statuses,
+)
+from demo_provision.jira_provisioner import (
     get_project as jira_get_project,
 )
 
@@ -190,13 +193,26 @@ def main() -> None:
         current_user = get_current_user(jira_client)
         lead_account_id = current_user["accountId"]
 
-        jira_create_project(
+        jira_project_data = jira_create_project(
             jira_client,
             key=args.jira_project_key,
             name=f"Copilot Demo ({args.jira_project_key})",
             lead_account_id=lead_account_id,
         )
         print(f"✅ Jira project created: {args.jira_project_key}")
+
+        # Ensure workflow statuses exist on the project board
+        # Workflow: To Do → AI Ready → In Progress → In Review → Done
+        project_id = str(jira_project_data["id"])
+        jira_create_statuses(
+            jira_client,
+            [
+                (args.trigger_status, "NEW"),        # To Do category
+                ("In Review", "INDETERMINATE"),       # In Progress category
+            ],
+            project_id,
+        )
+        print(f"✅ Created '{args.trigger_status}' and 'In Review' statuses on Jira board")
 
         # Create demo issues
         issue_keys: list[str] = []


### PR DESCRIPTION
## What

After creating the Jira project, the demo provisioner creates a project-scoped "AI Ready" status via `POST /rest/api/3/statuses`. This ensures the agent's JQL `status = "AI Ready"` query can match issues on the demo board.

Closes #130

## Changes

| File | What changed |
|------|-------------|
| `scripts/demo_provision/jira_provisioner.py` | Added `find_status()` and `create_status()` — top-level `scope` per Jira API contract |
| `scripts/demo_provision.py` | Calls status creation after project setup; always creates project-scoped status |
| `tests/test_demo_provision/test_jira_provisioner.py` | 3 new tests covering find + create with correct payload assertions |
| `docs/DEMO.md` | Note that provisioner auto-creates AI Ready status |
| `docs/wiki/configuration-reference.md` | Note on JIRA_TRIGGER_STATUS auto-provisioning |

## Code Review (GPT-5.3-Codex)

| Severity | Finding | Action |
|----------|---------|--------|
| HIGH | `scope` nested inside `statuses[]` — Jira API expects it at top level | ✅ Fixed: moved `scope` to top-level payload, updated test assertions |
| MEDIUM | Global name match skips project-scoped creation — board may not have the status | ✅ Fixed: always create project-scoped status regardless of global matches |

## Test Results

| Check | Result |
|-------|--------|
| `ruff check` | ✅ Pass |
| `ruff format --check` | ✅ Pass |
| `mypy src/` | ✅ Pass |
| `pytest` (305 tests) | ✅ 97.44% coverage |
| Diff size | 92 lines |

**E2E tests**: Not yet available (see #131). Validated unit tests cover the provisioner logic.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>