### PR TITLE
feat(k8s): diff passback for coding tasks

### DIFF
--- a/src/gitlab_copilot_agent/coding_orchestrator.py
+++ b/src/gitlab_copilot_agent/coding_orchestrator.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import structlog
 
 from gitlab_copilot_agent.coding_engine import run_coding_task
+from gitlab_copilot_agent.coding_workflow import apply_coding_result
 from gitlab_copilot_agent.concurrency import DistributedLock, MemoryLock, ProcessedIssueTracker
 from gitlab_copilot_agent.config import Settings
 from gitlab_copilot_agent.git_operations import git_clone, git_commit, git_create_branch, git_push
@@ -101,6 +102,7 @@ class CodingOrchestrator:
                         description,
                     )
                     await bound_log.ainfo("coding_complete", summary=result.summary[:200])
+                    await apply_coding_result(result, repo_path)
                     has_changes = await git_commit(
                         repo_path,
                         f"feat({issue.key.lower()}): {issue.fields.summary}",

--- a/src/gitlab_copilot_agent/coding_workflow.py
+++ b/src/gitlab_copilot_agent/coding_workflow.py
@@ -1,0 +1,34 @@
+"""Shared coding workflow: execute task → apply patch (if k8s) → commit → push."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import structlog
+
+from gitlab_copilot_agent.git_operations import git_apply_patch, git_head_sha
+from gitlab_copilot_agent.task_executor import CodingResult, TaskResult
+
+log = structlog.get_logger()
+
+
+async def apply_coding_result(result: TaskResult, repo_path: Path) -> None:
+    """Apply a CodingResult patch to the local clone if present.
+
+    For LocalTaskExecutor results the patch is empty — files are already on disk.
+    For KubernetesTaskExecutor results the patch is applied via ``git apply --3way``.
+
+    Raises:
+        RuntimeError: If base_sha doesn't match the local HEAD (clone diverged).
+        ValueError: If patch contains path traversal (checked inside git_apply_patch).
+    """
+    if not isinstance(result, CodingResult) or not result.patch:
+        return
+
+    local_head = await git_head_sha(repo_path)
+    if result.base_sha and result.base_sha != local_head:
+        raise RuntimeError(
+            f"Clone diverged: pod base_sha={result.base_sha[:12]} vs local HEAD={local_head[:12]}"
+        )
+    await git_apply_patch(repo_path, result.patch)
+    await log.ainfo("coding_patch_applied", repo=str(repo_path))

--- a/src/gitlab_copilot_agent/mr_comment_handler.py
+++ b/src/gitlab_copilot_agent/mr_comment_handler.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import structlog
 
 from gitlab_copilot_agent.coding_engine import CODING_SYSTEM_PROMPT
+from gitlab_copilot_agent.coding_workflow import apply_coding_result
 from gitlab_copilot_agent.concurrency import DistributedLock
 from gitlab_copilot_agent.config import Settings
 from gitlab_copilot_agent.git_operations import git_clone, git_commit, git_push
@@ -93,6 +94,7 @@ async def handle_copilot_comment(
                 result = await executor.execute(task)
                 await bound_log.ainfo("copilot_coding_complete", summary=result.summary[:200])
 
+                await apply_coding_result(result, repo_path)
                 has_changes = await git_commit(
                     repo_path, f"fix: {instruction[:50]}", AGENT_AUTHOR_NAME, AGENT_AUTHOR_EMAIL
                 )

--- a/tests/test_coding_workflow.py
+++ b/tests/test_coding_workflow.py
@@ -1,0 +1,48 @@
+"""Tests for coding_workflow.apply_coding_result."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gitlab_copilot_agent.coding_workflow import apply_coding_result
+from gitlab_copilot_agent.task_executor import CodingResult, ReviewResult
+
+_M = "gitlab_copilot_agent.coding_workflow"
+
+
+class TestApplyCodingResult:
+    async def test_noop_for_review_result(self) -> None:
+        result = ReviewResult(summary="looks good")
+        # Should return without doing anything
+        await apply_coding_result(result, Path("/tmp/fake"))
+
+    async def test_noop_for_empty_patch(self) -> None:
+        result = CodingResult(summary="no changes", patch="", base_sha="abc123")
+        await apply_coding_result(result, Path("/tmp/fake"))
+
+    async def test_applies_patch_when_sha_matches(self) -> None:
+        result = CodingResult(summary="fixed it", patch="diff content", base_sha="abc123" * 7)
+        with (
+            patch(f"{_M}.git_head_sha", AsyncMock(return_value="abc123" * 7)),
+            patch(f"{_M}.git_apply_patch", AsyncMock()) as mock_apply,
+        ):
+            await apply_coding_result(result, Path("/tmp/repo"))
+            mock_apply.assert_awaited_once_with(Path("/tmp/repo"), "diff content")
+
+    async def test_raises_on_sha_mismatch(self) -> None:
+        result = CodingResult(summary="fixed", patch="diff", base_sha="aaa" * 14)
+        with (
+            patch(f"{_M}.git_head_sha", AsyncMock(return_value="bbb" * 14)),
+            pytest.raises(RuntimeError, match="Clone diverged"),
+        ):
+            await apply_coding_result(result, Path("/tmp/repo"))
+
+    async def test_skips_sha_check_when_empty(self) -> None:
+        result = CodingResult(summary="fixed", patch="diff content", base_sha="")
+        with (
+            patch(f"{_M}.git_head_sha", AsyncMock(return_value="abc123" * 7)),
+            patch(f"{_M}.git_apply_patch", AsyncMock()) as mock_apply,
+        ):
+            await apply_coding_result(result, Path("/tmp/repo"))
+            mock_apply.assert_awaited_once()

--- a/tests/test_git_apply.py
+++ b/tests/test_git_apply.py
@@ -1,0 +1,154 @@
+"""Tests for git_apply_patch, git_head_sha, git_diff_staged, and _validate_patch."""
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from gitlab_copilot_agent.git_operations import (
+    _validate_patch,
+    git_apply_patch,
+    git_diff_staged,
+    git_head_sha,
+)
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    """Create a minimal git repo with one commit."""
+
+    async def _init() -> Path:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+
+        async def _run(*args: str) -> None:
+            proc = await asyncio.create_subprocess_exec(
+                "git",
+                "-C",
+                str(repo),
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await proc.communicate()
+
+        await _run("init")
+        await _run("config", "user.email", "test@test.com")
+        await _run("config", "user.name", "Test")
+        (repo / "file.txt").write_text("hello\n")
+        await _run("add", ".")
+        await _run("commit", "-m", "init")
+        return repo
+
+    return asyncio.get_event_loop().run_until_complete(_init())
+
+
+class TestGitHeadSha:
+    async def test_returns_sha(self, git_repo: Path) -> None:
+        sha = await git_head_sha(git_repo)
+        assert len(sha) == 40
+        assert sha.isalnum()
+
+
+class TestGitDiffStaged:
+    async def test_empty_when_no_changes(self, git_repo: Path) -> None:
+        diff = await git_diff_staged(git_repo)
+        assert diff == ""
+
+    async def test_returns_diff_after_add(self, git_repo: Path) -> None:
+        (git_repo / "new.txt").write_text("new content\n")
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "-C",
+            str(git_repo),
+            "add",
+            ".",
+            stdout=asyncio.subprocess.PIPE,
+        )
+        await proc.communicate()
+        diff = await git_diff_staged(git_repo)
+        assert "new.txt" in diff
+        assert "+new content" in diff
+
+
+class TestValidatePatch:
+    def test_clean_patch_ok(self) -> None:
+        patch = "diff --git a/file.txt b/file.txt\n--- a/file.txt\n+++ b/file.txt\n"
+        _validate_patch(patch)  # should not raise
+
+    def test_traversal_in_diff_header(self) -> None:
+        patch = "diff --git a/../etc/passwd b/../etc/passwd\n"
+        with pytest.raises(ValueError, match="path traversal"):
+            _validate_patch(patch)
+
+    def test_traversal_in_minus_line(self) -> None:
+        patch = "--- a/../secret\n"
+        with pytest.raises(ValueError, match="path traversal"):
+            _validate_patch(patch)
+
+    def test_traversal_in_plus_line(self) -> None:
+        patch = "+++ b/../secret\n"
+        with pytest.raises(ValueError, match="path traversal"):
+            _validate_patch(patch)
+
+    def test_dotdot_in_content_lines_ok(self) -> None:
+        patch = "+path = ../../something\n-old/../path\n"
+        _validate_patch(patch)  # content lines aren't checked
+
+    def test_hunk_content_with_triple_plus_ok(self) -> None:
+        # Content lines starting with +++ shouldn't trigger false positive
+        patch = "+++../../new\n---../../old\n"
+        _validate_patch(patch)  # no a/ or b/ prefix = not a file header
+
+
+class TestGitApplyPatch:
+    async def test_applies_valid_patch(self, git_repo: Path) -> None:
+        # Generate a patch from changes
+        (git_repo / "file.txt").write_text("modified\n")
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "-C",
+            str(git_repo),
+            "add",
+            ".",
+            stdout=asyncio.subprocess.PIPE,
+        )
+        await proc.communicate()
+        diff = await git_diff_staged(git_repo)
+
+        # Reset index and working tree to clean state
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "-C",
+            str(git_repo),
+            "reset",
+            "HEAD",
+            "--",
+            ".",
+            stdout=asyncio.subprocess.PIPE,
+        )
+        await proc.communicate()
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "-C",
+            str(git_repo),
+            "checkout",
+            "--",
+            ".",
+            stdout=asyncio.subprocess.PIPE,
+        )
+        await proc.communicate()
+        assert (git_repo / "file.txt").read_text() == "hello\n"
+
+        # Apply the patch
+        await git_apply_patch(git_repo, diff)
+        assert (git_repo / "file.txt").read_text() == "modified\n"
+
+    async def test_rejects_traversal_patch(self, git_repo: Path) -> None:
+        bad_patch = "diff --git a/../etc/passwd b/../etc/passwd\n"
+        with pytest.raises(ValueError, match="path traversal"):
+            await git_apply_patch(git_repo, bad_patch)
+
+    async def test_raises_on_bad_patch(self, git_repo: Path) -> None:
+        with pytest.raises(RuntimeError, match="git apply failed"):
+            await git_apply_patch(git_repo, "not a valid patch\n")


