### PR TITLE
fix(telemetry): suppress OTEL retry noise and duplicate log lines

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -103,7 +103,7 @@ def test_configure_stdlib_logging_routes_through_structlog() -> None:
 
 
 def test_configure_stdlib_logging_suppresses_otel_exporters() -> None:
-    """OTEL exporter loggers should be set to WARNING to suppress retry noise."""
+    """OTEL exporter loggers should be set to ERROR to suppress retry noise."""
     configure_stdlib_logging()
     for name in (
         "opentelemetry.exporter.otlp.proto.grpc",
@@ -111,7 +111,7 @@ def test_configure_stdlib_logging_suppresses_otel_exporters() -> None:
         "opentelemetry.sdk.metrics.export",
         "opentelemetry.sdk._logs.export",
     ):
-        assert logging.getLogger(name).level == logging.WARNING
+        assert logging.getLogger(name).level == logging.ERROR
 
 
 def test_init_telemetry_starts_probe_when_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What
Fixes two issues discovered during demo testing with no OTEL collector running:

1. **OTEL retry spam**: `Transient error StatusCode.UNAVAILABLE` warnings flooding console. Exporter loggers were set to WARNING but retry messages are also WARNING level. Fixed by setting to ERROR.

2. **Duplicate log lines**: Every structured log appeared twice. `emit_to_otel_logs` re-emitted to stdlib logger that propagated to root (which has structlog formatter). Fixed with `propagate = False`.

## How
- Set OTEL exporter logger levels to ERROR (was WARNING)
- Set `otel_logger.propagate = False`
- Updated test assertion

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>