### PR TITLE
fix(infra): remove explicit OTLP endpoint override that blocked managed agent

### DIFF
--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -164,14 +164,6 @@ resource "azurerm_container_app" "controller" {
         value = azurerm_user_assigned_identity.controller.client_id
       }
       env {
-        name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
-        value = "http://localhost:4318"
-      }
-      env {
-        name  = "OTEL_EXPORTER_OTLP_PROTOCOL"
-        value = "http/protobuf"
-      }
-      env {
         name  = "OTEL_SERVICE_NAME"
         value = "controller"
       }
@@ -285,14 +277,6 @@ resource "azurerm_container_app_job" "task_runner" {
       env {
         name  = "AZURE_CLIENT_ID"
         value = azurerm_user_assigned_identity.job.client_id
-      }
-      env {
-        name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
-        value = "http://localhost:4318"
-      }
-      env {
-        name  = "OTEL_EXPORTER_OTLP_PROTOCOL"
-        value = "http/protobuf"
       }
       env {
         name  = "OTEL_SERVICE_NAME"


### PR DESCRIPTION
## What

Removes the explicit `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_PROTOCOL` env vars from both container apps that were added in PR #232.

## Why

The managed OTLP agent in Azure Container Apps **auto-injects** `OTEL_EXPORTER_OTLP_ENDPOINT` pointing to the internal collector service (`k8se-otel.k8se-apps.svc.cluster.local:4317`, gRPC). The explicit values added in PR #232 (`localhost:4318`, HTTP) overrode this, causing `Connection refused` errors and flooding logs with stack traces.

Evidence from App Insights — revision 0000004 (without explicit env vars) was working:
```
otel_collector_connected → endpoint: http://k8se-otel.k8se-apps.svc.cluster.local:4317
gitlab_poller_started → interval: 30, projects: [79793676]
service started → gitlab_url: https://gitlab.com
```

Revision 0000005 (with explicit env vars from PR #232) broke OTLP connectivity.

## Changes

- Remove `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_PROTOCOL` from controller container app
- Remove `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_PROTOCOL` from task runner job
- Keep `OTEL_SERVICE_NAME` and `DEPLOYMENT_ENV` (app-level config, not collector routing)

## Non-ACA deployments

Unaffected. The Python code treats `OTEL_EXPORTER_OTLP_ENDPOINT` as the trigger — if unset, telemetry skips OTLP and logs to stdout only. K8s/local deployments set this via their own manifests.

## Testing

- `terraform fmt -check` ✅
- `terraform validate` ✅
- `tflint` ✅
- GPT-5.3-Codex code review: no issues

## Code Review

| Severity | Finding | Resolution |
|----------|---------|------------|
| — | No issues found | — |

Relates to #209