### PR DESCRIPTION
## What
K8s Job pods capture file changes as a unified diff and return them via ResultStore. The controller validates and applies the patch locally before committing.

## Why
Closes #144 — coding tasks with `KubernetesTaskExecutor` lost all file changes because the Job pod terminated before the controller could commit. This implements the "diff passback" pattern: pod captures → controller applies → controller commits.

## Changes

### Pod side (`task_runner.py`)
- After Copilot runs for coding tasks: `git add -A` → `git rev-parse HEAD` → `git diff --cached --binary`
- Serialized as `CodingResult{summary, patch, base_sha}` JSON
- `MAX_PATCH_SIZE` (10 MB) enforced before storing

### Controller side (`git_operations.py`, `coding_workflow.py`)
- `git_apply_patch()`: applies unified diff via stdin with `--3way --whitespace=nowarn`
- `_validate_patch()`: rejects patches with `../` in file headers (path traversal)
- `apply_coding_result()`: validates base_sha match, then applies patch
- No-op for `LocalTaskExecutor` results (empty patch — files already on disk)

### Caller updates
- `coding_orchestrator.py`: calls `apply_coding_result()` before `git_commit()`
- `mr_comment_handler.py`: calls `apply_coding_result()` before `git_commit()`

## Security
| Check | Implementation |
|-------|---------------|
| Path traversal | `_FILE_HEADER_RE` + `_PATH_TRAVERSAL_RE` on file header lines only |
| Clone divergence | `base_sha` compared to local HEAD before apply |
| Patch size | 10 MB limit in task_runner |
| No temp files | Patch piped via stdin to `git apply` |

