### PR TITLE
feat(infra): add ACR, Container Apps Environment, outputs, and Terraform tooling

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,10 @@
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
       "minikube": "none"
+    },
+    "ghcr.io/devcontainers/features/terraform:1": {
+      "version": "1.9",
+      "tflint": "0.53.0"
     }
   },
   "postCreateCommand": "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.7.5 bash && pipx install uv && uv sync --all-extras && chmod +x .venv/lib/python3.12/site-packages/copilot/bin/copilot && npm install -g @github/copilot && uv --version",

--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -1,0 +1,35 @@
+resource "azurerm_container_registry" "main" {
+  name                = replace("acr${var.resource_group_name}", "-", "")
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  sku                 = "Basic"
+  admin_enabled       = false
+
+  tags = var.tags
+}
+
+# Controller identity: ACR pull
+resource "azurerm_role_assignment" "controller_acr" {
+  scope                = azurerm_container_registry.main.id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_user_assigned_identity.controller.principal_id
+}
+
+# Job identity: ACR pull
+resource "azurerm_role_assignment" "job_acr" {
+  scope                = azurerm_container_registry.main.id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_user_assigned_identity.job.principal_id
+}
+
+# --- Container Apps Environment ---
+
+resource "azurerm_container_app_environment" "main" {
+  name                       = "cae-${var.resource_group_name}"
+  location                   = azurerm_resource_group.main.location
+  resource_group_name        = azurerm_resource_group.main.name
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+  infrastructure_subnet_id   = azurerm_subnet.infra.id
+
+  tags = var.tags
+}

--- a/infra/keyvault.tf
+++ b/infra/keyvault.tf
@@ -7,7 +7,7 @@ resource "azurerm_key_vault" "main" {
   tenant_id           = data.azurerm_client_config.current.tenant_id
   sku_name            = "standard"
 
-  enable_rbac_authorization = true
+  rbac_authorization_enabled = true
 
   tags = var.tags
 }

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,24 @@
+output "resource_group_name" {
+  description = "Name of the resource group"
+  value       = azurerm_resource_group.main.name
+}
+
+output "container_apps_environment_id" {
+  description = "ID of the Container Apps Environment"
+  value       = azurerm_container_app_environment.main.id
+}
+
+output "acr_login_server" {
+  description = "ACR login server URL"
+  value       = azurerm_container_registry.main.login_server
+}
+
+output "redis_hostname" {
+  description = "Azure Cache for Redis hostname"
+  value       = azurerm_redis_cache.main.hostname
+}
+
+output "key_vault_uri" {
+  description = "Azure Key Vault URI"
+  value       = azurerm_key_vault.main.vault_uri
+}

--- a/src/gitlab_copilot_agent/aca_executor.py
+++ b/src/gitlab_copilot_agent/aca_executor.py
@@ -98,6 +98,7 @@ class ContainerAppsTaskExecutor:
     def _start_execution(self, task: TaskParams) -> str:
         """Start a Container Apps Job execution (synchronous, called via to_thread)."""
         from azure.mgmt.appcontainers.models import (  # type: ignore[import-not-found,import-untyped,unused-ignore]  # noqa: I001
+            EnvironmentVar,
             JobExecutionContainer,
             JobExecutionTemplate,
         )
@@ -109,7 +110,7 @@ class ContainerAppsTaskExecutor:
             containers=[
                 JobExecutionContainer(
                     name="task",
-                    env=[{"name": e["name"], "value": e["value"]} for e in env_overrides],
+                    env=[EnvironmentVar(name=e["name"], value=e["value"]) for e in env_overrides],
                 )
             ],
         )

--- a/tests/test_aca_executor.py
+++ b/tests/test_aca_executor.py
@@ -91,6 +91,7 @@ def _install_azure_stub() -> tuple[MagicMock, MagicMock]:
 
     models_mod.JobExecutionTemplate = _Passthrough  # type: ignore[attr-defined]
     models_mod.JobExecutionContainer = _Passthrough  # type: ignore[attr-defined]
+    models_mod.EnvironmentVar = _Passthrough  # type: ignore[attr-defined]
 
     sys.modules["azure"] = azure_mod
     sys.modules["azure.identity"] = identity_mod


### PR DESCRIPTION
## What
Add Azure Container Registry, Container Apps Environment, Terraform outputs, and Terraform tooling to devcontainer.

## Why
Part of #209 — Azure Container Apps deployment option. This PR adds the foundational container infrastructure.

## Changes
- `infra/container-apps.tf`: ACR + Container Apps Environment on infra subnet
- `infra/outputs.tf`: Terraform outputs for resource group, ACR, Redis, Key Vault
- `infra/keyvault.tf`: Fix deprecated `enable_rbac_authorization` → `rbac_authorization_enabled`
- `.devcontainer/devcontainer.json`: Add terraform 1.9 + tflint 0.53.0 features
- `src/gitlab_copilot_agent/aca_executor.py`: Fix mypy EnvironmentVar type (use model class)
- `tests/test_aca_executor.py`: Add EnvironmentVar stub to fake Azure module

## Stack
Part 5 of Azure Container Apps (#209). Merge before feat/209-infra-container-apps.

Closes: n/a (part of #209)