### PR TITLE
feat(config): improve startup error messages for missing configuration

### DIFF
--- a/docs/wiki/deployment-guide.md
+++ b/docs/wiki/deployment-guide.md
@@ -522,9 +522,9 @@ kubectl logs <pod-name> -n default
 ```
 
 **Common Causes**:
-- Missing env vars (GITLAB_TOKEN, GITHUB_TOKEN)
+- Missing env vars — the agent prints a human-friendly summary listing each missing variable and its description
 - Invalid REDIS_URL
-- Pydantic validation error
+- Invalid configuration combination (e.g., no LLM auth, no ingestion path)
 
 ---
 

--- a/src/gitlab_copilot_agent/config.py
+++ b/src/gitlab_copilot_agent/config.py
@@ -208,7 +208,12 @@ class Settings(BaseSettings):
     @model_validator(mode="after")
     def _check_auth(self) -> "Settings":
         if not self.github_token and not self.copilot_provider_type:
-            raise ValueError("Either GITHUB_TOKEN or COPILOT_PROVIDER_TYPE must be set")
+            raise ValueError(
+                "No LLM authentication configured. Set one of:\n"
+                "  • GITHUB_TOKEN — GitHub PAT for Copilot LLM access\n"
+                "  • COPILOT_PROVIDER_TYPE + COPILOT_PROVIDER_BASE_URL + "
+                "COPILOT_PROVIDER_API_KEY — BYOK (Azure OpenAI, OpenAI direct)"
+            )
         if self.state_backend == "redis" and not self.redis_url:
             raise ValueError("REDIS_URL is required when STATE_BACKEND=redis")
         if self.gitlab_poll:


### PR DESCRIPTION
## What

Catch `ValidationError` during startup and print a human-friendly error message instead of a raw Pydantic traceback. Also improve the LLM auth validation message per issue comment.

Closes #172.

## Changes

### `src/gitlab_copilot_agent/main.py`
- Added `_print_config_errors(exc)` helper: formats missing fields as a table with env var names, descriptions, and a link to config docs
- Wrapped `Settings()` in `lifespan()` with `try/except ValidationError` → print friendly message → `sys.exit(1)`

### `src/gitlab_copilot_agent/config.py`
- Improved `_check_auth` error message: now explains both auth options:
  - `GITHUB_TOKEN` — GitHub PAT for Copilot LLM access
  - `COPILOT_PROVIDER_TYPE` + `COPILOT_PROVIDER_BASE_URL` + `COPILOT_PROVIDER_API_KEY` — BYOK

### `docs/wiki/deployment-guide.md`
- Updated Troubleshooting section to reference the new friendly error format

### Example output
```
❌ Configuration error:

  GITLAB_URL                               (missing) GitLab instance URL
  GITLAB_TOKEN                             (missing) GitLab API private token

See docs/wiki/configuration-reference.md for all settings.
```

## Code Review (GPT-5.3-Codex)

No findings.

## Testing

- `make lint`: all checks passed (ruff check + format + mypy --strict)
- `make test`: 393 passed, 2 pre-existing failures (demo template — unrelated)
- Coverage: 95.75%
- New tests: `test_missing_field_shown_with_env_var_and_description`, `test_value_error_shown_as_message`

## Diff

77 lines (+72 / -5), 4 files changed.