### PR TITLE
fix(infra): use Redis data access policies instead of RBAC roles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends git && \
 
 RUN pip install --no-cache-dir uv
 
-RUN useradd -m -u 1000 app
+RUN useradd -m -u 1000 app && mkdir -p /home/app/app && chown app:app /home/app/app
 
 USER app
 

--- a/infra/keyvault.tf
+++ b/infra/keyvault.tf
@@ -47,16 +47,20 @@ resource "azurerm_role_assignment" "job_kv" {
   principal_id         = azurerm_user_assigned_identity.job.principal_id
 }
 
-# Controller: Redis data access via Entra ID
-resource "azurerm_role_assignment" "controller_redis" {
-  scope                = azurerm_redis_cache.main.id
-  role_definition_name = "Redis Cache Data Contributor"
-  principal_id         = azurerm_user_assigned_identity.controller.principal_id
+# Controller: Redis data access via Entra ID (data access policy, not RBAC)
+resource "azurerm_redis_cache_access_policy_assignment" "controller_redis" {
+  name               = "controller-data-contributor"
+  redis_cache_id     = azurerm_redis_cache.main.id
+  access_policy_name = "Data Contributor"
+  object_id          = azurerm_user_assigned_identity.controller.principal_id
+  object_id_alias    = azurerm_user_assigned_identity.controller.name
 }
 
-# Job: Redis data access via Entra ID
-resource "azurerm_role_assignment" "job_redis" {
-  scope                = azurerm_redis_cache.main.id
-  role_definition_name = "Redis Cache Data Contributor"
-  principal_id         = azurerm_user_assigned_identity.job.principal_id
+# Job: Redis data access via Entra ID (data access policy, not RBAC)
+resource "azurerm_redis_cache_access_policy_assignment" "job_redis" {
+  name               = "job-data-contributor"
+  redis_cache_id     = azurerm_redis_cache.main.id
+  access_policy_name = "Data Contributor"
+  object_id          = azurerm_user_assigned_identity.job.principal_id
+  object_id_alias    = azurerm_user_assigned_identity.job.name
 }


### PR DESCRIPTION
## What

Fix two issues discovered during `terraform apply`:

1. **Redis RBAC role does not exist**: `Redis Cache Data Contributor` is not a valid Azure RBAC role. Azure Redis uses data access policies (`azurerm_redis_cache_access_policy_assignment`) for data-plane auth, not role assignments.

2. **Dockerfile permission error in ACR build**: `WORKDIR /home/app/app` creates the directory as root in ACR cloud builds. Fixed by explicitly creating and chowning the directory before `USER app`.

## Changes

- **infra/keyvault.tf**: Replace `azurerm_role_assignment` with `azurerm_redis_cache_access_policy_assignment` for both controller and job identities, using built-in `Data Contributor` policy
- **Dockerfile**: Combine `useradd` with `mkdir -p && chown` for workdir

## Testing

- `terraform apply` succeeded — all 6 resources created (environment, controller, job, role assignment, 2 Redis policies)
- Real Docker images built and pushed to ACR via `az acr build`
- `terraform fmt -check && terraform validate` pass

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>