### PR TITLE
fix(k8s): Job pod hostAliases, HOME, branch, and telemetry fixes

### DIFF
--- a/helm/gitlab-copilot-agent/templates/configmap.yaml
+++ b/helm/gitlab-copilot-agent/templates/configmap.yaml
@@ -17,6 +17,9 @@ data:
   K8S_JOB_CPU_LIMIT: {{ .Values.jobRunner.cpuLimit | quote }}
   K8S_JOB_MEMORY_LIMIT: {{ .Values.jobRunner.memoryLimit | quote }}
   K8S_JOB_TIMEOUT: {{ .Values.jobRunner.timeout | quote }}
+  {{- with .Values.hostAliases }}
+  K8S_JOB_HOST_ALIASES: {{ . | toJson | quote }}
+  {{- end }}
   {{- with .Values.controller.copilotProviderType }}
   COPILOT_PROVIDER_TYPE: {{ . | quote }}
   {{- end }}

--- a/src/gitlab_copilot_agent/coding_orchestrator.py
+++ b/src/gitlab_copilot_agent/coding_orchestrator.py
@@ -96,7 +96,7 @@ class CodingOrchestrator:
                         self._settings,
                         str(repo_path),
                         project_mapping.clone_url,
-                        f"agent/{issue.key.lower()}",
+                        project_mapping.target_branch,
                         issue.key,
                         issue.fields.summary,
                         description,

--- a/src/gitlab_copilot_agent/git_operations.py
+++ b/src/gitlab_copilot_agent/git_operations.py
@@ -123,7 +123,7 @@ async def git_commit(
         "-m",
         message,
     )
-    await log.ainfo("committed", message=message, repo=str(repo_path))
+    await log.ainfo("committed", commit_message=message, repo=str(repo_path))
     return True
 
 

--- a/src/gitlab_copilot_agent/telemetry.py
+++ b/src/gitlab_copilot_agent/telemetry.py
@@ -122,8 +122,36 @@ def emit_to_otel_logs(logger: Any, method: str, event_dict: dict[str, Any]) -> d
     level_name = event_dict.get("level", "info").upper()
     level = getattr(logging, level_name, logging.INFO)
     msg = event_dict.get("event", "")
-    # Filter out keys that conflict with stdlib LogRecord reserved attributes
-    _reserved = {"event", "level", "timestamp", "exc_info", "stack_info", "stackLevel"}
+    # Filter out keys that conflict with stdlib LogRecord reserved attributes.
+    # "message" is set by LogRecord.getMessage(); the rest are constructor args.
+    _reserved = {
+        "event",
+        "level",
+        "timestamp",
+        "exc_info",
+        "stack_info",
+        "stackLevel",
+        "name",
+        "msg",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_text",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "processName",
+        "process",
+        "taskName",
+        "message",
+    }
     extra = {k: v for k, v in event_dict.items() if k not in _reserved}
     logging.getLogger(_SERVICE_NAME).log(level, msg, extra=extra)
     return event_dict


### PR DESCRIPTION
## What

Fixes #148 — Job pods couldn't reach services requiring custom DNS (hostAliases), Copilot CLI crashed on read-only rootfs (HOME), coding tasks cloned wrong branch, and structlog keys conflicted with LogRecord reserved attributes.

## Changes

| File | Change |
|------|--------|
| `config.py` | Add `k8s_job_host_aliases` setting with JSON validation at startup |
| `k8s_executor.py` | `_parse_host_aliases()` + wire into PodSpec, `HOME=/tmp` env var |
| `coding_orchestrator.py` | Pass `target_branch` to executor (pod clones base, not agent branch) |
| `telemetry.py` | Expand LogRecord reserved key set to prevent `message` key conflict crash |
| `git_operations.py` | Rename `message=` to `commit_message=` in structlog call |
| `configmap.yaml` | Wire `K8S_JOB_HOST_ALIASES` from Helm `hostAliases` values |
| `test_k8s_executor.py` | Tests for hostAliases parsing, default (None), and Job spec wiring |
| `e2e/run.sh` | Stricter review assertions (require `position`-based reviews, reject failures) |

## E2E Results (kubernetes executor, k3d cluster)

```
--- Test 1: Webhook MR Review --- ✅
--- Test 2: Jira Polling Flow --- ✅ (push=1, MR=1)
--- Test 3: /copilot Command --- ✅
--- Test 4: GitLab Polling — MR Discovery --- ✅
=== ALL E2E TESTS PASSED ===
```

## Review Findings Addressed

- **Medium**: Added JSON schema validation for `k8s_job_host_aliases` at config load (Pydantic field_validator)
- **Medium**: E2E assertions now require `position`-based discussions and explicitly reject failure comments

Closes #148
Closes #142