### PR TITLE
docs: update wiki, security model, and ADR for diff passback and hostAliases

### DIFF
--- a/docs/wiki/configuration-reference.md
+++ b/docs/wiki/configuration-reference.md
@@ -152,6 +152,15 @@ Only used when `TASK_EXECUTOR=kubernetes`.
 - **Default**: `600`
 - **Description**: Job timeout in seconds (10 minutes)
 
+### `K8S_JOB_HOST_ALIASES`
+- **Type**: `str`
+- **Required**: ❌ No
+- **Default**: `""` (empty — no host aliases)
+- **Description**: JSON-encoded array of hostAliases for Job pods. Each entry must have `ip` and `hostnames` keys. Useful for environments with custom DNS (air-gapped, k3d dev).
+- **Format**: `[{"ip": "10.0.0.1", "hostnames": ["host.local", "api.local"]}]`
+- **Validation**: JSON structure validated at startup (must be array of objects with `ip` and `hostnames`)
+- **Helm Value**: Auto-generated from `hostAliases` value (serialized to JSON)
+
 ---
 
 ## State Backend
@@ -446,7 +455,8 @@ Helm `values.yaml` maps to env vars via `configmap.yaml` and `secret.yaml`:
 | `jira.inReviewStatus` | `JIRA_IN_REVIEW_STATUS` | ❌ |
 | `jira.pollInterval` | `JIRA_POLL_INTERVAL` | ❌ |
 | `extraEnv` | (arbitrary key-value pairs) | ❌ |
-| `hostAliases` | Pod `/etc/hosts` entries | ❌ |
+| `hostAliases` | `K8S_JOB_HOST_ALIASES` (JSON for Job pods) | ❌ |
+| `hostAliases` | Pod `/etc/hosts` entries (controller pod) | ❌ |
 
 See `helm/gitlab-copilot-agent/values.yaml` for full reference.
 

--- a/docs/wiki/request-flows.md
+++ b/docs/wiki/request-flows.md
@@ -55,7 +55,7 @@ sequenceDiagram
         EXEC->>EXEC: _wait_for_result (poll Redis)
         EXEC-->>EXEC: result from Redis
     end
-    EXEC-->>ORCH: raw_review: str
+    EXEC-->>ORCH: raw_review: TaskResult
     
     ORCH->>PARSE: parse_review(raw_review)
     PARSE-->>ORCH: ParsedReview (comments, summary)
@@ -125,8 +125,11 @@ sequenceDiagram
     
     MRC->>EXEC: execute(TaskParams: coding, prompt=instruction)
     EXEC->>COP: run_copilot_session(repo_path, CODING_SYSTEM_PROMPT, instruction)
-    COP-->>EXEC: result: str
-    EXEC-->>MRC: result: str
+    COP-->>EXEC: result: TaskResult
+    EXEC-->>MRC: result: TaskResult
+    
+    MRC->>MRC: apply_coding_result(result, repo_path)
+    Note over MRC: If K8s: validate base_sha, git apply --3way<br/>If Local: no-op (files on disk)
     
     MRC->>GIT: git_commit(repo_path, message, author)
     alt has_changes
@@ -291,8 +294,11 @@ sequenceDiagram
             
             CODING->>EXEC: execute(TaskParams: coding, Jira prompt)
             EXEC->>COP: run_copilot_session(repo_path, CODING_SYSTEM_PROMPT, jira_prompt)
-            COP-->>EXEC: result: str
-            EXEC-->>CODING: result: str
+            COP-->>EXEC: result: TaskResult
+            EXEC-->>CODING: result: TaskResult
+            
+            CODING->>CODING: apply_coding_result(result, repo_path)
+            Note over CODING: If K8s: validate base_sha, git apply --3way<br/>If Local: no-op (files on disk)
             
             CODING->>GIT: git_commit(repo_path, message, author)
             alt has_changes

--- a/docs/wiki/security-model.md
+++ b/docs/wiki/security-model.md
@@ -233,6 +233,33 @@ graph TB
 
 ---
 
