### PR TITLE
fix(infra): use random suffix for globally-unique Key Vault name

### DIFF
--- a/infra/keyvault.tf
+++ b/infra/keyvault.tf
@@ -1,7 +1,14 @@
 data "azurerm_client_config" "current" {}
 
+resource "random_string" "kv_suffix" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
 resource "azurerm_key_vault" "main" {
-  name                = "kv-${replace(var.resource_group_name, "rg-", "")}"
+  # Key Vault names: 3-24 chars, globally unique. Truncate base to fit suffix.
+  name                = "kv-${substr(replace(var.resource_group_name, "rg-", ""), 0, 16)}-${random_string.kv_suffix.result}"
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
   tenant_id           = data.azurerm_client_config.current.tenant_id

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
   }
 
   # S2: Remote encrypted state — see backend.tf


### PR DESCRIPTION
## What

Azure Key Vault names are globally unique. The static name `kv-copilot-dev` collided with an existing vault during initial deployment.

## How

- Add `hashicorp/random` provider (~> 3.6) to `main.tf`
- Add `random_string.kv_suffix` (4-char lowercase alphanumeric) in `keyvault.tf`
- Append suffix to Key Vault name: `kv-copilot-dev-3si0`
- Truncate base to 16 chars to stay within the 24-char KV name limit

## Testing

- `terraform fmt -check` ✅
- `terraform validate` ✅
- `tflint` ✅
- `make lint` ✅
- Successfully applied to Azure subscription — all 23 resources created

## Code Review (GPT-5.3-Codex)

| Severity | Finding | Resolution |
|----------|---------|------------|
| High | Existing deployments may lose KV secrets on name change | N/A — fresh deployment, state already has new name. `random_string` is stable in state. |
| Medium | 24-char KV name limit risk for long RG names | Fixed — added `substr(..., 0, 16)` truncation |

Relates to #209