### PR TITLE
feat(helm): add optional Jira configuration to chart and k3d flow

### DIFF
--- a/.env.k3d.example
+++ b/.env.k3d.example
@@ -9,6 +9,13 @@ GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
 # COPILOT_PROVIDER_TYPE=openai
 # COPILOT_PROVIDER_BASE_URL=https://api.openai.com/v1
 # COPILOT_PROVIDER_API_KEY=sk-xxxxxxxxxxxxxxxxxxxx
+# Jira integration (optional — agent runs review-only without these)
+# JIRA_URL=https://yourorg.atlassian.net
+# JIRA_EMAIL=you@company.com
+# JIRA_API_TOKEN=your-jira-api-token
+# JIRA_PROJECT_MAP='{"PROJ": {"gitlab_project": "group/repo", "target_branch": "main"}}'
+# JIRA_TRIGGER_STATUS=AI Ready
+# JIRA_POLL_INTERVAL=30
 # OpenTelemetry (uncomment to enable telemetry export)
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
 # DEPLOYMENT_ENV=development

--- a/docs/wiki/configuration-reference.md
+++ b/docs/wiki/configuration-reference.md
@@ -429,5 +429,12 @@ Helm `values.yaml` maps to env vars via `configmap.yaml` and `secret.yaml`:
 | `redis.enabled` | `REDIS_URL` (auto-generated) | ❌ |
 | `telemetry.otlpEndpoint` | `OTEL_EXPORTER_OTLP_ENDPOINT` | ❌ |
 | `telemetry.environment` | `DEPLOYMENT_ENV` | ❌ |
+| `jira.url` | `JIRA_URL` | ❌ |
+| `jira.email` | `JIRA_EMAIL` | ✅ |
+| `jira.apiToken` | `JIRA_API_TOKEN` | ✅ |
+| `jira.projectMap` | `JIRA_PROJECT_MAP` | ❌ |
+| `jira.triggerStatus` | `JIRA_TRIGGER_STATUS` | ❌ |
+| `jira.inProgressStatus` | `JIRA_IN_PROGRESS_STATUS` | ❌ |
+| `jira.pollInterval` | `JIRA_POLL_INTERVAL` | ❌ |
 
 See `helm/gitlab-copilot-agent/values.yaml` for full reference.

