### PR TITLE
fix(redis): use app_kwargs for managed identity in redis-entraid

### DIFF
--- a/src/gitlab_copilot_agent/redis_state.py
+++ b/src/gitlab_copilot_agent/redis_state.py
@@ -167,7 +167,6 @@ def _create_redis_client(
 
     if redis_host:
         try:
-            from azure.identity import DefaultAzureCredential
             from redis_entraid.cred_provider import (
                 create_from_default_azure_credential,
             )
@@ -175,13 +174,13 @@ def _create_redis_client(
             msg = "redis-entraid and azure-identity are required for Entra ID Redis auth"
             raise ImportError(msg) from exc
 
-        kwargs: dict[str, object] = {}
+        app_kwargs: dict[str, object] = {}
         if azure_client_id:
-            kwargs["managed_identity_client_id"] = azure_client_id
+            app_kwargs["managed_identity_client_id"] = azure_client_id
 
         credential_provider = create_from_default_azure_credential(
             ("https://redis.azure.com/.default",),
-            credential=DefaultAzureCredential(**kwargs),
+            app_kwargs=app_kwargs,
         )
         return aioredis.Redis(
             host=redis_host,


### PR DESCRIPTION
## What

Fix `TypeError: create_from_default_azure_credential() got an unexpected keyword argument 'credential'` that caused the controller to crash-loop in Azure Container Apps (exit code 3).

## Root Cause

`redis-entraid` `create_from_default_azure_credential()` creates `DefaultAzureCredential` internally via `app_kwargs`. It does not accept a pre-built credential object. The `managed_identity_client_id` must be passed through `app_kwargs` so the library forwards it to the `DefaultAzureCredential` constructor.

## Changes

- **src/gitlab_copilot_agent/redis_state.py**: Remove unused `azure.identity.DefaultAzureCredential` import. Pass `managed_identity_client_id` via `app_kwargs` instead of `credential` parameter.

## Testing

- `make lint` passes (ruff + mypy)
- `make test` passes (413 tests, 95.81% coverage)
- Verified against `redis-entraid` source: `app_kwargs` is unpacked into `DefaultAzureCredential(**config.app_kwargs)`

Closes #225

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>