### PR TITLE
fix(infra): add explicit OTLP env vars and fix managed agent destination config

### DIFF
--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -40,16 +40,29 @@ resource "azurerm_container_app_environment" "main" {
 
 # Managed OTLP agent — forwards traces/metrics/logs to App Insights.
 # Not yet supported by azurerm; use azapi to patch the environment.
+# Must include logAnalyticsConfiguration to avoid API validation error on PATCH.
 resource "azapi_update_resource" "cae_otlp" {
   type        = "Microsoft.App/managedEnvironments@2024-08-02-preview"
   resource_id = azurerm_container_app_environment.main.id
 
   body = {
     properties = {
+      appLogsConfiguration = {
+        destination = "log-analytics"
+        logAnalyticsConfiguration = {
+          customerId = azurerm_log_analytics_workspace.main.workspace_id
+          sharedKey  = azurerm_log_analytics_workspace.main.primary_shared_key
+        }
+      }
       appInsightsConfiguration = {
         connectionString = azurerm_application_insights.main.connection_string
       }
       openTelemetryConfiguration = {
+        destinationsConfiguration = {
+          appInsightsConfiguration = {
+            connectionString = azurerm_application_insights.main.connection_string
+          }
+        }
         tracesConfiguration = {
           destinations = ["appInsights"]
         }
@@ -149,6 +162,14 @@ resource "azurerm_container_app" "controller" {
       env {
         name  = "AZURE_CLIENT_ID"
         value = azurerm_user_assigned_identity.controller.client_id
+      }
+      env {
+        name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
+        value = "http://localhost:4318"
+      }
+      env {
+        name  = "OTEL_EXPORTER_OTLP_PROTOCOL"
+        value = "http/protobuf"
       }
       env {
         name  = "OTEL_SERVICE_NAME"
@@ -264,6 +285,14 @@ resource "azurerm_container_app_job" "task_runner" {
       env {
         name  = "AZURE_CLIENT_ID"
         value = azurerm_user_assigned_identity.job.client_id
+      }
+      env {
+        name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
+        value = "http://localhost:4318"
+      }
+      env {
+        name  = "OTEL_EXPORTER_OTLP_PROTOCOL"
+        value = "http/protobuf"
       }
       env {
         name  = "OTEL_SERVICE_NAME"


### PR DESCRIPTION
## What

Fixes the managed OTLP agent configuration discovered during deployment testing of PR #230.

## Problem

1. **No OTLP data flowing**: The managed OTLP agent does NOT auto-inject `OTEL_EXPORTER_OTLP_ENDPOINT` for apps using their own OTel SDK — only for managed auto-instrumentation (.NET, Java). Our Python app was starting without the OTLP endpoint configured.
2. **`destinationsConfiguration` null**: The App Insights connection string was only set at `appInsightsConfiguration` (top level), but the managed agent expects it under `openTelemetryConfiguration.destinationsConfiguration.appInsightsConfiguration`.
3. **API validation error**: PATCH to the managed environment fails without `appLogsConfiguration` in the body.

## Changes

- Add `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318` and `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` to both controller and task runner container apps
- Set App Insights connection string under `destinationsConfiguration` (nested in openTelemetryConfiguration)
- Include `appLogsConfiguration` in the azapi PATCH body to avoid validation errors

## Testing

- Terraform validate ✅
- Applied to dev environment
- Controller healthy with 200s on /health
- OTLP HTTP exporters active (attempting to send to localhost:4318)
- Managed agent sidecar deployment pending environment update propagation