--- a/docs/wiki/deployment-guide.md
+++ b/docs/wiki/deployment-guide.md
@@ -142,6 +142,18 @@ telemetry:
       requests: { cpu: 50m, memory: 128Mi }
 ```
 
+**Jira** (all optional — agent runs review-only without these):
+```yaml
+jira:
+  url: ""                  # JIRA_URL
+  email: ""                # JIRA_EMAIL (secret)
+  apiToken: ""             # JIRA_API_TOKEN (secret)
+  projectMap: ""           # JIRA_PROJECT_MAP
+  triggerStatus: "AI Ready"    # JIRA_TRIGGER_STATUS
+  inProgressStatus: "In Progress"  # JIRA_IN_PROGRESS_STATUS
+  pollInterval: 30         # JIRA_POLL_INTERVAL
+```
+
 ---
 
 ### Deployment

--- a/helm/gitlab-copilot-agent/templates/configmap.yaml
+++ b/helm/gitlab-copilot-agent/templates/configmap.yaml
@@ -29,3 +29,20 @@ data:
   {{- with .Values.telemetry.environment }}
   DEPLOYMENT_ENV: {{ . | quote }}
   {{- end }}
+  {{- with .Values.jira.url }}
+  JIRA_URL: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.jira.projectMap }}
+  JIRA_PROJECT_MAP: {{ . | quote }}
+  {{- end }}
+  {{- if .Values.jira.url }}
+  {{- with .Values.jira.triggerStatus }}
+  JIRA_TRIGGER_STATUS: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.jira.inProgressStatus }}
+  JIRA_IN_PROGRESS_STATUS: {{ . | quote }}
+  {{- end }}
+  {{- if .Values.jira.pollInterval }}
+  JIRA_POLL_INTERVAL: {{ .Values.jira.pollInterval | quote }}
+  {{- end }}
+  {{- end }}

--- a/helm/gitlab-copilot-agent/templates/secret.yaml
+++ b/helm/gitlab-copilot-agent/templates/secret.yaml
@@ -13,3 +13,9 @@ stringData:
   {{- with .Values.controller.copilotProviderApiKey }}
   COPILOT_PROVIDER_API_KEY: {{ . | quote }}
   {{- end }}
+  {{- with .Values.jira.email }}
+  JIRA_EMAIL: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.jira.apiToken }}
+  JIRA_API_TOKEN: {{ . | quote }}
+  {{- end }}

--- a/helm/gitlab-copilot-agent/values.yaml
+++ b/helm/gitlab-copilot-agent/values.yaml
@@ -35,3 +35,11 @@ service: { type: ClusterIP }
 serviceAccount: { create: true, name: "" }
 gitlab: { url: "", token: "", webhookSecret: "" }
 github: { token: "" }
+jira:
+  url: ""
+  email: ""
+  apiToken: ""
+  projectMap: ""
+  triggerStatus: "AI Ready"
+  inProgressStatus: "In Progress"
+  pollInterval: 30

--- a/scripts/gen-k3d-values.sh
+++ b/scripts/gen-k3d-values.sh
@@ -4,10 +4,18 @@
 set -euo pipefail
 ENV_FILE="${1:-.env.k3d}"
 # shellcheck source=/dev/null
-. "./${ENV_FILE}"
+. "${ENV_FILE}"
 cat <<EOF
 image: {repository: gitlab-copilot-agent, tag: local}
 gitlab: {url: "${GITLAB_URL}", token: "${GITLAB_TOKEN}", webhookSecret: "${GITLAB_WEBHOOK_SECRET}"}
 github: {token: "${GITHUB_TOKEN:-}"}
 controller: {copilotProviderType: "${COPILOT_PROVIDER_TYPE:-}", copilotProviderBaseUrl: "${COPILOT_PROVIDER_BASE_URL:-}", copilotProviderApiKey: "${COPILOT_PROVIDER_API_KEY:-}"}
+jira:
+  url: "${JIRA_URL:-}"
+  email: "${JIRA_EMAIL:-}"
+  apiToken: "${JIRA_API_TOKEN:-}"
+  projectMap: '${JIRA_PROJECT_MAP:-}'
+  triggerStatus: "${JIRA_TRIGGER_STATUS:-AI Ready}"
+  inProgressStatus: "${JIRA_IN_PROGRESS_STATUS:-In Progress}"
+  pollInterval: ${JIRA_POLL_INTERVAL:-30}
 EOF


### PR DESCRIPTION
## What

Add Jira configuration to the Helm chart and k3d deployment flow so the agent starts with Jira integration enabled when credentials are provided.

Closes #129

## Changes

| File | What changed |
|------|-------------|
| `helm/gitlab-copilot-agent/values.yaml` | Added `jira:` section with 7 config fields |
| `helm/gitlab-copilot-agent/templates/configmap.yaml` | Wire JIRA_URL, PROJECT_MAP, TRIGGER_STATUS, IN_PROGRESS_STATUS, POLL_INTERVAL (conditional on jira.url) |
| `helm/gitlab-copilot-agent/templates/secret.yaml` | Wire JIRA_EMAIL, JIRA_API_TOKEN (conditional) |
| `scripts/gen-k3d-values.sh` | Add Jira vars with safe quoting for projectMap JSON; fix `./` path prefix |
| `.env.k3d.example` | Add shell-safe Jira examples (single-quoted JSON) |
| `docs/wiki/deployment-guide.md` | Add Jira Helm values section |
| `docs/wiki/configuration-reference.md` | Add Jira Helm-to-env-var mapping table rows |

## Code Review (GPT-5.3-Codex)

| Severity | Finding | Action |
|----------|---------|--------|
| HIGH | `.env.k3d.example` JIRA_PROJECT_MAP unquoted — breaks shell sourcing | ✅ Fixed: single-quoted |
| MEDIUM | gen-k3d-values.sh allows YAML injection via crafted env values | Noted: operator-controlled values, not user input. Follow-up if needed. |

## Test Results

| Check | Result |
|-------|--------|
| `helm lint` | ✅ Pass |
| `helm template` (with Jira) | ✅ JIRA vars in configmap + secret |
| `helm template` (without Jira) | ✅ No JIRA vars — backward compatible |
| `pytest` (302 tests) | ✅ 97.42% coverage |
| `ruff check` + `ruff format` | ✅ Pass |
| `mypy --strict` | ✅ Pass |
| Diff size | 66 lines |

**E2E tests**: Not yet available (see #131).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>