### PR TITLE
fix(k8s): writable /tmp, correct env vars, bump memory limit

### DIFF
--- a/helm/gitlab-copilot-agent/values-local.yaml
+++ b/helm/gitlab-copilot-agent/values-local.yaml
@@ -4,7 +4,8 @@ service:
   type: LoadBalancer
 controller:
   resources:
-    limits: { cpu: 250m, memory: 256Mi }
+    limits: { cpu: 500m, memory: 1Gi }
+    requests: { cpu: 100m, memory: 512Mi }
 redis:
   storage: 256Mi
 jobRunner: { cpuLimit: "500m", memoryLimit: 512Mi }


### PR DESCRIPTION
## What
Fix three KubernetesTaskExecutor bugs preventing Job pods from running review/coding tasks.

## Why
Job pods created by `k8s_executor.py` failed due to: read-only filesystem blocking git clone (#141), missing copilot provider env vars (#143), and OOM at 256Mi (#145).

## Changes

### #141 — Read-only filesystem
- Add `emptyDir` volume mounted at `/tmp` so Job pods can write (git clone, Copilot CLI temp files)
- `readOnlyRootFilesystem` remains `true` — only `/tmp` is writable

### #143 — Missing copilot provider env vars
- Forward `COPILOT_PROVIDER_TYPE`, `COPILOT_PROVIDER_BASE_URL`, `COPILOT_PROVIDER_API_KEY`, `COPILOT_MODEL` to Job pods
- Forward `ALLOW_HTTP_CLONE` when set (needed for E2E with dumb HTTP)
- Remove stale `COPILOT_LLM_URL` (non-standard name that didn't match Settings)

### #145 — Controller OOMs at 256Mi
- Bump `values-local.yaml` controller limits to 1Gi/512Mi (Copilot CLI + Node.js exceeds 256Mi)

## Testing

### Unit tests (311 passed)
```
uv run pytest tests/ -m 'not k8s' --no-cov -q
311 passed in 13.86s
```

New tests added:
- `test_byok_env_vars_propagated` — verifies BYOK provider env vars in Job pod spec
- `test_creates_job_with_correct_spec` — extended to verify emptyDir volume/mount
- `test_env_vars_include_task_and_auth` — asserts `COPILOT_LLM_URL` is absent

### Code Review
GPT-5.3-Codex: no issues found.

Closes #141, closes #143, closes #145