### PR TITLE
feat(infra): add Controller Container App with Key Vault secrets

### DIFF
--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -13,6 +13,11 @@ output "acr_login_server" {
   value       = azurerm_container_registry.main.login_server
 }
 
+output "controller_fqdn" {
+  description = "FQDN of the controller Container App"
+  value       = azurerm_container_app.controller.latest_revision_fqdn
+}
+
 output "redis_hostname" {
   description = "Azure Cache for Redis hostname"
   value       = azurerm_redis_cache.main.hostname

--- a/infra/variables-apps.tf
+++ b/infra/variables-apps.tf
@@ -33,3 +33,40 @@ variable "redis_capacity" {
   type        = number
   default     = 0
 }
+
+# --- Container Apps ---
+
+variable "controller_image" {
+  description = "Container image for the controller"
+  type        = string
+}
+
+variable "controller_min_replicas" {
+  description = "Minimum replicas for the controller (0 = scale to zero)"
+  type        = number
+  default     = 0
+}
+
+variable "controller_max_replicas" {
+  description = "Maximum replicas for the controller"
+  type        = number
+  default     = 1
+}
+
+# --- GitLab / Copilot ---
+
+variable "gitlab_url" {
+  description = "GitLab instance URL"
+  type        = string
+}
+
+variable "gitlab_projects" {
+  description = "Comma-separated GitLab project paths or IDs to scope poller"
+  type        = string
+}
+
+variable "copilot_model" {
+  description = "LLM model name for Copilot sessions"
+  type        = string
+  default     = "gpt-4"
+}


### PR DESCRIPTION
## What
Add the Controller Container App with Key Vault secret references and dynamic blocks.

## Why
Part of #209 — the controller polls GitLab, dispatches tasks to Container Apps Jobs, and collects results from Redis.

## Changes
- `infra/container-apps.tf`: Controller app with user-assigned identity, dynamic secret blocks, health probe
- `infra/variables-apps.tf`: Controller image, replicas, GitLab, and Copilot config variables
- `infra/outputs.tf`: Controller FQDN output

## Security
- S1: Secrets via Key Vault references (never plaintext env vars)
- S4: Dedicated controller managed identity with ACR pull + Key Vault Secrets User

## Stack
Part 6 of Azure Container Apps (#209). Depends on #217. Merge before feat/209-infra-job.

Closes: n/a (part of #209)