### PR TITLE
fix(jira): enforce GITLAB_PROJECTS allowlist in Jira poller

### DIFF
--- a/src/gitlab_copilot_agent/main.py
+++ b/src/gitlab_copilot_agent/main.py
@@ -110,7 +110,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         handler = CodingOrchestrator(
             settings, gl_client, jira_client, app.state.executor, repo_locks, tracker
         )
-        poller = JiraPoller(jira_client, settings.jira, project_map, handler)
+        poller = JiraPoller(jira_client, settings.jira, project_map, handler, allowed_project_ids)
         await poller.start()
         await log.ainfo("jira_poller_started", interval=settings.jira.poll_interval)
 


### PR DESCRIPTION
## What
Enforces the GITLAB_PROJECTS allowlist in the Jira integration flow. When configured, Jira-triggered tasks are skipped if the target GitLab project is not in the allowlist.

## Why
Without this check, the Jira poller processes tasks for ALL mapped projects regardless of GITLAB_PROJECTS. This creates unexpected behavior when operators intend to restrict the agent to specific projects.

## How
- Added `allowed_project_ids` parameter to `JiraPoller.__init__()`
- Added allowlist check in `_poll_once()` — skips with structured log when project not allowed
- Wired `allowed_project_ids` from `Settings.gitlab_project_ids` in `main.py`
- Backward compatible: `None` (unset) allows all projects

## Testing
- 3 new unit tests: project in allowlist (allowed), project not in allowlist (skipped), no allowlist (backward compat)
- 332 tests pass, 93% coverage
- Lint + format + mypy clean

## Diff
83 lines across 3 files.

Closes #117