### PR TITLE
chore: restrict Dependabot to LTS/stable Docker base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # Node 22 is LTS (active until 2027-04). Only allow digest/patch updates.
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
+      # Python 3.12 is stable. Only allow digest/patch updates within 3.12.x.
+      - dependency-name: "python"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## What

Add ignore rules to `.github/dependabot.yml` to prevent Dependabot from proposing incompatible base image bumps. Also adds `pip` ecosystem monitoring.

## Why

PRs #159 (node 22→25) and #160 (python 3.12→3.14) both broke CI:
- **Node 25** is non-LTS and missing `libatomic.so.1` on Debian slim
- **Python 3.14** is pre-release — `pydantic-core` has no prebuilt wheels

Dependabot's Docker ecosystem doesn't understand LTS/stability — it just proposes the highest version number. The ignore rules restrict it to:
- **node**: digest and minor/patch updates only (stay on 22 LTS)
- **python**: digest and patch updates only (stay on 3.12.x)