### PR TITLE
fix(aca): pass image in job execution template override

### DIFF
--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -152,6 +152,10 @@ resource "azurerm_container_app" "controller" {
         value = "job-task-runner"
       }
       env {
+        name  = "ACA_JOB_IMAGE"
+        value = var.job_image
+      }
+      env {
         name  = "REDIS_HOST"
         value = azurerm_redis_cache.main.hostname
       }

--- a/src/gitlab_copilot_agent/aca_executor.py
+++ b/src/gitlab_copilot_agent/aca_executor.py
@@ -110,6 +110,7 @@ class ContainerAppsTaskExecutor:
             containers=[
                 JobExecutionContainer(
                     name="task",
+                    image=self._settings.aca_job_image,
                     env=[EnvironmentVar(name=e["name"], value=e["value"]) for e in env_overrides],
                 )
             ],

--- a/src/gitlab_copilot_agent/config.py
+++ b/src/gitlab_copilot_agent/config.py
@@ -129,6 +129,9 @@ class Settings(BaseSettings):
     aca_job_name: str = Field(
         default="", description="Name of the Azure Container Apps Job resource"
     )
+    aca_job_image: str = Field(
+        default="", description="Docker image for Container Apps Job executions"
+    )
     aca_job_timeout: int = Field(
         default=600, description="Container Apps Job execution timeout in seconds"
     )
@@ -274,6 +277,7 @@ class Settings(BaseSettings):
                     ("ACA_SUBSCRIPTION_ID", self.aca_subscription_id),
                     ("ACA_RESOURCE_GROUP", self.aca_resource_group),
                     ("ACA_JOB_NAME", self.aca_job_name),
+                    ("ACA_JOB_IMAGE", self.aca_job_image),
                 ]
                 if not val
             ]

--- a/tests/test_aca_executor.py
+++ b/tests/test_aca_executor.py
@@ -31,6 +31,7 @@ REDIS_URL = "rediss://test-redis.redis.cache.windows.net:6380"
 ACA_SUBSCRIPTION_ID = "00000000-0000-0000-0000-000000000000"
 ACA_RESOURCE_GROUP = "rg-copilot-test"
 ACA_JOB_NAME = "copilot-job"
+ACA_JOB_IMAGE = "myregistry.azurecr.io/copilot-agent:test"
 ACA_JOB_TIMEOUT = 3  # short for tests
 EXECUTION_NAME = "copilot-job-exec-abc123"
 CACHED_RESULT = "cached review output"
@@ -47,6 +48,7 @@ def _make_settings(**overrides: Any) -> Any:
         "aca_subscription_id": ACA_SUBSCRIPTION_ID,
         "aca_resource_group": ACA_RESOURCE_GROUP,
         "aca_job_name": ACA_JOB_NAME,
+        "aca_job_image": ACA_JOB_IMAGE,
         "aca_job_timeout": ACA_JOB_TIMEOUT,
     }
     return make_settings(**(defaults | overrides))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -136,6 +136,7 @@ def test_local_executor_does_not_require_k8s_names() -> None:
 ACA_SUBSCRIPTION_ID = "00000000-0000-0000-0000-000000000000"
 ACA_RESOURCE_GROUP = "rg-test"
 ACA_JOB_NAME = "copilot-job"
+ACA_JOB_IMAGE = "myregistry.azurecr.io/copilot-agent:latest"
 ACA_REDIS_URL = "rediss://test-redis.redis.cache.windows.net:6380"
 
 
@@ -143,6 +144,18 @@ def test_aca_executor_requires_azure_settings() -> None:
     """task_executor=container_apps fails without required Azure settings."""
     with pytest.raises(ValidationError, match="ACA_SUBSCRIPTION_ID"):
         make_settings(task_executor="container_apps", redis_url=ACA_REDIS_URL)
+
+
+def test_aca_executor_requires_job_image() -> None:
+    """task_executor=container_apps fails without ACA_JOB_IMAGE."""
+    with pytest.raises(ValidationError, match="ACA_JOB_IMAGE"):
+        make_settings(
+            task_executor="container_apps",
+            aca_subscription_id=ACA_SUBSCRIPTION_ID,
+            aca_resource_group=ACA_RESOURCE_GROUP,
+            aca_job_name=ACA_JOB_NAME,
+            redis_url=ACA_REDIS_URL,
+        )
 
 
 def test_aca_executor_requires_redis() -> None:
@@ -153,6 +166,7 @@ def test_aca_executor_requires_redis() -> None:
             aca_subscription_id=ACA_SUBSCRIPTION_ID,
             aca_resource_group=ACA_RESOURCE_GROUP,
             aca_job_name=ACA_JOB_NAME,
+            aca_job_image=ACA_JOB_IMAGE,
         )
 
 
@@ -163,10 +177,12 @@ def test_aca_executor_accepts_valid_config() -> None:
         aca_subscription_id=ACA_SUBSCRIPTION_ID,
         aca_resource_group=ACA_RESOURCE_GROUP,
         aca_job_name=ACA_JOB_NAME,
+        aca_job_image=ACA_JOB_IMAGE,
         redis_url=ACA_REDIS_URL,
         state_backend="redis",
     )
     assert settings.aca_subscription_id == ACA_SUBSCRIPTION_ID
+    assert settings.aca_job_image == ACA_JOB_IMAGE
     assert settings.aca_job_timeout == 600
 
 
@@ -177,6 +193,7 @@ def test_aca_executor_accepts_redis_host() -> None:
         aca_subscription_id=ACA_SUBSCRIPTION_ID,
         aca_resource_group=ACA_RESOURCE_GROUP,
         aca_job_name=ACA_JOB_NAME,
+        aca_job_image=ACA_JOB_IMAGE,
         redis_host="test-redis.redis.cache.windows.net",
         state_backend="redis",
     )


### PR DESCRIPTION
## What

Fix ACA Job execution failing with `ContainerAppImageRequired` error. Azure requires the `image` field on per-execution container overrides even when the Job template already defines it.

## Why

Discovered during live testing: Jira poller finds issue → clones repo → creates branch → starts ACA Job → Azure rejects with missing image error. The full Jira→GitLab pipeline works except the job dispatch.

## How

- Add `aca_job_image` config field (required when `task_executor=container_apps`)
- Pass `image=self._settings.aca_job_image` to `JobExecutionContainer`
- Add `ACA_JOB_IMAGE` env var to controller in Terraform (from `var.job_image`)
- Add validation test for missing image config

## Testing

- `make lint` ✅ (ruff check, ruff format, mypy --strict)
- `make test` ✅ (415 passed, 95.61% coverage)
- Cross-model code review (GPT-5.3-Codex): no issues

## E2E Validation

The error was caught from live App Insights traces:
```
exceptions | ContainerAppImageRequired: Container with name 'task' must have an 'Image' property specified.
```

Closes #234