+### Coding Patches (K8s Executor)
+
+**Source**: K8s Job pod captures `git diff --cached --binary` after Copilot modifies files, stores as `CodingResult.patch` in Redis.
+
+**Validation** (`coding_workflow.py` → `apply_coding_result()`, `git_operations.py` → `_validate_patch()`):
+
+**Checks**:
+1. `base_sha` validation — patch base must match local HEAD (detects clone divergence or replay)
+2. Path traversal scan — rejects patches containing `../` in file headers (`diff --git a/`, `--- a/`, `+++ b/`)
+3. Size limit — `MAX_PATCH_SIZE` (10 MB) prevents Redis OOM and excessive disk write
+4. Applied via `git apply --3way` — git validates patch format and refuses malformed hunks
+
+**Threats**:
+- **Patch injection**: Compromised Job pod writes crafted patch to Redis (e.g., overwrite `.github/workflows/` to gain CI execution)
+- **Path traversal**: Patch references `../../etc/crontab` to escape repo boundary
+- **Replay attack**: Attacker replays old CodingResult from Redis to overwrite newer work
+- **Oversized patch**: DoS via large diff consuming Redis memory and controller disk
+
+**Mitigations**:
+- Path traversal blocked by `_validate_patch()` before `git apply`
+- `git apply` itself rejects paths outside the work tree
+- `base_sha` check prevents replay (old base_sha won't match current HEAD)
+- Size limit prevents resource exhaustion
+- Only the controller has git push access — a malicious patch is visible in the MR diff before merge
+
+---
+
 ## Sandbox Isolation
 
 ### Local Executor
@@ -266,21 +293,29 @@ graph TB
 - Separate pod with own network namespace
 - `securityContext`:
   - `runAsNonRoot: true`
+  - `runAsUser: 1000`
   - `readOnlyRootFilesystem: true`
   - `capabilities.drop: ["ALL"]`
 - Resource limits: CPU, memory
+- `HOME=/tmp` (writable tmpfs for Copilot CLI state)
 - TTL after finished: 300s (pod auto-deleted)
+- Optional `hostAliases` for custom DNS resolution
 
 **Credentials Passed**:
-- `GITLAB_TOKEN`, `GITHUB_TOKEN` (or `COPILOT_PROVIDER_API_KEY`) as env vars
-- Available to pod process (no further isolation)
+- `GITLAB_TOKEN` (clone only — pod has no push access)
+- `GITHUB_TOKEN` (or `COPILOT_PROVIDER_API_KEY`) as env vars
+- `GITLAB_WEBHOOK_SECRET` (required by Settings validation, not used in pod)
+
+**Result Path**: Pod stores `CodingResult` (summary + patch + base_sha) or `ReviewResult` (summary only) in Redis. Controller reads result — only the controller commits, pushes, and posts API calls.
 
 **Threat**: Malicious repo code executed during review → can read pod env, exfiltrate tokens.
 
 **Mitigation**: 
 - ReadOnlyRootFilesystem prevents writing malicious binaries
-- No network egress policy (attacker can still exfiltrate via DNS/HTTP)
+- Pod cannot push code (no git push credentials or capability)
+- Results validated before apply: `base_sha` match, path traversal scan, size limit
 - Agent does not execute arbitrary code (only SDK, git, standard tools)
+- No network egress policy yet (attacker can still exfiltrate via DNS/HTTP — see Recommended Hardening)
 
 **Code**: `k8s_executor.py` → `_create_job()`
 
@@ -373,8 +408,10 @@ graph TB
 | GITHUB_TOKEN | Compromise | Copilot quota abuse | GitHub App tokens, SDK env isolation |
 | JIRA_API_TOKEN | Compromise | Issue manipulation | Scoped permissions, rotation |
 | Redis | Unauthorized access | Lock bypass, result tampering | NetworkPolicy, consider AUTH + TLS |
+| Redis | CodingResult tampering | Inject malicious patch into commit | base_sha validation, path traversal scan, MR review gate |
 | Copilot SDK | Prompt injection | Exfiltrate env vars via output | Env allowlist, output treated as data |
-| K8s Job | Malicious repo code | Token exfiltration | ReadOnlyRootFilesystem, no arbitrary code exec |
+| K8s Job | Malicious repo code | Token exfiltration | ReadOnlyRootFilesystem, no push access, egress NetworkPolicy |
+| K8s Job | Malicious patch injection | Write arbitrary files in MR | Path traversal check, MAX_PATCH_SIZE, git apply validation |
 | Repo config | Symlink escape | Read system files | Boundary check in `_resolve_real_path()` |
 | Clone URL | SSRF / local file access | Read local files, internal services | HTTPS-only, no embedded creds, git CLI validation |
 
@@ -383,15 +420,17 @@ graph TB
 ## Recommended Hardening
 
 1. **NetworkPolicy**: Restrict Redis to service + job pods only
-2. **Redis AUTH**: Enable password authentication
-3. **GitLab IP Allowlist**: Restrict `/webhook` endpoint
-4. **Project Access Tokens**: Use instead of personal tokens for GITLAB_TOKEN
-5. **GitHub App Tokens**: Use instead of PATs for GITHUB_TOKEN
-6. **Audit Logging**: Enable GitLab/Jira API audit logs
-7. **Rotate Secrets**: Quarterly rotation of all tokens/keys
-8. **Egress NetworkPolicy**: Block job pod egress to internal services
-9. **Resource Quotas**: Limit job pod resource consumption
-10. **Read-Only Root FS**: Already enforced for job pods
+2. **Redis AUTH + TLS**: Enable password authentication and encryption in transit
+3. **K8s Secrets for Job pods**: Mount credentials via Secret refs, not env vars in configmap
+4. **GitLab IP Allowlist**: Restrict `/webhook` endpoint
+5. **Project Access Tokens**: Use instead of personal tokens for GITLAB_TOKEN
+6. **GitHub App Tokens**: Use instead of PATs for GITHUB_TOKEN
+7. **Audit Logging**: Enable GitLab/Jira API audit logs
+8. **Rotate Secrets**: Quarterly rotation of all tokens/keys
+9. **Egress NetworkPolicy**: Block job pod egress to internal services (allow GitLab, Copilot API, Redis only)
+10. **Resource Quotas**: Limit job pod resource consumption
+11. **Pin Docker Base Images**: Use digest-based pins to prevent supply chain attacks
+12. **Review Gate for /copilot**: Require human approval before auto-push on coding commands (prevents prompt injection → auto-merge)
 
 ---
 
@@ -411,7 +450,8 @@ graph TB
 4. **Auditability**: All actions logged with trace context
 
 **Residual Risks**:
-1. Redis compromise allows lock bypass and dedup poisoning (mitigate: AUTH + NetworkPolicy)
+1. Redis compromise allows lock bypass, dedup poisoning, and CodingResult tampering (mitigate: AUTH + NetworkPolicy + TLS)
 2. K8s Job can exfiltrate tokens via network (mitigate: egress NetworkPolicy)
-3. Copilot API compromise can generate malicious reviews (mitigate: manual review process)
+3. Copilot API compromise can generate malicious reviews or code patches (mitigate: manual MR review before merge, patch validation)
 4. HMAC secret compromise allows full webhook replay (mitigate: rotation, monitoring)
+5. Prompt injection in `/copilot` command could instruct agent to write malicious code — the patch lands as a MR, not directly on main (mitigate: require human review before merge)


### PR DESCRIPTION
## What

Updates 7 documentation files to reflect changes from PRs #147 (TaskResult refactor), #149 (diff passback), and #150 (hostAliases + runtime fixes). Includes security model updates for the new patch injection attack surface.

## Files Updated

| File | Changes |
|------|---------|
| `task-execution.md` | TaskResult types, diff capture flow, coding_workflow, Job spec updates |
| `architecture-overview.md` | CodingResult data flow in diagram, coding_workflow in Processing Layer |
| `request-flows.md` | apply_coding_result() in /copilot and Jira sequence diagrams |
| `module-reference.md` | New coding_workflow.py entry, updated executor/runner/git_ops modules |
| `configuration-reference.md` | K8S_JOB_HOST_ALIASES env var, Helm mapping |
| `security-model.md` | Coding Patches section (threats + mitigations), K8s executor isolation updates, attack surface table, hardening recommendations, residual risks |
| `ADR 0003` | Addenda for diff passback decision and hostAliases |

## Security Model Updates

New attack surfaces documented:
- **Patch injection** via Redis tampering → mitigated by base_sha validation, path traversal scan, MR review gate
- **K8s Job pod** isolation clarified: read-only clone, no push access, results validated before apply
- **Prompt injection** in /copilot → lands as MR (not direct commit), requires human review

New hardening recommendations:
- Redis AUTH + TLS
- K8s Secrets for Job pods (not configmap env)
- Egress NetworkPolicy scoped to required services
- Pin Docker base images to digests
- Review gate for /copilot auto-push

Relates to #144