## Testing

### Unit tests (328 passed)
```
uv run pytest tests/ -m 'not k8s' --no-cov -q
328 passed in 13.69s
```

### New tests
- `test_git_apply.py`: git_head_sha, git_diff_staged, _validate_patch (6 cases), git_apply_patch (3 cases including real git repo)
- `test_coding_workflow.py`: apply_coding_result (5 cases: review noop, empty patch, sha match, sha mismatch, empty sha)
- `test_task_runner.py`: updated for structured result format

### Lint + type check
```
ruff check: All checks passed!
ruff format: 69 files already formatted
mypy: Success: no issues found in 30 source files
```

### Code review
GPT-5.3-Codex found 1 medium issue: patch validator false-positives on hunk content lines starting with `+++`/`---`. Fixed by restricting to actual file headers (`--- a/`, `+++ b/`, `diff --git`).

## Note on diff size
354 total lines (source: 150, tests: 204). This is an atomic feature — diff capture, apply, validation, and caller wiring must ship together. Cannot be split without leaving broken code paths.

Part 2 of 2 for #144. Depends on PR #147 (merged).

## E2E Results (kubernetes executor)

Job pod lifecycle works end-to-end: starts → clones repo → runs task_runner. The Copilot session times out because Job pods lack hostAliases to resolve `host.k3d.internal` (the mock LLM). This is tracked in #148 — once fixed, the diff capture code path will be exercised.

| Stage | Status |
|-------|--------|
| Job pod starts | ✅ |
| Task runner loads | ✅ |
| Git clone in pod | ✅ |
| Copilot session | ❌ Timeout (#148) |
| Diff capture | ⏳ Blocked on above |
| Patch apply | ⏳ Blocked on above |