### PR TITLE
feat(git): add retry-with-backoff for transient git clone failures

### DIFF
--- a/src/gitlab_copilot_agent/config.py
+++ b/src/gitlab_copilot_agent/config.py
@@ -97,6 +97,16 @@ class Settings(BaseSettings):
         default=None, description="Redis URL (required when STATE_BACKEND=redis)"
     )
 
+    # Git clone retry
+    git_clone_max_retries: int = Field(
+        default=3, ge=1, description="Max retry attempts for transient git clone failures"
+    )
+    git_clone_backoff_base: float = Field(
+        default=5.0,
+        ge=0,
+        description="Base interval in seconds for exponential backoff on clone retry",
+    )
+
     # Project allowlist (optional — scopes webhook and poller)
     gitlab_projects: str | None = Field(
         default=None,


### PR DESCRIPTION
## What

Add inline retry logic to `git_clone()` for transient errors, with exponential backoff and configurable parameters. This is part 1 of 2 for #190.

## Why

A transient 403 from GitLab during `git clone` caused DEMO-1 to get stuck in "In Progress" indefinitely. The same URL worked fine minutes later. The agent should retry transient errors before giving up.

## Changes

- **`TransientCloneError`** exception with attempt count
- **`_is_transient_clone_error()`** stderr classifier — retries 403, 5xx, connection refused, timed out, DNS failures; fails immediately on 401, 404, repo not found
- **Retry loop** in `git_clone()` with exponential backoff (`base * 3^attempt`)
- **OTel span attributes**: `clone.attempts`, `clone.outcome` (success/permanent_failure/transient_failure)
- **Settings**: `git_clone_max_retries` (default 3, min 1), `git_clone_backoff_base` (default 5s, min 0)

## Stack

- **PR 1 (this)**: Core retry infrastructure → `main`
- **PR 2**: Orchestrator integration + tests → `feat/190-git-clone-retry-core` (#194)

## Code review (GPT-5.3-Codex)

| # | Severity | Finding | Resolution |
|---|----------|---------|------------|
| 1 | High | Transient failures marked as processed blocks retries — `_tracker.mark()` in transient handler means poller skips the issue even after operator moves it back to "AI Ready" | **Fixed in PR 2**: Removed `_tracker.mark()` from transient handler. Issue stays retryable on next poll cycle. |
| 2 | Medium | `git_clone_max_retries=0` disables cloning entirely — no validation on settings allows zero-attempt config | **Fixed**: Added `ge=1` on `git_clone_max_retries` and `ge=0` on `git_clone_backoff_base` via Pydantic Field validators. |

## Test results

```
370 passed, coverage 95.87%
```

## E2E results

```
Test 1: Webhook MR Review ✅
Test 2: Jira Polling Flow ✅
Test 3: /copilot Command ✅
Test 4: GitLab Polling — MR Discovery ✅
=== ALL E2E TESTS PASSED ===
```

Closes #190 (part 1 of 2)