### PR TITLE
feat(k8s): mount Job pod credentials via K8s Secrets

### DIFF
--- a/helm/gitlab-copilot-agent/templates/configmap.yaml
+++ b/helm/gitlab-copilot-agent/templates/configmap.yaml
@@ -17,6 +17,8 @@ data:
   K8S_JOB_CPU_LIMIT: {{ .Values.jobRunner.cpuLimit | quote }}
   K8S_JOB_MEMORY_LIMIT: {{ .Values.jobRunner.memoryLimit | quote }}
   K8S_JOB_TIMEOUT: {{ .Values.jobRunner.timeout | quote }}
+  K8S_SECRET_NAME: {{ include "app.fullname" . | quote }}
+  K8S_CONFIGMAP_NAME: {{ include "app.fullname" . | quote }}
   {{- with .Values.hostAliases }}
   K8S_JOB_HOST_ALIASES: {{ . | toJson | quote }}
   {{- end }}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -91,3 +91,27 @@ def test_jira_property_uses_custom_values() -> None:
     assert settings.jira.in_progress_status == "AI Working"
     assert settings.jira.in_review_status == "QA Review"
     assert settings.jira.poll_interval == 60
+
+
+def test_k8s_executor_warns_without_secret_name() -> None:
+    """task_executor=kubernetes warns (not errors) when k8s_secret_name is not set."""
+    settings = make_settings(task_executor="kubernetes")
+    assert settings.k8s_secret_name is None
+
+
+def test_k8s_executor_accepts_both_names() -> None:
+    """task_executor=kubernetes succeeds when both names are provided."""
+    settings = make_settings(
+        task_executor="kubernetes",
+        k8s_secret_name="my-secret",
+        k8s_configmap_name="my-configmap",
+    )
+    assert settings.k8s_secret_name == "my-secret"
+    assert settings.k8s_configmap_name == "my-configmap"
+
+
+def test_local_executor_does_not_require_k8s_names() -> None:
+    """task_executor=local does not require k8s_secret_name or k8s_configmap_name."""
+    settings = make_settings(task_executor="local")
+    assert settings.k8s_secret_name is None
+    assert settings.k8s_configmap_name is None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -37,6 +37,8 @@ def test_create_executor_k8s_returns_executor(
         redis_url="redis://localhost:6379/0",
         state_backend="redis",
         task_executor="kubernetes",
+        k8s_secret_name="test-secret",
+        k8s_configmap_name="test-configmap",
     )
     executor = _create_executor("kubernetes", settings)
     assert isinstance(executor, TaskExecutor)


### PR DESCRIPTION
## What
Mount sensitive Job pod credentials (GITLAB_TOKEN, GITHUB_TOKEN, COPILOT_PROVIDER_API_KEY, GITLAB_WEBHOOK_SECRET) via K8s `secretKeyRef` instead of plaintext env vars.

## Why
Closes #153 — addresses A05 Security Misconfiguration finding from OWASP review (#144). Plaintext credentials in pod specs are visible via `kubectl describe pod`.

## How
- Sensitive env vars use `value_from.secret_key_ref` when `k8s_secret_name` is configured
- Non-sensitive vars remain as plaintext (backward compat for non-Helm deployments)
- Only 4 credentials mounted — no JIRA_* or other unnecessary secrets in Job pods
- Model validator warns (not errors) when K8s executor runs without secret/configmap names
- Helm values expose `secretName` and `configMapName` fields

## Testing
- Unit tests: 26 passed (secretKeyRef assertions, plaintext fallback, no-JIRA validation)
- Lint/format/mypy: all pass
- GPT-5.3-Codex code review: Critical finding fixed (GITLAB_WEBHOOK_SECRET missing), High finding fixed (validator changed to warning)

## Code Review Findings (Fixed)
| Severity | Finding | Resolution |
|----------|---------|------------|
| Critical | GITLAB_WEBHOOK_SECRET missing from Job pods — Settings() requires it | Added to secretKeyRef list |
| High | Hard-error validator makes plaintext fallback unreachable | Changed to warning |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>