### PR TITLE
feat(config): make GITLAB_WEBHOOK_SECRET optional for polling-only mode

### DIFF
--- a/docs/wiki/configuration-reference.md
+++ b/docs/wiki/configuration-reference.md
@@ -20,11 +20,11 @@ Every environment variable in `config.py`, grouped by category.
 - **Validation**: Non-empty string
 
 ### `GITLAB_WEBHOOK_SECRET`
-- **Type**: `str`
-- **Required**: ✅ Yes
-- **Description**: Secret for validating webhook payloads via HMAC (X-Gitlab-Token header)
-- **Security**: Must match GitLab webhook configuration
-- **Validation**: Non-empty string
+- **Type**: `str | None`
+- **Required**: ❌ No (required for webhook mode, optional for polling-only)
+- **Default**: `None`
+- **Description**: Secret for validating webhook payloads via HMAC (X-Gitlab-Token header). When not set, the `/webhook` endpoint returns 403.
+- **Security**: Must match GitLab webhook configuration when using webhooks
 
 ---
 
@@ -474,7 +474,7 @@ Helm `values.yaml` maps to env vars via `configmap.yaml` and `secret.yaml`:
 |------------|---------|---------|
 | `gitlab.url` | `GITLAB_URL` | ❌ |
 | `gitlab.token` | `GITLAB_TOKEN` | ✅ |
-| `gitlab.webhookSecret` | `GITLAB_WEBHOOK_SECRET` | ✅ |
+| `gitlab.webhookSecret` | `GITLAB_WEBHOOK_SECRET` | ✅ (optional for polling-only) |
 | `github.token` | `GITHUB_TOKEN` | ✅ |
 | `controller.copilotProviderType` | `COPILOT_PROVIDER_TYPE` | ❌ |
 | `controller.copilotProviderBaseUrl` | `COPILOT_PROVIDER_BASE_URL` | ❌ |

--- a/docs/wiki/deployment-guide.md
+++ b/docs/wiki/deployment-guide.md
@@ -120,7 +120,7 @@ jobRunner:
 gitlab:
   url: ""                  # GITLAB_URL
   token: ""                # GITLAB_TOKEN (secret)
-  webhookSecret: ""        # GITLAB_WEBHOOK_SECRET (secret)
+  webhookSecret: ""        # GITLAB_WEBHOOK_SECRET (secret, optional for polling-only)
 
 github:
   token: ""                # GITHUB_TOKEN (secret)
