### PR TITLE
fix(coding): improve pipeline reliability — stale jobs, patch integrity, structured output

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,12 @@ The service supports two execution backends controlled by `TASK_EXECUTOR`:
 
 When using Kubernetes execution, the pod boundary provides process isolation (see [ADR-0003](docs/adr/0003-kubernetes-migration-plan.md)). Configure with `K8S_*` environment variables above.
 
+**Coding task reliability**:
+- Agent outputs structured JSON listing files intentionally changed (prevents accidental artifact commits)
+- In-session retry if agent doesn't return required format
+- Branch name collision detection appends `-2`, `-3`, etc. on retry
+- Stale completed K8s Jobs are automatically replaced on re-execution
+
 ## Troubleshooting
 
 ### Common Issues

--- a/docs/wiki/data-models.md
+++ b/docs/wiki/data-models.md
@@ -336,6 +336,22 @@ See [configuration-reference.md](configuration-reference.md) for all fields.
 
 ---
 
+## Coding Pipeline Models (`coding_engine.py`)
+
+### `CodingAgentOutput`
+**Purpose**: Structured output expected from the coding agent's final message.
+
+**Config**: `strict=True`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `summary` | `str` | Brief description of changes made and test results |
+| `files_changed` | `list[str]` | Paths of files intentionally created, modified, or deleted (excludes generated artifacts like `__pycache__/`, `*.pyc`) |
+
+**Parsing**: Extracted from agent response via regex matching fenced JSON blocks (`` ```json ... ``` ``). If the agent doesn't include a valid JSON block, the session retries once with explicit format instructions.
+
+---
+
 ## Task Execution Models (`task_executor.py`, `review_engine.py`)
 
 ### `TaskParams`

--- a/docs/wiki/request-flows.md
+++ b/docs/wiki/request-flows.md
@@ -290,7 +290,8 @@ sequenceDiagram
             CODING->>GIT: git_clone(clone_url, target_branch, token)
             GIT-->>CODING: repo_path: Path
             
