### PR TITLE
feat(infra): add Task Runner Container Apps Job

### DIFF
--- a/infra/dev.tfvars.example
+++ b/infra/dev.tfvars.example
@@ -1,3 +1,11 @@
 subscription_id     = "00000000-0000-0000-0000-000000000000"
 resource_group_name = "rg-copilot-dev"
 location            = "eastus2"
+
+# Container images (update after ACR build)
+controller_image = "acrrg-copilot-dev.azurecr.io/controller:latest"
+job_image        = "acrrg-copilot-dev.azurecr.io/task-runner:latest"
+
+# GitLab
+gitlab_url      = "https://gitlab.example.com"
+gitlab_projects = "group/project1,group/project2"

--- a/infra/variables-apps.tf
+++ b/infra/variables-apps.tf
@@ -41,6 +41,29 @@ variable "controller_image" {
   type        = string
 }
 
+variable "job_image" {
+  description = "Container image for the task runner job"
+  type        = string
+}
+
+variable "job_cpu" {
+  description = "CPU cores for job executions"
+  type        = number
+  default     = 1.0
+}
+
+variable "job_memory" {
+  description = "Memory (Gi) for job executions"
+  type        = string
+  default     = "2Gi"
+}
+
+variable "job_timeout" {
+  description = "Job execution timeout in seconds"
+  type        = number
+  default     = 600
+}
+
 variable "controller_min_replicas" {
   description = "Minimum replicas for the controller (0 = scale to zero)"
   type        = number


### PR DESCRIPTION
## What
Add the Task Runner Container Apps Job for ephemeral task execution.

## Why
Part of #209 — each task (review/coding) runs as an isolated Container Apps Job execution, triggered by the controller.

## Changes
- `infra/container-apps.tf`: Task Runner Job with manual trigger, Key Vault secrets, RBAC for controller to start jobs
- `infra/variables-apps.tf`: Job image, CPU, memory, timeout variables
- `infra/dev.tfvars.example`: All required variable examples

## Security
- S1: Secrets via Key Vault references on template (never per-execution)
- S4: Dedicated job managed identity with ACR pull + Key Vault Secrets User
- Controller gets Contributor on Job resource only (least-privilege for `jobs.begin_start`)

## Code Review
Fixed High finding: controller lacked RBAC to start job executions. Added `controller_job_start` role assignment scoped to the job resource.

## Stack
Part 7 of Azure Container Apps (#209). Depends on #218. Merge before feat/209-ci-deploy.

Closes: n/a (part of #209)