@@ -213,7 +213,7 @@ cp .env.k3d.example .env.k3d
 ```bash
 GITLAB_URL=https://gitlab.example.com
 GITLAB_TOKEN=glpat-xxxxx
-GITLAB_WEBHOOK_SECRET=my-secret
+GITLAB_WEBHOOK_SECRET=my-secret  # optional for polling-only mode
 GITHUB_TOKEN=ghp_xxxxx
 COPILOT_PROVIDER_TYPE=
 COPILOT_PROVIDER_BASE_URL=
@@ -479,14 +479,14 @@ kubectl get hpa -n default
 
 **Fields**:
 - `GITLAB_TOKEN`
-- `GITLAB_WEBHOOK_SECRET`
+- `GITLAB_WEBHOOK_SECRET` (if webhook mode enabled)
 - `GITHUB_TOKEN`
 - `COPILOT_PROVIDER_API_KEY` (if BYOK)
 - `JIRA_API_TOKEN` (if Jira enabled)
 - `REDIS_PASSWORD` (auto-generated if not set via `redis.password`)
 - `REDIS_URL` (auto-generated with password embedded)
 
-**Job Pod Credentials**: When the K8s executor is used, Job pods receive sensitive env vars (`GITLAB_TOKEN`, `GITHUB_TOKEN`, `COPILOT_PROVIDER_API_KEY`, `GITLAB_WEBHOOK_SECRET`) via `secretKeyRef` pointing to this Secret — not as plaintext. Only the tokens needed by Job pods are mounted; other secrets (Jira, etc.) are excluded.
+**Job Pod Credentials**: When the K8s executor is used, Job pods receive sensitive env vars (`GITLAB_TOKEN`, `GITHUB_TOKEN`, `COPILOT_PROVIDER_API_KEY`, and `GITLAB_WEBHOOK_SECRET` if set) via `secretKeyRef` pointing to this Secret — not as plaintext. Only the tokens needed by Job pods are mounted; other secrets (Jira, etc.) are excluded.
 
 **Base64 Encoding**: Handled automatically by Helm.
 

--- a/docs/wiki/security-model.md
+++ b/docs/wiki/security-model.md
@@ -304,7 +304,7 @@ graph TB
 **Credentials Passed** (via K8s Secret refs when `k8s_secret_name` configured):
 - `GITLAB_TOKEN` (clone only — pod has no push access)
 - `GITHUB_TOKEN` (or `COPILOT_PROVIDER_API_KEY`) via `secretKeyRef`
-- `GITLAB_WEBHOOK_SECRET` (required by Settings validation, not used in pod)
+- `GITLAB_WEBHOOK_SECRET` (optional — only when webhooks are used, not used in pod)
 
 Only the 3 tokens needed by Job pods are mounted — other secrets (`JIRA_*`, etc.) are excluded to limit blast radius.
 

--- a/helm/gitlab-copilot-agent/templates/secret.yaml
+++ b/helm/gitlab-copilot-agent/templates/secret.yaml
@@ -7,7 +7,9 @@ type: Opaque
 stringData:
   {{- $redisPassword := include "app.redisPassword" . }}
   GITLAB_TOKEN: {{ required "gitlab.token is required" .Values.gitlab.token | quote }}
-  GITLAB_WEBHOOK_SECRET: {{ required "gitlab.webhookSecret is required" .Values.gitlab.webhookSecret | quote }}
+  {{- with .Values.gitlab.webhookSecret }}
+  GITLAB_WEBHOOK_SECRET: {{ . | quote }}
+  {{- end }}
   REDIS_PASSWORD: {{ $redisPassword | quote }}
   REDIS_URL: "redis://:{{ $redisPassword | urlquery }}@{{ include "app.fullname" . }}-redis:{{ .Values.redis.port }}"
   {{- with .Values.github.token }}

--- a/helm/gitlab-copilot-agent/values.yaml
+++ b/helm/gitlab-copilot-agent/values.yaml
@@ -34,7 +34,7 @@ telemetry:
 jobRunner: { image: "", cpuLimit: "1", memoryLimit: 1Gi, timeout: 600 }
 service: { type: ClusterIP }
 serviceAccount: { create: true, name: "" }
-gitlab: { url: "", token: "", webhookSecret: "" }
+gitlab: { url: "", token: "", webhookSecret: "" }  # webhookSecret is optional for polling-only mode
 github: { token: "" }
 jira:
   url: ""

--- a/src/gitlab_copilot_agent/config.py
+++ b/src/gitlab_copilot_agent/config.py
@@ -38,7 +38,10 @@ class Settings(BaseSettings):
     # GitLab
     gitlab_url: str = Field(description="GitLab instance URL")
     gitlab_token: str = Field(description="GitLab API private token")
-    gitlab_webhook_secret: str = Field(description="Secret for validating webhook payloads")
+    gitlab_webhook_secret: str | None = Field(
+        default=None,
+        description="Secret for validating webhook payloads (required for webhook mode)",
+    )
 
     # Copilot / LLM
     copilot_model: str = Field(default="gpt-4", description="Model to use for reviews")
@@ -212,6 +215,11 @@ class Settings(BaseSettings):
             entries = [e.strip() for e in (self.gitlab_projects or "").split(",") if e.strip()]
             if not entries:
                 raise ValueError("GITLAB_PROJECTS is required when GITLAB_POLL=true")
+        if not self.gitlab_poll and not self.gitlab_webhook_secret:
+            raise ValueError(
+                "GITLAB_WEBHOOK_SECRET is required when GITLAB_POLL is not enabled. "
+                "Set GITLAB_WEBHOOK_SECRET for webhook mode or GITLAB_POLL=true for polling mode."
+            )
         return self
 
     @model_validator(mode="after")

--- a/src/gitlab_copilot_agent/k8s_executor.py
+++ b/src/gitlab_copilot_agent/k8s_executor.py
@@ -88,7 +88,7 @@ def _build_env(task: TaskParams, settings: Settings) -> list[object]:
     # Required keys are always mounted; optional keys only when the setting is non-empty.
     _secret_vars: list[tuple[str, str | None]] = [
         ("GITLAB_TOKEN", settings.gitlab_token),  # always required
-        ("GITLAB_WEBHOOK_SECRET", settings.gitlab_webhook_secret),  # always required
+        ("GITLAB_WEBHOOK_SECRET", settings.gitlab_webhook_secret),  # optional — skipped when None
         ("GITHUB_TOKEN", settings.github_token),
         ("COPILOT_PROVIDER_API_KEY", settings.copilot_provider_api_key),
     ]

--- a/src/gitlab_copilot_agent/webhook.py
+++ b/src/gitlab_copilot_agent/webhook.py
@@ -18,7 +18,9 @@ router = APIRouter()
 HANDLED_ACTIONS = frozenset({"open", "update"})
 
 
-def _validate_webhook_token(received: str | None, expected: str) -> None:
+def _validate_webhook_token(received: str | None, expected: str | None) -> None:
+    if expected is None:
+        raise HTTPException(status_code=403, detail="Webhook secret not configured")
     if received is None or not hmac.compare_digest(received, expected):
         raise HTTPException(status_code=401, detail="Invalid webhook token")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,6 +30,20 @@ def test_settings_loads_required_env_vars(monkeypatch: pytest.MonkeyPatch) -> No
     assert settings.gitlab_webhook_secret == WEBHOOK_SECRET
 
 
+def test_settings_loads_without_webhook_secret() -> None:
+    """Webhook secret is optional for polling-only mode."""
+    settings = make_settings(
+        gitlab_webhook_secret=None, gitlab_poll=True, gitlab_projects="group/project"
+    )
+    assert settings.gitlab_webhook_secret is None
+
+
+def test_settings_rejects_no_ingestion_path() -> None:
+    """Must have at least one event path: webhook secret or polling."""
+    with pytest.raises(ValidationError, match="GITLAB_WEBHOOK_SECRET is required"):
+        make_settings(gitlab_webhook_secret=None)
+
+
 def test_settings_defaults() -> None:
     """Verify optional fields have correct defaults (without requiring env vars)."""
     settings = make_settings()


### PR DESCRIPTION
## What

Make `GITLAB_WEBHOOK_SECRET` optional (`str | None`, default `None`) so polling-only deployments don't need a dummy webhook secret.

Closes #171.

## Changes

### `src/gitlab_copilot_agent/config.py`
- `gitlab_webhook_secret: str` → `str | None = Field(default=None)`
- Added startup validation: at least one ingestion path must be configured (webhook secret OR `GITLAB_POLL=true`)

### `src/gitlab_copilot_agent/webhook.py`
- `_validate_webhook_token` now returns **403** when `expected` is `None` (secret not configured)
- Existing 401 behavior unchanged when secret is set but token is wrong/missing

### `src/gitlab_copilot_agent/k8s_executor.py`
- Updated comment: `GITLAB_WEBHOOK_SECRET` marked as optional (already skipped when `None` via `if not value: continue`)

### `helm/gitlab-copilot-agent/templates/secret.yaml`
- `GITLAB_WEBHOOK_SECRET` now conditional (`{{- with }}`) instead of `required`

### `helm/gitlab-copilot-agent/values.yaml`
- Added comment noting `webhookSecret` is optional for polling-only

### Documentation
- `configuration-reference.md`: Updated type, required status, description, Helm values table
- `deployment-guide.md`: Notes `GITLAB_WEBHOOK_SECRET` is optional for polling-only in examples and secret fields list
- `security-model.md`: Updated from "required by Settings validation" to "optional"

## Code Review (GPT-5.3-Codex)

**Finding: No ingestion path validation** — Severity: Medium
- Without webhook secret AND without polling, the agent starts but processes zero events
- **Fixed**: Added model validator that raises `ValueError` when both `gitlab_poll=False` and `gitlab_webhook_secret=None`

## Testing

- `make lint`: all checks passed (ruff check + format + mypy --strict)
- `make test`: 391 passed, 2 pre-existing failures (demo template — unrelated)
- Coverage: 95.78%
- New tests: `test_webhook_returns_403_when_secret_not_configured`, `test_settings_loads_without_webhook_secret`, `test_settings_rejects_no_ingestion_path`

## Diff

70 lines (+53 / -17), 10 files changed.