### PR TITLE
feat(agent): auto-transition Jira issues to "In Review" after MR creation

### DIFF
--- a/docs/wiki/configuration-reference.md
+++ b/docs/wiki/configuration-reference.md
@@ -238,6 +238,12 @@ All optional — service runs review-only without these.
 - **Default**: `"In Progress"`
 - **Description**: Status to transition to after agent picks up issue
 
+### `JIRA_IN_REVIEW_STATUS`
+- **Type**: `str`
+- **Required**: ❌ No
+- **Default**: `"In Review"`
+- **Description**: Status to transition to after MR creation
+
 ### `JIRA_POLL_INTERVAL`
 - **Type**: `int`
 - **Required**: ❌ No
@@ -369,6 +375,7 @@ JIRA_EMAIL=bot@example.com
 JIRA_API_TOKEN=xxxxx
 JIRA_TRIGGER_STATUS="AI Ready"
 JIRA_IN_PROGRESS_STATUS="In Progress"
+JIRA_IN_REVIEW_STATUS="In Review"
 JIRA_POLL_INTERVAL=30
 JIRA_PROJECT_MAP='{"mappings":{"PROJ":{"gitlab_project_id":42,"clone_url":"https://gitlab.example.com/group/project.git","target_branch":"main"}}}'
 
@@ -436,6 +443,7 @@ Helm `values.yaml` maps to env vars via `configmap.yaml` and `secret.yaml`:
 | `jira.projectMap` | `JIRA_PROJECT_MAP` | ❌ |
 | `jira.triggerStatus` | `JIRA_TRIGGER_STATUS` | ❌ |
 | `jira.inProgressStatus` | `JIRA_IN_PROGRESS_STATUS` | ❌ |
+| `jira.inReviewStatus` | `JIRA_IN_REVIEW_STATUS` | ❌ |
 | `jira.pollInterval` | `JIRA_POLL_INTERVAL` | ❌ |
 
 See `helm/gitlab-copilot-agent/values.yaml` for full reference.

--- a/docs/wiki/deployment-guide.md
+++ b/docs/wiki/deployment-guide.md
@@ -151,6 +151,7 @@ jira:
   projectMap: ""           # JIRA_PROJECT_MAP
   triggerStatus: "AI Ready"    # JIRA_TRIGGER_STATUS
   inProgressStatus: "In Progress"  # JIRA_IN_PROGRESS_STATUS