-            CODING->>GIT: git_create_branch(repo_path, "agent/{issue-key}")
+            CODING->>GIT: git_unique_branch(repo_path, "agent/{issue-key}")
+            Note over GIT: Checks remote refs via git ls-remote<br/>Appends -2, -3 on collision
             
             CODING->>EXEC: execute(TaskParams: coding, Jira prompt)
             EXEC->>COP: run_copilot_session(repo_path, CODING_SYSTEM_PROMPT, jira_prompt)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ packages = ["src/gitlab_copilot_agent"]
 dev = [
     "fakeredis>=2.34.0",
     "lupa>=2.6",
+    "mypy>=1.14.1",
     "pytest-asyncio>=0.25.3",
     "pytest-cov>=7.0.0",
     "ruff>=0.9.6",

--- a/tests/test_coding_orchestrator.py
+++ b/tests/test_coding_orchestrator.py
@@ -44,7 +44,7 @@ _TEST_MAPPING = GitLabProjectMapping(
 @patch("gitlab_copilot_agent.coding_orchestrator.run_coding_task")
 @patch("gitlab_copilot_agent.coding_orchestrator.git_push")
 @patch("gitlab_copilot_agent.coding_orchestrator.git_commit")
-@patch("gitlab_copilot_agent.coding_orchestrator.git_create_branch")
+@patch("gitlab_copilot_agent.coding_orchestrator.git_unique_branch")
 @patch("gitlab_copilot_agent.coding_orchestrator.git_clone")
 async def test_handle_full_pipeline(
     mock_clone: AsyncMock,
@@ -55,6 +55,7 @@ async def test_handle_full_pipeline(
     tmp_path: Path,
 ) -> None:
     mock_clone.return_value = tmp_path
+    mock_branch.return_value = "agent/proj-42"
     mock_coding.return_value = CodingResult(summary="Changes made")
     mock_gitlab, mock_jira = AsyncMock(), AsyncMock()
     mock_gitlab.create_merge_request.return_value = 1
@@ -74,7 +75,7 @@ async def test_handle_full_pipeline(
 @patch("gitlab_copilot_agent.coding_orchestrator.run_coding_task")
 @patch("gitlab_copilot_agent.coding_orchestrator.git_push")
 @patch("gitlab_copilot_agent.coding_orchestrator.git_commit")
-@patch("gitlab_copilot_agent.coding_orchestrator.git_create_branch")
+@patch("gitlab_copilot_agent.coding_orchestrator.git_unique_branch")
 @patch("gitlab_copilot_agent.coding_orchestrator.git_clone")
 async def test_in_review_transition_failure_is_non_blocking(
     mock_clone: AsyncMock,
@@ -86,6 +87,7 @@ async def test_in_review_transition_failure_is_non_blocking(
 ) -> None:
     """If 'In Review' transition fails, the task still completes successfully."""
     mock_clone.return_value = tmp_path
+    mock_branch.return_value = "agent/proj-42"
     mock_coding.return_value = CodingResult(summary="Changes made")
     mock_gitlab, mock_jira = AsyncMock(), AsyncMock()
     mock_gitlab.create_merge_request.return_value = 1
@@ -104,7 +106,7 @@ async def test_in_review_transition_failure_is_non_blocking(
 @patch("gitlab_copilot_agent.coding_orchestrator.run_coding_task")
 @patch("gitlab_copilot_agent.coding_orchestrator.git_push")
 @patch("gitlab_copilot_agent.coding_orchestrator.git_commit")
-@patch("gitlab_copilot_agent.coding_orchestrator.git_create_branch")
+@patch("gitlab_copilot_agent.coding_orchestrator.git_unique_branch")
 @patch("gitlab_copilot_agent.coding_orchestrator.git_clone")
 async def test_custom_in_review_status_used(
     mock_clone: AsyncMock,
@@ -116,6 +118,7 @@ async def test_custom_in_review_status_used(
 ) -> None:
     """Custom JIRA_IN_REVIEW_STATUS is used for the transition."""
     mock_clone.return_value = tmp_path
+    mock_branch.return_value = "agent/proj-42"
     mock_coding.return_value = CodingResult(summary="Changes made")
     mock_gitlab, mock_jira = AsyncMock(), AsyncMock()
     mock_gitlab.create_merge_request.return_value = 1

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -4,12 +4,15 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from gitlab_copilot_agent.coding_engine import parse_agent_output
 from gitlab_copilot_agent.task_runner import (
     ENV_BRANCH,
     ENV_REPO_URL,
     ENV_TASK_ID,
     ENV_TASK_PAYLOAD,
     ENV_TASK_TYPE,
+    _build_coding_result,
+    _coding_response_validator,
     _get_required_env,
     _parse_task_payload,
     _validate_repo_url,
@@ -108,6 +111,83 @@ class TestRunTask:
             patch(f"{_M}._build_coding_result", AsyncMock(return_value=coding_json)),
             patch(f"{_M}._store_result", AsyncMock()),
             patch(f"{_M}.shutil.rmtree"),
+            patch("gitlab_copilot_agent.coding_engine.ensure_gitignore"),
         ):
             assert await run_task() == 0
             assert ms.call_args[1]["task_type"] == "coding"
+            assert ms.call_args[1]["validate_response"] is not None
+
+
+VALID_AGENT_OUTPUT = (
+    'Done.\n\n```json\n{"summary": "Added utils", "files_changed": ["src/utils.py"]}\n```'
+)
+
+
+class TestCodingResponseValidator:
+    def test_valid_output_returns_none(self) -> None:
+        assert _coding_response_validator(VALID_AGENT_OUTPUT) is None
+
+    def test_missing_json_returns_retry_prompt(self) -> None:
+        result = _coding_response_validator("I made some changes to the code.")
+        assert result is not None
+        assert "files_changed" in result
+
+    def test_malformed_json_returns_retry_prompt(self) -> None:
+        result = _coding_response_validator('```json\n{"bad": true}\n```')
+        assert result is not None
+
+
+class TestParseAgentOutput:
+    def test_valid_block(self) -> None:
+        out = parse_agent_output(VALID_AGENT_OUTPUT)
+        assert out is not None
+        assert out.summary == "Added utils"
+        assert out.files_changed == ["src/utils.py"]
+
+    def test_no_json_block(self) -> None:
+        assert parse_agent_output("No JSON here") is None
+
+    def test_invalid_json_returns_none(self) -> None:
+        assert parse_agent_output("```json\nnot json\n```") is None
+
+    def test_missing_fields_returns_none(self) -> None:
+        assert parse_agent_output('```json\n{"summary": "x"}\n```') is None
+
+
+DELETED_FILE_OUTPUT = (
+    '```json\n{"summary": "Removed old module",'
+    ' "files_changed": ["src/old.py", "src/utils.py"]}\n```'
+)
+TRAVERSAL_OUTPUT = (
+    '```json\n{"summary": "Hack", "files_changed": ["../../etc/passwd", "src/ok.py"]}\n```'
+)
+
+
+class TestBuildCodingResult:
+    async def test_deleted_file_staged_via_git_add(self) -> None:
+        """Deleted files are staged with `git add --` (no exists() gate)."""
+        git_mock = AsyncMock(return_value="")
+        with (
+            patch(f"{_M}._run_git_simple", git_mock),
+            patch(f"{_M}.git_head_sha", AsyncMock(return_value="abc123")),
+            patch(f"{_M}.git_diff_staged", AsyncMock(return_value="diff --git ...")),
+        ):
+            result = await _build_coding_result(Path("/repo"), DELETED_FILE_OUTPUT, AsyncMock())
+        data = json.loads(result)
+        assert data["summary"] == "Removed old module"
+        # Both files staged regardless of whether they exist on disk
+        assert git_mock.await_count == 2
+        git_mock.assert_any_await(Path("/repo"), "add", "--", "src/old.py")
+        git_mock.assert_any_await(Path("/repo"), "add", "--", "src/utils.py")
+
+    async def test_path_traversal_skipped(self) -> None:
+        """Files with .. path components are skipped."""
+        git_mock = AsyncMock(return_value="")
+        with (
+            patch(f"{_M}._run_git_simple", git_mock),
+            patch(f"{_M}.git_head_sha", AsyncMock(return_value="abc123")),
+            patch(f"{_M}.git_diff_staged", AsyncMock(return_value="diff --git ...")),
+        ):
+            await _build_coding_result(Path("/repo"), TRAVERSAL_OUTPUT, AsyncMock())
+        # Only src/ok.py staged; ../../etc/passwd skipped
+        git_mock.assert_awaited_once_with(Path("/repo"), "add", "--", "src/ok.py")

--- a/uv.lock
+++ b/uv.lock
@@ -309,6 +309,7 @@ kubernetes = [
 dev = [
     { name = "fakeredis" },
     { name = "lupa" },
+    { name = "mypy" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -345,6 +346,7 @@ provides-extras = ["kubernetes", "dev"]
 dev = [
     { name = "fakeredis", specifier = ">=2.34.0" },
     { name = "lupa", specifier = ">=2.6" },
+    { name = "mypy", specifier = ">=1.14.1" },
     { name = "pytest-asyncio", specifier = ">=0.25.3" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.9.6" },


### PR DESCRIPTION
## What

Fixes five reliability issues in the Jira → coding → MR pipeline discovered during E2E testing.

Closes #185, closes #188

## Why

The coding pipeline was fragile: retries reused stale K8s Jobs, `.strip()` corrupted patches, `git add -A` staged binary artifacts, branch collisions failed pushes, and missing agent output went unretried.

## Changes

### Stale K8s Job replacement (`k8s_executor.py`)
On 409 (Job exists), check status: if completed (succeeded/failed), delete and recreate. Running jobs are still reused.

### Structured agent output (`coding_engine.py`, `task_runner.py`)
- `CodingAgentOutput` Pydantic model with `summary` and `files_changed`
- `parse_agent_output()` extracts fenced JSON from agent response
- Only explicitly listed files are staged — no `git add -A`
- Prompt and model explicitly cover created, modified, and deleted files
- Path traversal (`../`) guarded against

### In-session retry (`copilot_session.py`, `task_runner.py`)
- `validate_response` callback on `run_copilot_session()`
- If agent omits JSON block, sends follow-up prompt (1 retry max)

### Patch integrity (`git_operations.py`)
- `git_diff_staged()` reads stdout without `.strip()` — preserves trailing context lines

### Branch disambiguation (`git_operations.py`, `coding_orchestrator.py`)
- `git_unique_branch()` checks `git ls-remote --heads` for collisions
- Appends `-2`, `-3`, etc. — works with shallow clones

### E2E mock (`mock_llm.py`)
- Mock LLM now returns task-appropriate response (review format vs coding format)
- Detects coding tasks via `files_changed` keyword in system prompt

### Dev tooling (`pyproject.toml`)
- Added `mypy>=1.14.1` to dev dependency group (was only system-installed)

### Documentation
- README, task-execution, data-models, module-reference, request-flows updated

## Testing

- 357 tests pass, lint clean (ruff + format + mypy)
- E2E: CI pipeline validates webhook review + Jira coding flow
- Live E2E: Jira DEMO-3 → coding job → patch → branch `agent/demo-3-2` → MR !19 → auto-review → Jira "In Review"

## Code Review Findings (GPT-5.3-Codex)

| Severity | Finding | Resolution |
|----------|---------|------------|
| High | File deletions silently dropped by `.exists()` check | Fixed — removed gate, added path traversal guard + tests |
| Medium | Stale job delete/recreate can race (async k8s deletion) | Follow-up #187 |