### PR TITLE
feat(telemetry): graceful OTEL collector degradation

### DIFF
--- a/docs/wiki/configuration-reference.md
+++ b/docs/wiki/configuration-reference.md
@@ -311,7 +311,10 @@ All optional — service runs review-only without these.
 - **Default**: Unset (telemetry disabled)
 - **Description**: OTLP gRPC endpoint for traces, metrics, and logs
 - **Example**: `"http://otel-collector:4317"`
-- **Behavior**: If unset, `init_telemetry()` is a no-op
+- **Behavior**:
+  - If unset, `init_telemetry()` is a no-op — zero overhead
+  - If set but collector is unreachable, the service starts normally and logs `otel_collector_unavailable`. A background task probes the endpoint every 30s and logs `otel_collector_connected` when the collector becomes available.
+  - OTEL SDK retry messages are suppressed (routed through structlog at WARNING level only for persistent failures). No unstructured retry spam in the console.
 
 ### `SERVICE_VERSION`
 - **Type**: `str` (not in Settings model)

--- a/src/gitlab_copilot_agent/main.py
+++ b/src/gitlab_copilot_agent/main.py
@@ -26,6 +26,7 @@ from gitlab_copilot_agent.redis_state import create_dedup, create_lock, create_r
 from gitlab_copilot_agent.task_executor import LocalTaskExecutor, TaskExecutor
 from gitlab_copilot_agent.telemetry import (
     add_trace_context,
+    configure_stdlib_logging,
     emit_to_otel_logs,
     init_telemetry,
     shutdown_telemetry,
@@ -43,6 +44,7 @@ structlog.configure(
         structlog.dev.ConsoleRenderer(),
     ],
 )
+configure_stdlib_logging()
 
 log = structlog.get_logger()
 


### PR DESCRIPTION
## What
Implements graceful OTEL collector degradation (#173). The agent no longer crashes or spams logs when the collector is unavailable.

## Why
Running without an OTEL collector (common in dev/demo) produced noisy unstructured retry messages and startup confusion.

## How
- **stdlib → structlog**: Root logger gets a `ProcessorFormatter` so all Python logging (including SDK internals) renders as structured JSON
- **Exporter noise suppression**: OTEL exporter loggers set to WARNING — hides transient gRPC retry spam
- **Startup probe**: `_check_grpc_connectivity()` tests the endpoint at boot. Logs `otel_collector_connected` or `otel_collector_unavailable`
- **Background probe**: If unreachable at startup, an async task retries every 30s and logs once when connected
- **TLS support**: Connectivity probe uses `grpc.secure_channel()` for `https://` endpoints
- **Docs**: Updated configuration-reference.md with degradation behavior

## Code Review (GPT-5.3-Codex)
| Severity | Finding | Resolution |
|----------|---------|------------|
| Medium | TLS endpoints always reported unreachable (insecure channel only) | Fixed: branch by scheme, use `ssl_channel_credentials()` for https |

Closes #173