+  inReviewStatus: "In Review"      # JIRA_IN_REVIEW_STATUS
   pollInterval: 30         # JIRA_POLL_INTERVAL
 ```
 

--- a/helm/gitlab-copilot-agent/templates/configmap.yaml
+++ b/helm/gitlab-copilot-agent/templates/configmap.yaml
@@ -42,6 +42,9 @@ data:
   {{- with .Values.jira.inProgressStatus }}
   JIRA_IN_PROGRESS_STATUS: {{ . | quote }}
   {{- end }}
+  {{- with .Values.jira.inReviewStatus }}
+  JIRA_IN_REVIEW_STATUS: {{ . | quote }}
+  {{- end }}
   {{- if .Values.jira.pollInterval }}
   JIRA_POLL_INTERVAL: {{ .Values.jira.pollInterval | quote }}
   {{- end }}

--- a/helm/gitlab-copilot-agent/values.yaml
+++ b/helm/gitlab-copilot-agent/values.yaml
@@ -42,4 +42,5 @@ jira:
   projectMap: ""
   triggerStatus: "AI Ready"
   inProgressStatus: "In Progress"
+  inReviewStatus: "In Review"
   pollInterval: 30

--- a/scripts/gen-k3d-values.sh
+++ b/scripts/gen-k3d-values.sh
@@ -17,5 +17,6 @@ jira:
   projectMap: '${JIRA_PROJECT_MAP:-}'
   triggerStatus: "${JIRA_TRIGGER_STATUS:-AI Ready}"
   inProgressStatus: "${JIRA_IN_PROGRESS_STATUS:-In Progress}"
+  inReviewStatus: "${JIRA_IN_REVIEW_STATUS:-In Review}"
   pollInterval: ${JIRA_POLL_INTERVAL:-30}
 EOF

--- a/src/gitlab_copilot_agent/config.py
+++ b/src/gitlab_copilot_agent/config.py
@@ -20,6 +20,9 @@ class JiraSettings(BaseModel):
     in_progress_status: str = Field(
         default="In Progress", description="Status to transition to after pickup"
     )
+    in_review_status: str = Field(
+        default="In Review", description="Status to transition to after MR creation"
+    )
     poll_interval: int = Field(default=30, description="Polling interval in seconds")
     project_map_json: str = Field(
         description="JSON string mapping Jira project keys to GitLab projects"
@@ -103,6 +106,7 @@ class Settings(BaseSettings):
     jira_api_token: str | None = Field(default=None, description="Jira API token")
     jira_trigger_status: str = Field(default="AI Ready", description="Status that triggers agent")
     jira_in_progress_status: str = Field(default="In Progress", description="Status after pickup")
+    jira_in_review_status: str = Field(default="In Review", description="Status after MR creation")
     jira_poll_interval: int = Field(default=30, description="Poll interval seconds")
     jira_project_map: str | None = Field(
         default=None, description="JSON: Jira project key → GitLab project config"
@@ -118,6 +122,7 @@ class Settings(BaseSettings):
                 api_token=self.jira_api_token,
                 trigger_status=self.jira_trigger_status,
                 in_progress_status=self.jira_in_progress_status,
+                in_review_status=self.jira_in_review_status,
                 poll_interval=self.jira_poll_interval,
                 project_map_json=self.jira_project_map,
             )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -82,10 +82,12 @@ def test_jira_property_uses_custom_values() -> None:
         jira_project_map=JIRA_PROJECT_MAP_JSON,
         jira_trigger_status="Ready for AI",
         jira_in_progress_status="AI Working",
+        jira_in_review_status="QA Review",
         jira_poll_interval=60,
     )
 
     assert settings.jira is not None
     assert settings.jira.trigger_status == "Ready for AI"
     assert settings.jira.in_progress_status == "AI Working"
+    assert settings.jira.in_review_status == "QA Review"
     assert settings.jira.poll_interval == 60


### PR DESCRIPTION
## What

After the coding orchestrator creates an MR from a Jira issue, it now transitions the issue to "In Review" status. This completes the workflow: To Do → AI Ready → In Progress → **In Review** → Done.

Closes #135

## Changes

| File | What changed |
|------|-------------|
| `src/config.py` | Add `jira_in_review_status` field (default: "In Review") + wire into JiraSettings |
| `src/coding_orchestrator.py` | Add `_transition_to_in_review()` — called after MR creation, non-blocking on failure |
| `helm/values.yaml` + `configmap.yaml` | Add `jira.inReviewStatus` → `JIRA_IN_REVIEW_STATUS` |
| `scripts/gen-k3d-values.sh` | Add `JIRA_IN_REVIEW_STATUS` |
| `docs/wiki/configuration-reference.md` | Add config var docs + Helm mapping |
| `docs/wiki/deployment-guide.md` | Add to Jira Helm values example |
| `tests/test_coding_orchestrator.py` | 3 new tests: full pipeline (2 transitions), failure non-blocking, custom status |
| `tests/test_config.py` | Verify custom in_review_status flows through |

## Code Review (GPT-5.3-Codex)

No significant issues found. ✅

## Test Results

| Check | Result |
|-------|--------|
| `ruff check` | ✅ Pass |
| `ruff format --check` | ✅ Pass |
| `mypy --strict` | ✅ Pass |
| `helm lint` | ✅ Pass |
| `pytest` (308 tests) | ✅ 97.48% coverage |
| Diff size | 93 lines |

**E2E tests**: Not yet available (see #131).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>