### PR TITLE
feat(infra): add Jira support and fix environment drift

### DIFF
--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -32,15 +32,23 @@ resource "azurerm_container_app_environment" "main" {
   infrastructure_subnet_id   = azurerm_subnet.infra.id
 
   tags = var.tags
+
+  lifecycle {
+    ignore_changes = [infrastructure_resource_group_name]
+  }
 }
 
-# S1: Key Vault secret refs shared by controller and job
+# S1: Key Vault secret refs — base set shared by all workloads, plus controller-only
 locals {
-  kv_secrets = {
+  kv_secrets_base = {
     "gitlab-token"    = "gitlab-token"
     "github-token"    = "github-token"
     "copilot-api-key" = "copilot-api-key"
   }
+  kv_secrets_controller = merge(
+    local.kv_secrets_base,
+    var.jira_url != "" ? { "jira-api-token" = "jira-api-token" } : {}
+  )
 }
 
 # --- Controller Container App ---
@@ -120,9 +128,32 @@ resource "azurerm_container_app" "controller" {
         value = azurerm_user_assigned_identity.controller.client_id
       }
 
+      # Jira (non-secret env vars — only set when jira_url is provided)
+      dynamic "env" {
+        for_each = var.jira_url != "" ? [1] : []
+        content {
+          name  = "JIRA_URL"
+          value = var.jira_url
+        }
+      }
+      dynamic "env" {
+        for_each = var.jira_url != "" ? [1] : []
+        content {
+          name  = "JIRA_EMAIL"
+          value = var.jira_email
+        }
+      }
+      dynamic "env" {
+        for_each = var.jira_url != "" ? [1] : []
+        content {
+          name  = "JIRA_PROJECT_MAP"
+          value = var.jira_project_map
+        }
+      }
+
       # S1: Secrets via Key Vault references
       dynamic "env" {
-        for_each = local.kv_secrets
+        for_each = local.kv_secrets_controller
         content {
           name        = upper(replace(env.key, "-", "_"))
           secret_name = env.key
@@ -138,13 +169,15 @@ resource "azurerm_container_app" "controller" {
   }
 
   dynamic "secret" {
-    for_each = local.kv_secrets
+    for_each = local.kv_secrets_controller
     content {
       name                = secret.key
       key_vault_secret_id = "${azurerm_key_vault.main.vault_uri}secrets/${secret.value}"
       identity            = azurerm_user_assigned_identity.controller.id
     }
   }
+
+  depends_on = [null_resource.kv_seed_secrets]
 
   tags = var.tags
 }
@@ -204,7 +237,7 @@ resource "azurerm_container_app_job" "task_runner" {
 
       # S1: Secrets via Key Vault references
       dynamic "env" {
-        for_each = local.kv_secrets
+        for_each = local.kv_secrets_base
         content {
           name        = upper(replace(env.key, "-", "_"))
           secret_name = env.key
@@ -214,13 +247,15 @@ resource "azurerm_container_app_job" "task_runner" {
   }
 
   dynamic "secret" {
-    for_each = local.kv_secrets
+    for_each = local.kv_secrets_base
     content {
       name                = secret.key
       key_vault_secret_id = "${azurerm_key_vault.main.vault_uri}secrets/${secret.value}"
       identity            = azurerm_user_assigned_identity.job.id
     }
   }
+
+  depends_on = [null_resource.kv_seed_secrets]
 
   tags = var.tags
 }

--- a/infra/keyvault.tf
+++ b/infra/keyvault.tf
@@ -14,9 +14,133 @@ resource "azurerm_key_vault" "main" {
   tenant_id           = data.azurerm_client_config.current.tenant_id
   sku_name            = "standard"
 
-  rbac_authorization_enabled = true
+  rbac_authorization_enabled    = true
+  public_network_access_enabled = false
 
   tags = var.tags
+}
+
+# --- KV Private Endpoint (keeps secret traffic on VNet) ---
+
+resource "azurerm_private_dns_zone" "keyvault" {
+  name                = "privatelink.vaultcore.azure.net"
+  resource_group_name = azurerm_resource_group.main.name
+
+  tags = var.tags
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "keyvault" {
+  name                  = "keyvault-vnet-link"
+  resource_group_name   = azurerm_resource_group.main.name
+  private_dns_zone_name = azurerm_private_dns_zone.keyvault.name
+  virtual_network_id    = azurerm_virtual_network.main.id
+}
+
+resource "azurerm_private_endpoint" "keyvault" {
+  name                = "pe-kv-${var.resource_group_name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  subnet_id           = azurerm_subnet.keyvault.id
+
+  private_service_connection {
+    name                           = "keyvault-connection"
+    private_connection_resource_id = azurerm_key_vault.main.id
+    subresource_names              = ["vault"]
+    is_manual_connection           = false
+  }
+
+  private_dns_zone_group {
+    name                 = "keyvault-dns"
+    private_dns_zone_ids = [azurerm_private_dns_zone.keyvault.id]
+  }
+
+  tags = var.tags
+}
+
+# Deployer: Key Vault Secrets Officer (for bootstrap seeding and rotation)
+resource "azurerm_role_assignment" "deployer_kv" {
+  scope                = azurerm_key_vault.main.id
+  role_definition_name = "Key Vault Secrets Officer"
+  principal_id         = data.azurerm_client_config.current.object_id
+}
+
+# --- KV Bootstrap: single-apply chain ---
+# open public access → seed secrets → (apps deploy via depends_on) → close public access
+
+resource "null_resource" "kv_bootstrap_open" {
+  count = var.kv_bootstrap ? 1 : 0
+
+  triggers = {
+    vault_name   = azurerm_key_vault.main.name
+    secrets_hash = sha256(jsonencode(var.kv_bootstrap_secrets))
+  }
+
+  provisioner "local-exec" {
+    command     = <<-EOT
+      az keyvault update --name "$VAULT_NAME" --public-network-access Enabled -o none
+      echo "⏳ Waiting for propagation..."
+      sleep 15
+      echo "✓ KV public access enabled"
+    EOT
+    interpreter = ["bash", "-c"]
+    environment = {
+      VAULT_NAME = azurerm_key_vault.main.name
+    }
+  }
+
+  depends_on = [azurerm_key_vault.main, azurerm_role_assignment.deployer_kv]
+}
+
+resource "null_resource" "kv_seed_secrets" {
+  count = var.kv_bootstrap && length(var.kv_bootstrap_secrets) > 0 ? 1 : 0
+
+  triggers = {
+    vault_name   = azurerm_key_vault.main.name
+    secret_names = join(",", keys(nonsensitive(var.kv_bootstrap_secrets)))
+    secrets_hash = sha256(jsonencode(var.kv_bootstrap_secrets))
+  }
+
+  provisioner "local-exec" {
+    command     = <<-EOT
+      for name in $(echo "$SECRET_NAMES" | tr ',' ' '); do
+        az keyvault secret set --vault-name "$VAULT_NAME" --name "$name" \
+          --value "$(echo "$SECRETS_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['$name'])")" \
+          -o none && echo "✓ $name"
+      done
+    EOT
+    interpreter = ["bash", "-c"]
+    environment = {
+      VAULT_NAME   = azurerm_key_vault.main.name
+      SECRET_NAMES = join(",", keys(nonsensitive(var.kv_bootstrap_secrets)))
+      SECRETS_JSON = jsonencode(var.kv_bootstrap_secrets)
+    }
+  }
+
+  depends_on = [null_resource.kv_bootstrap_open]
+}
+
+# Container Apps depend on kv_seed_secrets (see container-apps.tf).
+# Close public access immediately after seeding — apps use private endpoint.
+resource "null_resource" "kv_bootstrap_close" {
+  count = var.kv_bootstrap ? 1 : 0
+
+  triggers = {
+    vault_name   = azurerm_key_vault.main.name
+    secrets_hash = sha256(jsonencode(var.kv_bootstrap_secrets))
+  }
+
+  provisioner "local-exec" {
+    command     = <<-EOT
+      az keyvault update --name "$VAULT_NAME" --public-network-access Disabled -o none
+      echo "✓ KV public access disabled"
+    EOT
+    interpreter = ["bash", "-c"]
+    environment = {
+      VAULT_NAME = azurerm_key_vault.main.name
+    }
+  }
+
+  depends_on = [null_resource.kv_bootstrap_open, null_resource.kv_seed_secrets]
 }
 
 # S4: Controller identity — ACR pull, Key Vault read (all secrets), Job trigger

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.6"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
   }
 
   # S2: Remote encrypted state — see backend.tf

--- a/infra/networking.tf
+++ b/infra/networking.tf
@@ -35,6 +35,14 @@ resource "azurerm_subnet" "redis" {
   address_prefixes     = [var.redis_subnet_prefix]
 }
 
+# Key Vault private endpoint subnet
+resource "azurerm_subnet" "keyvault" {
+  name                 = "snet-keyvault"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = [var.kv_subnet_prefix]
+}
+
 # --- NSGs ---
 
 resource "azurerm_network_security_group" "infra" {
@@ -66,6 +74,19 @@ resource "azurerm_network_security_group" "infra" {
     destination_port_range     = "6380"
     source_address_prefix      = var.infra_subnet_prefix
     destination_address_prefix = var.redis_subnet_prefix
+  }
+
+  # Allow outbound to Key Vault via private endpoint
+  security_rule {
+    name                       = "AllowKeyVaultOutbound"
+    priority                   = 120
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = var.infra_subnet_prefix
+    destination_address_prefix = var.kv_subnet_prefix
   }
 
   # Deny all other outbound

--- a/infra/variables-apps.tf
+++ b/infra/variables-apps.tf
@@ -20,6 +20,12 @@ variable "redis_subnet_prefix" {
   default     = "10.0.2.0/24"
 }
 
+variable "kv_subnet_prefix" {
+  description = "CIDR for the Key Vault private endpoint subnet"
+  type        = string
+  default     = "10.0.3.0/24"
+}
+
 # --- Redis ---
 
 variable "redis_sku" {
@@ -92,4 +98,39 @@ variable "copilot_model" {
   description = "LLM model name for Copilot sessions"
   type        = string
   default     = "gpt-4"
+}
+
+# --- Jira (optional — leave empty to skip) ---
+
+variable "jira_url" {
+  description = "Jira instance URL (empty to disable Jira integration)"
+  type        = string
+  default     = ""
+}
+
+variable "jira_email" {
+  description = "Jira user email for basic auth"
+  type        = string
+  default     = ""
+}
+
+variable "jira_project_map" {
+  description = "JSON mapping Jira project keys to GitLab project config"
+  type        = string
+  default     = ""
+}
+
+# --- Key Vault Bootstrap ---
+
+variable "kv_bootstrap" {
+  description = "Enable to seed KV secrets in a single apply. Opens public access, seeds secrets, deploys apps, then closes public access."
+  type        = bool
+  default     = false
+}
+
+variable "kv_bootstrap_secrets" {
+  description = "Map of secret-name → value to seed into Key Vault. Only used when kv_bootstrap=true."
+  type        = map(string)
+  default     = {}
+  sensitive   = true
 }


### PR DESCRIPTION
## What

Add Jira integration, KV private endpoint, single-apply bootstrap mode, and Container Apps Environment drift fix.

## Changes

### KV Private Endpoint
- New `snet-keyvault` subnet (10.0.3.0/24)
- Private DNS zone (`privatelink.vaultcore.azure.net`) + VNet link
- Private endpoint for KV data plane traffic
- NSG rule: Container Apps → KV subnet on 443
- `public_network_access_enabled = false` always — apps use private endpoint

### KV Bootstrap (single apply)
- `kv_bootstrap = true` triggers: `open → seed → close` chain via `depends_on`
- `kv_bootstrap_open`: enables public access via `az keyvault update` (deployer needs public access to seed)
- `kv_seed_secrets`: seeds secrets via `az keyvault secret set`
- `kv_bootstrap_close`: disables public access (depends on both open and seed)
- All three share `secrets_hash` trigger — value changes re-run the full cycle
- Container Apps `depends_on` seed to ensure secrets exist before deploy

### Jira Support (optional)
- `jira_url`, `jira_email`, `jira_project_map` variables (default empty)
- Controller-only KV secret for `jira-api-token`
- Split `kv_secrets` into `kv_secrets_base` (shared) and `kv_secrets_controller`

### Drift Fix
- `lifecycle { ignore_changes = [infrastructure_resource_group_name] }` on Container Apps Environment

## Usage

```bash
# Single apply: seeds secrets, deploys apps, locks down KV
terraform apply -var kv_bootstrap=true \
  -var 'kv_bootstrap_secrets={"gitlab-token":"...","github-token":"...","copilot-api-key":"...","jira-api-token":"..."}' \
  -var-file=dev.tfvars

# Subsequent applies (no bootstrap needed)
terraform apply -var-file=dev.tfvars
```

## Diff: 228 lines (4 files) — all Terraform

## Code Review

Cross-model review (GPT-5.3-Codex). Findings addressed:
- **High**: `close` could run before `open` when secrets empty — added `depends_on [open, seed]` ✅
- **High**: open/close not re-triggered on secret changes — added `secrets_hash` to all three triggers ✅

## Testing

- `terraform fmt -check` ✅
- `terraform validate` ✅
- `make lint` (Python) ✅

Closes #209