### PR TITLE
fix(review): include MR diff in prompt to prevent full-repo review

### DIFF
--- a/src/gitlab_copilot_agent/review_engine.py
+++ b/src/gitlab_copilot_agent/review_engine.py
@@ -1,9 +1,16 @@
 """Copilot review engine — runs an agent review session on an MR."""
 
+import structlog
 from pydantic import BaseModel, ConfigDict, Field
 
 from gitlab_copilot_agent.config import Settings
 from gitlab_copilot_agent.task_executor import TaskExecutor, TaskParams, TaskResult
+
+log = structlog.get_logger()
+
+# Max characters of diff to include in the prompt.  Beyond this the diff is
+# truncated and the LLM is told to run git diff for the full picture.
+MAX_DIFF_CHARS = 120_000
 
 SYSTEM_PROMPT = """\
 You are a senior code reviewer. Review the merge request diff thoroughly.
@@ -14,9 +21,6 @@ Focus on:
 - Performance issues
 - Code clarity and maintainability
 
-You have access to the full repository via built-in file tools. Use them to
-read source files and understand context beyond the diff.
-
 IMPORTANT: The "line" field in your output MUST be the line number as shown in
 the NEW version of the file (the right-hand side of the diff). Use the line
 numbers from the `+` side of the `git diff` output. Double-check each line
@@ -24,9 +28,8 @@ number by counting from the hunk header `@@ ... +START,COUNT @@`.
 Use the FULL file path as shown in the diff (e.g. `src/demo_app/search.py`,
 not just `search.py`).
 
-CRITICAL: Only comment on files and lines that are PART OF THE DIFF. Do not
-review or comment on files that are not changed in the merge request, even if
-they contain issues. Your comments must be anchored to changed lines.
+CRITICAL: Only comment on files and lines that are PART OF THE DIFF provided
+in the user message. Do not review or comment on files that are not in the diff.
 
 Output your review as a JSON array:
 ```json
@@ -70,18 +73,31 @@ class ReviewRequest(BaseModel):
     target_branch: str = Field(description="Target branch name")
 
 
-def build_review_prompt(req: ReviewRequest) -> str:
-    """Build the user prompt — the agent uses git diff and file tools."""
-    return (
+def build_review_prompt(req: ReviewRequest, diff_text: str | None = None) -> str:
+    """Build the user prompt — includes the diff directly when available."""
+    prompt = (
         f"## Merge Request\n"
         f"**Title:** {req.title}\n"
         f"**Description:** {req.description or '(none)'}\n"
         f"**Source branch:** {req.source_branch}\n"
         f"**Target branch:** {req.target_branch}\n\n"
-        f"Review this merge request. Run "
-        f"`git diff {req.target_branch}...{req.source_branch}` to see "
-        f"the changes, then read relevant files for context."
     )
+    if diff_text:
+        if len(diff_text) > MAX_DIFF_CHARS:
+            log.warning(
+                "diff_truncated",
+                original_len=len(diff_text),
+                max_len=MAX_DIFF_CHARS,
+            )
+            diff_text = diff_text[:MAX_DIFF_CHARS] + "\n... (diff truncated)"
+        prompt += f"## Diff\n\n```diff\n{diff_text}\n```\n\n"
+        prompt += "Review ONLY the changes shown in the diff above."
+    else:
+        prompt += (
+            f"Run `git diff {req.target_branch}...{req.source_branch}` to see "
+            f"the changes, then read relevant files for context."
+        )
+    return prompt
 
 
 async def run_review(
@@ -90,6 +106,7 @@ async def run_review(
     repo_path: str,
     repo_url: str,
     review_request: ReviewRequest,
+    diff_text: str | None = None,
 ) -> TaskResult:
     """Run a Copilot agent review and return the structured result."""
     task = TaskParams(
@@ -98,7 +115,7 @@ async def run_review(
         repo_url=repo_url,
         branch=review_request.source_branch,
         system_prompt=SYSTEM_PROMPT,
-        user_prompt=build_review_prompt(review_request),
+        user_prompt=build_review_prompt(review_request, diff_text),
         settings=settings,
         repo_path=repo_path,
     )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -95,8 +95,8 @@ async def test_orchestrator_cleans_up_on_error(
     """Verify cleanup runs even when review raises."""
     mock_gl_instance = mock_client_class.return_value
     mock_gl_instance.clone_repo = AsyncMock(return_value="/tmp/fake-repo")
+    mock_gl_instance.get_mr_details = AsyncMock(side_effect=RuntimeError("SDK crashed"))
     mock_gl_instance.cleanup = AsyncMock()
-    mock_run_review.side_effect = RuntimeError("SDK crashed")
 
     payload = MergeRequestWebhookPayload(
         object_kind="merge_request",

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -182,8 +182,8 @@ async def test_review_pipeline_records_error_metrics(
     """handle_review records reviews_total with outcome=error on failure."""
     mock_gl = mock_client_class.return_value
     mock_gl.clone_repo = AsyncMock(return_value="/tmp/fake-repo")
+    mock_gl.get_mr_details = AsyncMock(side_effect=RuntimeError("boom"))
     mock_gl.cleanup = AsyncMock()
-    mock_run_review.side_effect = RuntimeError("boom")
 
     mock_total = MagicMock()
     mock_duration = MagicMock()


### PR DESCRIPTION
## What
Fixes the LLM reviewing the entire repository instead of just the MR diff.

## Why
The SYSTEM_PROMPT told the LLM it had "access to the full repository" and to use built-in file tools for context. The LLM would explore the entire repo and comment on files outside the diff, producing noisy and irrelevant reviews.

## How
- Fetch `mr_details` **before** running the review (was fetched after)
- Build diff text from `MRChange` objects (`old_path`, `new_path`, `diff`)
- Pass `diff_text` directly into `build_review_prompt()` so the LLM has the actual diff in its prompt
- Remove "full repository access" language from SYSTEM_PROMPT
- Truncate diff at 120K chars to prevent prompt overflow on large MRs (logs a warning)
- Fallback: if no diff available, prompt still instructs `git diff`

## Code Review (GPT-5.3-Codex)
| Severity | Finding | Action |
|----------|---------|--------|
| **High** | Unbounded diff can blow up prompt/env vars for large MRs | ✅ Fixed — added 120K char truncation with warning log |
| **Medium** | Prompt injection via unescaped code-fence delimiters in diff | Follow-up issue (internal tool, low risk) |

## Testing
- 343 tests pass, ruff check + format clean
- Diff: 62 lines (4 files)
- E2E: k3d cluster has network connectivity issues preventing pod startup (pre-existing infra issue — pods can't reach PyPI for `uv run` to resolve dev deps). Code change is not related.

## Files Changed
- `src/gitlab_copilot_agent/orchestrator.py` — fetch mr_details before review, build diff text
- `src/gitlab_copilot_agent/review_engine.py` — accept diff_text in build_review_prompt, truncation, updated SYSTEM_PROMPT
- `tests/test_integration.py` — add get_mr_details AsyncMock to error-path test
- `tests/test_metrics.py` — add get_mr_details AsyncMock to error-path test