### PR TITLE
feat(ci): add deploy workflow with OIDC federation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,84 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        required: true
+        type: choice
+        options:
+          - dev
+          - staging
+      image_tag:
+        description: "Container image tag to deploy"
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  TERRAFORM_VERSION: "1.9.x"
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    outputs:
+      acr_image: ${{ steps.meta.outputs.acr_image }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: ACR login
+        run: az acr login --name ${{ vars.ACR_NAME }}
+
+      - name: Build and push
+        id: meta
+        run: |
+          IMAGE="${{ vars.ACR_NAME }}.azurecr.io/gitlab-copilot-agent:${{ inputs.image_tag }}"
+          docker build -t "$IMAGE" .
+          docker push "$IMAGE"
+          echo "acr_image=$IMAGE" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    needs: build-push
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+
+      - name: Terraform init
+        working-directory: infra
+        run: |
+          terraform init \
+            -backend-config="resource_group_name=${{ vars.TF_STATE_RESOURCE_GROUP }}" \
+            -backend-config="storage_account_name=${{ vars.TF_STATE_STORAGE_ACCOUNT }}" \
+            -backend-config="container_name=tfstate" \
+            -backend-config="key=${{ inputs.environment }}.terraform.tfstate"
+
+      - name: Terraform apply
+        working-directory: infra
+        run: |
+          terraform apply -auto-approve \
+            -var-file="${{ inputs.environment }}.tfvars" \
+            -var="controller_image=${{ needs.build-push.outputs.acr_image }}" \
+            -var="job_image=${{ needs.build-push.outputs.acr_image }}"


### PR DESCRIPTION
## What
GitHub Actions workflow for deploying to Azure Container Apps via Terraform.

## Why
Part of #209 — CI/CD pipeline for building, pushing to ACR, and applying Terraform to provision/update infrastructure.

## Changes
- `.github/workflows/deploy.yml`: Manual workflow_dispatch for dev/staging

## Security
- S3: OIDC federation — no stored Azure credentials in GitHub
- Scoped permissions: `id-token: write`, `contents: read`
- Environment-specific variables and state files

## Stack
Part 8 of Azure Container Apps (#209). Depends on #219. Merge before feat/209-docs.

Closes: n/a (part of #209)