### PR TITLE
fix(aca): use Redis dispatch queue instead of per-execution template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ demo.env
 *.tfvars
 !*.tfvars.example
 .terraform.lock.hcl
+infra/tfplan

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN uv sync --no-dev --extra kubernetes --extra azure --frozen && \
     find .venv -name "copilot" -path "*/bin/copilot" -exec chmod +x {} \;
 
 COPY --chown=app:app src/ src/
+RUN uv sync --no-dev --extra kubernetes --extra azure --frozen
+
 COPY --chown=app:app scripts/entrypoint.sh /opt/entrypoint.sh
 EXPOSE 8000
 ENTRYPOINT ["/opt/entrypoint.sh"]

--- a/src/gitlab_copilot_agent/aca_executor.py
+++ b/src/gitlab_copilot_agent/aca_executor.py
@@ -11,6 +11,8 @@ import structlog
 from gitlab_copilot_agent.task_executor import CodingResult, ReviewResult, TaskResult
 
 if TYPE_CHECKING:
+    from azure.mgmt.appcontainers import ContainerAppsAPIClient
+
     from gitlab_copilot_agent.concurrency import ResultStore
     from gitlab_copilot_agent.config import Settings
     from gitlab_copilot_agent.task_executor import TaskParams
@@ -20,23 +22,25 @@ log = structlog.get_logger()
 _JOB_POLL_INTERVAL = 5  # seconds; ACA API is slower than k8s, use longer interval
 _EXECUTION_LOCK_TTL = 900  # sentinel TTL to prevent duplicate executions
 _EXECUTION_LOCK_PREFIX = "aca_exec:"
+_DISPATCH_QUEUE = "task_dispatch_queue"
 
 
-def _build_env_overrides(task: TaskParams) -> list[dict[str, str]]:
-    """Build per-execution env var overrides.
+def _build_dispatch_payload(task: TaskParams) -> str:
+    """Serialize task params for Redis dispatch queue.
 
-    Only non-sensitive task params are passed per-execution (S1: secrets are
-    pre-configured on the Job template as Key Vault references).
+    Only non-sensitive params are stored (S1: secrets live on the Job template
+    as Key Vault references and are never passed through Redis).
     """
-    return [
-        {"name": "TASK_TYPE", "value": task.task_type},
-        {"name": "TASK_ID", "value": task.task_id},
-        {"name": "REPO_URL", "value": task.repo_url},
-        {"name": "BRANCH", "value": task.branch},
-        {"name": "SYSTEM_PROMPT", "value": task.system_prompt},
-        {"name": "USER_PROMPT", "value": task.user_prompt},
-        {"name": "TASK_PAYLOAD", "value": json.dumps({"prompt": task.user_prompt})},
-    ]
+    return json.dumps(
+        {
+            "task_type": task.task_type,
+            "task_id": task.task_id,
+            "repo_url": task.repo_url,
+            "branch": task.branch,
+            "system_prompt": task.system_prompt,
+            "user_prompt": task.user_prompt,
+        }
+    )
 
 
 def _parse_result(raw: str, task_type: str) -> TaskResult:
@@ -57,9 +61,9 @@ def _parse_result(raw: str, task_type: str) -> TaskResult:
 class ContainerAppsTaskExecutor:
     """Dispatches tasks as Azure Container Apps Job executions.
 
-    Secrets (GITLAB_TOKEN, GITHUB_TOKEN, etc.) are pre-configured on the Job
-    template as Key Vault secret references. Only non-sensitive task params
-    are passed per-execution to avoid exposure in Azure Activity Logs (S1).
+    Task params are dispatched via a Redis queue. The job is started with no
+    per-execution template override (ACA replaces rather than merges), so the
+    base template's command, env vars, and Key Vault secret refs are preserved.
     """
 
     def __init__(self, settings: Settings, result_store: ResultStore) -> None:
@@ -80,40 +84,41 @@ class ContainerAppsTaskExecutor:
             log.info("aca_execution_already_started", task_id=task.task_id)
             return await self._wait_for_result(existing, task)
 
-        execution_name = await asyncio.to_thread(self._start_execution, task)
+        # Write task params to Redis so the job can read them on startup.
+        # ACA begin_start(template=...) does a full REPLACE (not merge),
+        # so we pass no template and let the base job template run as-is.
+        payload = _build_dispatch_payload(task)
+        await self._store.push_task(_DISPATCH_QUEUE, payload)
+
+        try:
+            execution_name = await asyncio.to_thread(self._start_execution, task)
+        except Exception:
+            # Compensating cleanup: remove the specific queued payload on failure
+            await self._store.remove_task(_DISPATCH_QUEUE, payload)
+            raise
+
         await self._store.set(lock_key, execution_name, ttl=_EXECUTION_LOCK_TTL)
         return await self._wait_for_result(execution_name, task)
 
-    def _create_client(self) -> object:
+    def _create_client(self) -> ContainerAppsAPIClient:
         """Create a fresh Azure Container Apps management client."""
         from azure.identity import DefaultAzureCredential
-        from azure.mgmt.appcontainers import ContainerAppsAPIClient
+        from azure.mgmt.appcontainers import ContainerAppsAPIClient as _Client
 
         credential = DefaultAzureCredential()
-        return ContainerAppsAPIClient(
+        return _Client(
             credential=credential,
             subscription_id=self._settings.aca_subscription_id,
         )
 
     def _start_execution(self, task: TaskParams) -> str:
-        """Start a Container Apps Job execution (synchronous, called via to_thread)."""
-        from azure.mgmt.appcontainers.models import (
-            EnvironmentVar,
-            JobExecutionContainer,
-            JobExecutionTemplate,
-        )
+        """Start a Container Apps Job execution (synchronous, called via to_thread).
 
+        No per-execution template is passed — the base job template (with KV
+        secret refs, command, and base env vars) is used as-is. Task params
+        are dispatched via Redis instead.
+        """
         client = self._create_client()
-        env_overrides = _build_env_overrides(task)
-
-        template = JobExecutionTemplate(
-            containers=[
-                JobExecutionContainer(
-                    name="task",
-                    env=[EnvironmentVar(name=e["name"], value=e["value"]) for e in env_overrides],
-                )
-            ],
-        )
 
         bound_log = log.bind(
             task_id=task.task_id,
@@ -122,26 +127,25 @@ class ContainerAppsTaskExecutor:
         )
         bound_log.info("aca_job_starting")
 
-        poller = client.jobs.begin_start(  # type: ignore[attr-defined]
+        poller = client.jobs.begin_start(
             resource_group_name=self._settings.aca_resource_group,
             job_name=self._settings.aca_job_name,
-            template=template,
         )
         result = poller.result()
-        execution_name: str = result.name
+        execution_name = str(result.name or "unknown")
         bound_log.info("aca_job_started", execution_name=execution_name)
         return execution_name
 
     def _get_execution_status(self, execution_name: str) -> str:
         """Read execution status (synchronous, called via to_thread)."""
         client = self._create_client()
-        execution = client.jobs.get_execution(  # type: ignore[attr-defined]
+        for execution in client.jobs_executions.list(
             resource_group_name=self._settings.aca_resource_group,
             job_name=self._settings.aca_job_name,
-            job_execution_name=execution_name,
-        )
-        status: str = execution.properties.status if execution.properties else "Unknown"
-        return status
+        ):
+            if execution.name == execution_name:
+                return str(execution.status or "Unknown")
+        return "Unknown"
 
     async def _wait_for_result(self, execution_name: str, task: TaskParams) -> TaskResult:
         """Poll execution status and read result from Redis."""

--- a/src/gitlab_copilot_agent/concurrency.py
+++ b/src/gitlab_copilot_agent/concurrency.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from collections import OrderedDict
 from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
@@ -41,6 +42,9 @@ class ResultStore(Protocol):
 
     async def get(self, key: str) -> str | None: ...
     async def set(self, key: str, value: str, ttl: int = 3600) -> None: ...
+    async def push_task(self, queue: str, payload: str) -> None: ...
+    async def pop_task(self, queue: str) -> str | None: ...
+    async def remove_task(self, queue: str, payload: str) -> None: ...
 
     async def aclose(self) -> None: ...
 
@@ -50,6 +54,7 @@ class MemoryResultStore:
 
     def __init__(self) -> None:
         self._data: dict[str, str] = {}
+        self._queues: dict[str, list[str]] = {}
 
     async def get(self, key: str) -> str | None:
         return self._data.get(key)
@@ -57,8 +62,21 @@ class MemoryResultStore:
     async def set(self, key: str, value: str, ttl: int = 3600) -> None:
         self._data[key] = value
 
+    async def push_task(self, queue: str, payload: str) -> None:
+        self._queues.setdefault(queue, []).append(payload)
+
+    async def pop_task(self, queue: str) -> str | None:
+        items = self._queues.get(queue, [])
+        return items.pop(0) if items else None
+
+    async def remove_task(self, queue: str, payload: str) -> None:
+        items = self._queues.get(queue, [])
+        with contextlib.suppress(ValueError):
+            items.remove(payload)
+
     async def aclose(self) -> None:
         self._data.clear()
+        self._queues.clear()
 
 
 class MemoryLock:

--- a/src/gitlab_copilot_agent/config.py
+++ b/src/gitlab_copilot_agent/config.py
@@ -285,3 +285,63 @@ class Settings(BaseSettings):
                     "(used for result passback from job executions)"
                 )
         return self
+
+
+class TaskRunnerSettings(BaseSettings):
+    """Minimal settings for the task runner job.
+
+    Unlike the full ``Settings``, this has no controller-specific validations
+    (webhook secret, polling projects, k8s/ACA executor config).  The task
+    runner only needs GitLab + Copilot credentials and prompt configuration.
+    """
+
+    model_config = {"env_prefix": ""}
+
+    # GitLab
+    gitlab_url: str = Field(description="GitLab instance URL")
+    gitlab_token: str = Field(description="GitLab API private token")
+
+    # Copilot / LLM
+    copilot_model: str = Field(default="gpt-4", description="Model to use")
+    copilot_provider_type: str | None = Field(default=None, description="BYOK provider type")
+    copilot_provider_base_url: str | None = Field(default=None, description="BYOK provider URL")
+    copilot_provider_api_key: str | None = Field(default=None, description="BYOK provider API key")
+    github_token: str | None = Field(default=None, description="GitHub token for Copilot auth")
+
+    # System prompts
+    system_prompt: str | None = Field(default=None, description="Global base prompt")
+    system_prompt_suffix: str | None = Field(default=None, description="Appended to global base")
+    coding_system_prompt: str | None = Field(default=None, description="Coding prompt override")
+    coding_system_prompt_suffix: str | None = Field(default=None, description="Coding suffix")
+    review_system_prompt: str | None = Field(default=None, description="Review prompt override")
+    review_system_prompt_suffix: str | None = Field(default=None, description="Review suffix")
+    mr_comment_system_prompt: str | None = Field(default=None, description="MR comment override")
+    mr_comment_system_prompt_suffix: str | None = Field(
+        default=None, description="MR comment suffix"
+    )
+
+    # Runtime
+    clone_dir: str | None = Field(default=None, description="Base directory for repo clones")
+    log_level: str = Field(default="info", description="Log level")
+
+    # Redis (for result storage)
+    state_backend: Literal["memory", "redis"] = Field(
+        default="memory", description="State backend"
+    )
+    redis_url: str | None = Field(default=None, description="Redis connection string")
+    redis_host: str | None = Field(default=None, description="Redis hostname for Entra ID auth")
+    redis_port: int = Field(default=6380, description="Redis TLS port")
+    azure_client_id: str | None = Field(default=None, description="Managed identity client ID")
+
+    @property
+    def redis_configured(self) -> bool:
+        """True when Redis connectivity is configured."""
+        return bool(self.redis_url or self.redis_host)
+
+    @model_validator(mode="after")
+    def _check_auth(self) -> "TaskRunnerSettings":
+        if not self.github_token and not self.copilot_provider_type:
+            raise ValueError(
+                "No LLM authentication configured. Set GITHUB_TOKEN or COPILOT_PROVIDER_TYPE."
+            )
+        return self

--- a/src/gitlab_copilot_agent/copilot_session.py
+++ b/src/gitlab_copilot_agent/copilot_session.py
@@ -15,7 +15,7 @@ from copilot.types import (
     SessionConfig,
 )
 
-from gitlab_copilot_agent.config import Settings
+from gitlab_copilot_agent.config import Settings, TaskRunnerSettings
 from gitlab_copilot_agent.metrics import (
     copilot_session_duration,
 )
@@ -43,7 +43,7 @@ def build_sdk_env(github_token: str | None) -> dict[str, str]:
 
 
 async def run_copilot_session(
-    settings: Settings,
+    settings: Settings | TaskRunnerSettings,
     repo_path: str,
     system_prompt: str,
     user_prompt: str,

--- a/src/gitlab_copilot_agent/prompt_defaults.py
+++ b/src/gitlab_copilot_agent/prompt_defaults.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
-    from gitlab_copilot_agent.config import Settings
+    from gitlab_copilot_agent.config import Settings, TaskRunnerSettings
 
 PromptType = Literal["coding", "review", "mr_comment"]
 
@@ -130,7 +130,7 @@ _SUFFIX_FIELDS: dict[PromptType, str] = {
 }
 
 
-def get_prompt(settings: Settings, prompt_type: PromptType) -> str:
+def get_prompt(settings: Settings | TaskRunnerSettings, prompt_type: PromptType) -> str:
     """Resolve the effective system prompt for *prompt_type*.
 
     Resolution:

--- a/src/gitlab_copilot_agent/redis_state.py
+++ b/src/gitlab_copilot_agent/redis_state.py
@@ -147,6 +147,31 @@ class RedisResultStore:
         except (RedisConnectionError, RedisTimeoutError, OSError):
             log.warning("redis_result_unreachable", op="set", key=key)
 
+    async def push_task(self, queue: str, payload: str) -> None:
+        """Push a task dispatch payload onto a Redis list (LPUSH).
+
+        Raises on failure — caller must not start a job without a queued payload.
+        """
+        await self._client.lpush(f"{_RESULT_PREFIX}{queue}", payload)  # type: ignore[misc]
+
+    async def pop_task(self, queue: str) -> str | None:
+        """Pop a task dispatch payload from a Redis list (RPOP — FIFO)."""
+        try:
+            val = await self._client.rpop(f"{_RESULT_PREFIX}{queue}")  # type: ignore[misc]
+        except (RedisConnectionError, RedisTimeoutError, OSError):
+            log.warning("redis_result_unreachable", op="pop_task", queue=queue)
+            return None
+        if val is None:
+            return None
+        return val.decode() if isinstance(val, bytes) else str(val)
+
+    async def remove_task(self, queue: str, payload: str) -> None:
+        """Remove a specific payload from a Redis list (LREM)."""
+        try:
+            await self._client.lrem(f"{_RESULT_PREFIX}{queue}", 1, payload)  # type: ignore[misc]
+        except (RedisConnectionError, RedisTimeoutError, OSError):
+            log.warning("redis_result_unreachable", op="remove_task", queue=queue)
+
     async def aclose(self) -> None:
         await self._client.aclose()
 

--- a/src/gitlab_copilot_agent/task_runner.py
+++ b/src/gitlab_copilot_agent/task_runner.py
@@ -11,7 +11,7 @@ from urllib.parse import ParseResult, urlparse
 import structlog
 
 from gitlab_copilot_agent.coding_engine import parse_agent_output
-from gitlab_copilot_agent.config import Settings
+from gitlab_copilot_agent.config import TaskRunnerSettings
 from gitlab_copilot_agent.copilot_session import run_copilot_session
 from gitlab_copilot_agent.git_operations import (
     MAX_PATCH_SIZE,
@@ -31,6 +31,7 @@ ENV_REDIS_PORT = "REDIS_PORT"
 ENV_AZURE_CLIENT_ID = "AZURE_CLIENT_ID"
 VALID_TASK_TYPES: frozenset[str] = frozenset({"review", "coding", "echo"})
 _RESULT_TTL = 3600  # 1 hour
+_DISPATCH_QUEUE = "task_dispatch_queue"
 
 _RETRY_PROMPT = (
     "Your response did not include the required JSON output block. "
@@ -66,6 +67,40 @@ async def _store_result(task_id: str, result: str) -> None:
     )
     try:
         await store.set(task_id, result, ttl=_RESULT_TTL)
+    finally:
+        await store.aclose()
+
+
+async def _load_dispatch_params() -> dict[str, str] | None:
+    """Try to load task params from the Redis dispatch queue.
+
+    The queue stores full JSON payloads (atomic pop = data retrieval).
+    Returns a dict with task_type, task_id, repo_url, branch, system_prompt,
+    user_prompt — or None if no dispatched task is available.
+    """
+    redis_url = os.environ.get(ENV_REDIS_URL, "").strip()
+    redis_host = os.environ.get(ENV_REDIS_HOST, "").strip()
+    if not redis_url and not redis_host:
+        return None
+    from gitlab_copilot_agent.redis_state import create_result_store
+
+    store = create_result_store(
+        "redis",
+        redis_url=redis_url or None,
+        redis_host=redis_host or None,
+        redis_port=int(os.environ.get(ENV_REDIS_PORT, "6380")),
+        azure_client_id=os.environ.get(ENV_AZURE_CLIENT_ID),
+    )
+    try:
+        raw = await store.pop_task(_DISPATCH_QUEUE)
+        if raw is None:
+            return None
+        params: dict[str, str] = json.loads(raw)
+        await log.ainfo("dispatch_params_loaded", task_id=params.get("task_id"))
+        return params
+    except Exception:
+        await log.awarning("dispatch_load_failed", exc_info=True)
+        return None
     finally:
         await store.aclose()
 
@@ -159,22 +194,32 @@ async def _run_git_simple(repo_path: Path, *args: str) -> str:
 
 
 async def run_task() -> int:
-    try:
-        task_type = _get_required_env(ENV_TASK_TYPE)
-        task_id = _get_required_env(ENV_TASK_ID)
-        repo_url = _get_required_env(ENV_REPO_URL)
-        branch = _get_required_env(ENV_BRANCH)
-        payload_raw = _get_required_env(ENV_TASK_PAYLOAD)
-    except RuntimeError:
-        await log.aerror("missing_env_var", exc_info=True)
-        return 1
+    # Try Redis dispatch queue first (ACA executor), fall back to env vars (k8s)
+    params = await _load_dispatch_params()
+    if params is not None:
+        task_type = params["task_type"]
+        task_id = params["task_id"]
+        repo_url = params["repo_url"]
+        branch = params["branch"]
+        user_prompt = params["user_prompt"]
+        payload_raw = json.dumps({"prompt": user_prompt})
+    else:
+        try:
+            task_type = _get_required_env(ENV_TASK_TYPE)
+            task_id = _get_required_env(ENV_TASK_ID)
+            repo_url = _get_required_env(ENV_REPO_URL)
+            branch = _get_required_env(ENV_BRANCH)
+            payload_raw = _get_required_env(ENV_TASK_PAYLOAD)
+            user_prompt = _parse_task_payload(payload_raw).get("prompt", payload_raw)
+        except RuntimeError:
+            await log.aerror("missing_env_var", exc_info=True)
+            return 1
     bound_log = log.bind(task_id=task_id, task_type=task_type)
     if task_type not in VALID_TASK_TYPES:
         await bound_log.aerror("invalid_task_type", valid=sorted(VALID_TASK_TYPES))
         return 1
     if task_type == "echo":
         try:
-            user_prompt = _parse_task_payload(payload_raw).get("prompt", payload_raw)
             result = json.dumps({"echo": user_prompt, "task_id": task_id})
             await _store_result(task_id, result)
             await bound_log.ainfo("echo_complete")
@@ -182,10 +227,9 @@ async def run_task() -> int:
         except Exception:
             await bound_log.aerror("echo_failed", exc_info=True)
             return 1
-    settings = Settings()
+    settings = TaskRunnerSettings()
     _validate_repo_url(repo_url, settings.gitlab_url)
     await bound_log.ainfo("task_start", repo=_sanitize_url(repo_url), branch=branch)
-    user_prompt = _parse_task_payload(payload_raw).get("prompt", payload_raw)
     repo_path = await git_clone(
         repo_url, branch, settings.gitlab_token, clone_dir=settings.clone_dir
     )

--- a/tests/test_aca_executor.py
+++ b/tests/test_aca_executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import sys
 import types
@@ -74,7 +75,6 @@ def _install_azure_stub() -> tuple[MagicMock, MagicMock]:
     azure_mod = types.ModuleType("azure")
     mgmt_mod = types.ModuleType("azure.mgmt")
     aca_mod = types.ModuleType("azure.mgmt.appcontainers")
-    models_mod = types.ModuleType("azure.mgmt.appcontainers.models")
 
     credential_mock = MagicMock(name="DefaultAzureCredential")
     identity_mod.DefaultAzureCredential = credential_mock  # type: ignore[attr-defined]
@@ -83,21 +83,10 @@ def _install_azure_stub() -> tuple[MagicMock, MagicMock]:
     client_class_mock = MagicMock(return_value=client_mock)
     aca_mod.ContainerAppsAPIClient = client_class_mock  # type: ignore[attr-defined]
 
-    # Model stubs that store kwargs
-    class _Passthrough:
-        def __init__(self, **kwargs: Any) -> None:
-            for k, v in kwargs.items():
-                setattr(self, k, v)
-
-    models_mod.JobExecutionTemplate = _Passthrough  # type: ignore[attr-defined]
-    models_mod.JobExecutionContainer = _Passthrough  # type: ignore[attr-defined]
-    models_mod.EnvironmentVar = _Passthrough  # type: ignore[attr-defined]
-
     sys.modules["azure"] = azure_mod
     sys.modules["azure.identity"] = identity_mod
     sys.modules["azure.mgmt"] = mgmt_mod
     sys.modules["azure.mgmt.appcontainers"] = aca_mod
-    sys.modules["azure.mgmt.appcontainers.models"] = models_mod
 
     return client_mock, client_mock.jobs
 
@@ -125,6 +114,11 @@ def jobs_mock(client_mock: MagicMock) -> MagicMock:
 
 
 @pytest.fixture
+def jobs_executions_mock(client_mock: MagicMock) -> MagicMock:
+    return client_mock.jobs_executions
+
+
+@pytest.fixture
 def fake_result_store() -> MagicMock:
     store = MagicMock()
     store.get = MagicMock(return_value=asyncio.coroutine(lambda *a: None)())
@@ -136,12 +130,25 @@ class MemoryResultStore:
 
     def __init__(self) -> None:
         self._data: dict[str, str] = {}
+        self._queues: dict[str, list[str]] = {}
 
     async def get(self, key: str) -> str | None:
         return self._data.get(key)
 
     async def set(self, key: str, value: str, ttl: int = 0) -> None:
         self._data[key] = value
+
+    async def push_task(self, queue: str, payload: str) -> None:
+        self._queues.setdefault(queue, []).append(payload)
+
+    async def pop_task(self, queue: str) -> str | None:
+        items = self._queues.get(queue, [])
+        return items.pop(0) if items else None
+
+    async def remove_task(self, queue: str, payload: str) -> None:
+        items = self._queues.get(queue, [])
+        with contextlib.suppress(ValueError):
+            items.remove(payload)
 
     async def aclose(self) -> None:
         pass
@@ -160,40 +167,40 @@ class TestProtocolCompliance:
         )
 
 
-class TestEnvOverrides:
-    """Verify only non-sensitive params are passed per-execution (S1)."""
+class TestDispatchPayload:
+    """Verify only non-sensitive params are serialized for Redis dispatch (S1)."""
 
-    def test_env_overrides_contain_only_task_params(self) -> None:
-        from gitlab_copilot_agent.aca_executor import _build_env_overrides
+    def test_payload_contains_only_task_params(self) -> None:
+        from gitlab_copilot_agent.aca_executor import _build_dispatch_payload
 
         task = _make_task()
-        overrides = _build_env_overrides(task)
-        names = {e["name"] for e in overrides}
+        payload = json.loads(_build_dispatch_payload(task))
+        keys = set(payload.keys())
 
-        # Must include task params
-        assert "TASK_TYPE" in names
-        assert "TASK_ID" in names
-        assert "REPO_URL" in names
-        assert "BRANCH" in names
-        assert "SYSTEM_PROMPT" in names
-        assert "USER_PROMPT" in names
-        assert "TASK_PAYLOAD" in names
+        expected_keys = {
+            "task_type",
+            "task_id",
+            "repo_url",
+            "branch",
+            "system_prompt",
+            "user_prompt",
+        }
+        assert keys == expected_keys
 
         # Must NOT include secrets (S1 compliance)
-        secret_names = {"GITLAB_TOKEN", "GITHUB_TOKEN", "COPILOT_PROVIDER_API_KEY", "REDIS_URL"}
-        assert names.isdisjoint(secret_names), (
-            f"Secrets leaked in env overrides: {names & secret_names}"
-        )
+        secret_keys = {"gitlab_token", "github_token", "copilot_provider_api_key", "redis_url"}
+        assert keys.isdisjoint(secret_keys), f"Secrets in dispatch: {keys & secret_keys}"
 
-    def test_env_overrides_values_match_task(self) -> None:
-        from gitlab_copilot_agent.aca_executor import _build_env_overrides
+    def test_payload_values_match_task(self) -> None:
+        from gitlab_copilot_agent.aca_executor import _build_dispatch_payload
 
         task = _make_task()
-        overrides = {e["name"]: e["value"] for e in _build_env_overrides(task)}
-        assert overrides["TASK_TYPE"] == TASK_TYPE
-        assert overrides["TASK_ID"] == TASK_ID
-        assert overrides["REPO_URL"] == REPO_URL
-        assert overrides["BRANCH"] == BRANCH
+        payload = json.loads(_build_dispatch_payload(task))
+        assert payload["task_type"] == TASK_TYPE
+        assert payload["task_id"] == TASK_ID
+        assert payload["repo_url"] == REPO_URL
+        assert payload["branch"] == BRANCH
+        assert payload["user_prompt"] == USER_PROMPT
 
 
 class TestCachedResult:
@@ -213,26 +220,32 @@ class TestCachedResult:
 
 class TestJobExecution:
     @patch("gitlab_copilot_agent.aca_executor._JOB_POLL_INTERVAL", 0.01)
-    async def test_starts_execution_and_polls_result(self, jobs_mock: MagicMock) -> None:
+    async def test_starts_execution_and_polls_result(
+        self, jobs_mock: MagicMock, jobs_executions_mock: MagicMock
+    ) -> None:
         from gitlab_copilot_agent.aca_executor import ContainerAppsTaskExecutor
 
         poller = MagicMock()
-        poller.result.return_value = MagicMock(name=EXECUTION_NAME)
+        exec_result = MagicMock()
+        exec_result.name = EXECUTION_NAME
+        poller.result.return_value = exec_result
         jobs_mock.begin_start.return_value = poller
 
         # Transition: Running → Succeeded (gives time for result to appear)
         running = MagicMock()
-        running.properties.status = "Running"
+        running.name = EXECUTION_NAME
+        running.status = "Running"
         succeeded = MagicMock()
-        succeeded.properties.status = "Succeeded"
+        succeeded.name = EXECUTION_NAME
+        succeeded.status = "Succeeded"
         call_count = 0
 
-        def _status_side_effect(**kwargs: Any) -> Any:
+        def _list_side_effect(**kwargs: Any) -> list[Any]:
             nonlocal call_count
             call_count += 1
-            return running if call_count <= 1 else succeeded
+            return [running] if call_count <= 1 else [succeeded]
 
-        jobs_mock.get_execution.side_effect = _status_side_effect
+        jobs_executions_mock.list.side_effect = _list_side_effect
 
         store = MemoryResultStore()
         review_json = json.dumps({"result_type": "review", "summary": "LGTM"})
@@ -250,16 +263,81 @@ class TestJobExecution:
         assert isinstance(result, ReviewResult)
         assert result.summary == "LGTM"
 
-    async def test_coding_result_includes_patch(self, jobs_mock: MagicMock) -> None:
+    @patch("gitlab_copilot_agent.aca_executor._JOB_POLL_INTERVAL", 0.01)
+    async def test_dispatches_params_via_redis_not_template(
+        self, jobs_mock: MagicMock, jobs_executions_mock: MagicMock
+    ) -> None:
+        """Verify task params go to Redis and begin_start has no template."""
         from gitlab_copilot_agent.aca_executor import ContainerAppsTaskExecutor
 
         poller = MagicMock()
-        poller.result.return_value = MagicMock(name=EXECUTION_NAME)
+        exec_result = MagicMock()
+        exec_result.name = EXECUTION_NAME
+        poller.result.return_value = exec_result
         jobs_mock.begin_start.return_value = poller
 
         execution = MagicMock()
-        execution.properties.status = "Succeeded"
-        jobs_mock.get_execution.return_value = execution
+        execution.name = EXECUTION_NAME
+        execution.status = "Succeeded"
+        jobs_executions_mock.list.return_value = [execution]
+
+        store = MemoryResultStore()
+        review_json = json.dumps({"result_type": "review", "summary": "ok"})
+
+        # Set result after dispatch but before poll completes
+        async def _set_result_later() -> None:
+            await asyncio.sleep(0.01)
+            await store.set(TASK_ID, review_json)
+
+        executor = ContainerAppsTaskExecutor(settings=_make_settings(), result_store=store)
+
+        async with asyncio.TaskGroup() as tg:
+            tg.create_task(_set_result_later())
+            await executor.execute(_make_task())
+
+        # begin_start called WITHOUT template kwarg
+        _, kwargs = jobs_mock.begin_start.call_args
+        assert "template" not in kwargs
+
+    @patch("gitlab_copilot_agent.aca_executor._JOB_POLL_INTERVAL", 0.01)
+    async def test_cleans_up_queue_on_start_failure(self, jobs_mock: MagicMock) -> None:
+        """If begin_start fails, only the failed task's payload is removed."""
+        from gitlab_copilot_agent.aca_executor import (
+            _DISPATCH_QUEUE,
+            ContainerAppsTaskExecutor,
+        )
+
+        jobs_mock.begin_start.side_effect = RuntimeError("ACA API error")
+
+        store = MemoryResultStore()
+        # Pre-seed an unrelated payload to prove remove_task is targeted
+        await store.push_task(_DISPATCH_QUEUE, '{"other": "task"}')
+
+        executor = ContainerAppsTaskExecutor(settings=_make_settings(), result_store=store)
+
+        with pytest.raises(RuntimeError, match="ACA API error"):
+            await executor.execute(_make_task())
+
+        # The pre-existing payload must survive — only the failed one is removed
+        surviving = await store.pop_task(_DISPATCH_QUEUE)
+        assert surviving == '{"other": "task"}'
+        assert await store.pop_task(_DISPATCH_QUEUE) is None
+
+    async def test_coding_result_includes_patch(
+        self, jobs_mock: MagicMock, jobs_executions_mock: MagicMock
+    ) -> None:
+        from gitlab_copilot_agent.aca_executor import ContainerAppsTaskExecutor
+
+        poller = MagicMock()
+        exec_result = MagicMock()
+        exec_result.name = EXECUTION_NAME
+        poller.result.return_value = exec_result
+        jobs_mock.begin_start.return_value = poller
+
+        execution = MagicMock()
+        execution.name = EXECUTION_NAME
+        execution.status = "Succeeded"
+        jobs_executions_mock.list.return_value = [execution]
 
         store = MemoryResultStore()
         coding_json = json.dumps(
@@ -281,16 +359,21 @@ class TestJobExecution:
 
 
 class TestFailureHandling:
-    async def test_raises_on_failed_execution(self, jobs_mock: MagicMock) -> None:
+    async def test_raises_on_failed_execution(
+        self, jobs_mock: MagicMock, jobs_executions_mock: MagicMock
+    ) -> None:
         from gitlab_copilot_agent.aca_executor import ContainerAppsTaskExecutor
 
         poller = MagicMock()
-        poller.result.return_value = MagicMock(name=EXECUTION_NAME)
+        exec_result = MagicMock()
+        exec_result.name = EXECUTION_NAME
+        poller.result.return_value = exec_result
         jobs_mock.begin_start.return_value = poller
 
         execution = MagicMock()
-        execution.properties.status = "Failed"
-        jobs_mock.get_execution.return_value = execution
+        execution.name = EXECUTION_NAME
+        execution.status = "Failed"
+        jobs_executions_mock.list.return_value = [execution]
 
         store = MemoryResultStore()
         executor = ContainerAppsTaskExecutor(settings=_make_settings(), result_store=store)
@@ -302,17 +385,20 @@ class TestFailureHandling:
 class TestTimeout:
     @patch("gitlab_copilot_agent.aca_executor._JOB_POLL_INTERVAL", 0.01)
     async def test_raises_timeout_when_execution_does_not_complete(
-        self, jobs_mock: MagicMock
+        self, jobs_mock: MagicMock, jobs_executions_mock: MagicMock
     ) -> None:
         from gitlab_copilot_agent.aca_executor import ContainerAppsTaskExecutor
 
         poller = MagicMock()
-        poller.result.return_value = MagicMock(name=EXECUTION_NAME)
+        exec_result = MagicMock()
+        exec_result.name = EXECUTION_NAME
+        poller.result.return_value = exec_result
         jobs_mock.begin_start.return_value = poller
 
         execution = MagicMock()
-        execution.properties.status = "Running"
-        jobs_mock.get_execution.return_value = execution
+        execution.name = EXECUTION_NAME
+        execution.status = "Running"
+        jobs_executions_mock.list.return_value = [execution]
 
         store = MemoryResultStore()
         executor = ContainerAppsTaskExecutor(settings=_make_settings(), result_store=store)

--- a/tests/test_redis_state.py
+++ b/tests/test_redis_state.py
@@ -260,6 +260,98 @@ async def test_result_store_set_tolerates_connection_error() -> None:
     await store.set("task:123", "result")  # Should not raise
 
 
+async def test_result_store_push_task() -> None:
+    """RedisResultStore.push_task calls LPUSH."""
+    from unittest.mock import AsyncMock
+
+    from gitlab_copilot_agent.redis_state import RedisResultStore
+
+    mock_client = AsyncMock()
+    store = RedisResultStore(mock_client)
+    await store.push_task("queue", '{"task": "data"}')
+    mock_client.lpush.assert_awaited_once()
+
+
+async def test_result_store_push_task_raises_on_error() -> None:
+    """RedisResultStore.push_task propagates errors (fail-fast)."""
+    from unittest.mock import AsyncMock
+
+    from redis.exceptions import ConnectionError as RedisConnError
+
+    from gitlab_copilot_agent.redis_state import RedisResultStore
+
+    mock_client = AsyncMock()
+    mock_client.lpush.side_effect = RedisConnError("Connection refused")
+    store = RedisResultStore(mock_client)
+    with pytest.raises(RedisConnError):
+        await store.push_task("queue", '{"task": "data"}')
+
+
+async def test_result_store_pop_task_returns_value() -> None:
+    """RedisResultStore.pop_task returns decoded string from RPOP."""
+    from unittest.mock import AsyncMock
+
+    from gitlab_copilot_agent.redis_state import RedisResultStore
+
+    mock_client = AsyncMock()
+    mock_client.rpop.return_value = b'{"task": "data"}'
+    store = RedisResultStore(mock_client)
+    result = await store.pop_task("queue")
+    assert result == '{"task": "data"}'
+
+
+async def test_result_store_pop_task_returns_none_on_empty() -> None:
+    """RedisResultStore.pop_task returns None when queue is empty."""
+    from unittest.mock import AsyncMock
+
+    from gitlab_copilot_agent.redis_state import RedisResultStore
+
+    mock_client = AsyncMock()
+    mock_client.rpop.return_value = None
+    store = RedisResultStore(mock_client)
+    assert await store.pop_task("queue") is None
+
+
+async def test_result_store_pop_task_tolerates_connection_error() -> None:
+    """RedisResultStore.pop_task returns None on connection error."""
+    from unittest.mock import AsyncMock
+
+    from redis.exceptions import ConnectionError as RedisConnError
+
+    from gitlab_copilot_agent.redis_state import RedisResultStore
+
+    mock_client = AsyncMock()
+    mock_client.rpop.side_effect = RedisConnError("Connection refused")
+    store = RedisResultStore(mock_client)
+    assert await store.pop_task("queue") is None
+
+
+async def test_result_store_remove_task() -> None:
+    """RedisResultStore.remove_task calls LREM with payload."""
+    from unittest.mock import AsyncMock
+
+    from gitlab_copilot_agent.redis_state import RedisResultStore
+
+    mock_client = AsyncMock()
+    store = RedisResultStore(mock_client)
+    await store.remove_task("queue", '{"task": "data"}')
+    mock_client.lrem.assert_awaited_once()
+
+
+async def test_result_store_remove_task_tolerates_connection_error() -> None:
+    """RedisResultStore.remove_task tolerates connection errors."""
+    from unittest.mock import AsyncMock
+
+    from redis.exceptions import ConnectionError as RedisConnError
+
+    from gitlab_copilot_agent.redis_state import RedisResultStore
+
+    mock_client = AsyncMock()
+    mock_client.lrem.side_effect = RedisConnError("Connection refused")
+    store = RedisResultStore(mock_client)
+    await store.remove_task("queue", '{"task": "data"}')  # Should not raise
+
+
 # -- Config validation tests --
 
 

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -14,7 +14,9 @@ from gitlab_copilot_agent.task_runner import (
     _build_coding_result,
     _coding_response_validator,
     _get_required_env,
+    _load_dispatch_params,
     _parse_task_payload,
+    _store_result,
     _validate_repo_url,
     run_task,
 )
@@ -78,6 +80,7 @@ class TestRunTask:
         fp = Path("/tmp/fake")
         expected = json.dumps({"result_type": "review", "summary": "done"})
         with (
+            patch(f"{_M}._load_dispatch_params", AsyncMock(return_value=None)),
             patch(f"{_M}.git_clone", AsyncMock(return_value=fp)),
             patch(f"{_M}.run_copilot_session", AsyncMock(return_value="done")),
             patch(f"{_M}._store_result", AsyncMock()) as store,
@@ -89,15 +92,42 @@ class TestRunTask:
 
     async def test_missing_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv(ENV_TASK_TYPE, raising=False)
-        assert await run_task() == 1
+        with patch(f"{_M}._load_dispatch_params", AsyncMock(return_value=None)):
+            assert await run_task() == 1
+
+    async def test_redis_dispatch_path(self, env_vars: None) -> None:
+        """When Redis dispatch returns params, env vars are not needed."""
+        dispatch_params = {
+            "task_type": "review",
+            "task_id": TASK_ID,
+            "repo_url": EXAMPLE_CLONE_URL,
+            "branch": "feat/x",
+            "system_prompt": "Review code.",
+            "user_prompt": "Review this",
+        }
+        expected = json.dumps({"result_type": "review", "summary": "done"})
+        fp = Path("/tmp/fake")
+        with (
+            patch(f"{_M}._load_dispatch_params", AsyncMock(return_value=dispatch_params)),
+            patch(f"{_M}.git_clone", AsyncMock(return_value=fp)),
+            patch(f"{_M}.run_copilot_session", AsyncMock(return_value="done")),
+            patch(f"{_M}._store_result", AsyncMock()) as store,
+            patch(f"{_M}.shutil.rmtree"),
+        ):
+            assert await run_task() == 0
+            store.assert_awaited_once_with(TASK_ID, expected)
 
     async def test_bad_type(self, task_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv(ENV_TASK_TYPE, "bad")
-        assert await run_task() == 1
+        with patch(f"{_M}._load_dispatch_params", AsyncMock(return_value=None)):
+            assert await run_task() == 1
 
     async def test_url_mismatch(self, task_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv(ENV_REPO_URL, BAD_HOST)
-        with pytest.raises(RuntimeError, match="does not match"):
+        with (
+            patch(f"{_M}._load_dispatch_params", AsyncMock(return_value=None)),
+            pytest.raises(RuntimeError, match="does not match"),
+        ):
             await run_task()
 
     async def test_coding(self, task_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -106,6 +136,7 @@ class TestRunTask:
             {"result_type": "coding", "summary": "x", "patch": "p", "base_sha": "abc"}
         )
         with (
+            patch(f"{_M}._load_dispatch_params", AsyncMock(return_value=None)),
             patch(f"{_M}.git_clone", AsyncMock(return_value=Path("/tmp/r"))),
             patch(f"{_M}.run_copilot_session", AsyncMock(return_value="x")) as ms,
             patch(f"{_M}._build_coding_result", AsyncMock(return_value=coding_json)),
@@ -191,3 +222,87 @@ class TestBuildCodingResult:
             await _build_coding_result(Path("/repo"), TRAVERSAL_OUTPUT, AsyncMock())
         # Only src/ok.py staged; ../../etc/passwd skipped
         git_mock.assert_awaited_once_with(Path("/repo"), "add", "--", "src/ok.py")
+
+
+_REDIS_MOD = "gitlab_copilot_agent.redis_state"
+
+
+class TestStoreResult:
+    """Tests for _store_result function."""
+
+    async def test_skips_when_no_redis(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Returns immediately when no Redis env vars are set."""
+        monkeypatch.delenv("REDIS_URL", raising=False)
+        monkeypatch.delenv("REDIS_HOST", raising=False)
+        await _store_result("task-1", '{"result": "ok"}')  # Should not raise
+
+    async def test_stores_via_redis(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Stores result in Redis when REDIS_URL is set."""
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        mock_store = MagicMock()
+        mock_store.set = AsyncMock()
+        mock_store.aclose = AsyncMock()
+        with patch(f"{_REDIS_MOD}.create_result_store", return_value=mock_store):
+            await _store_result("task-1", '{"result": "ok"}')
+        mock_store.set.assert_awaited_once_with("task-1", '{"result": "ok"}', ttl=3600)
+        mock_store.aclose.assert_awaited_once()
+
+    async def test_closes_store_on_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Store is closed even if set() raises."""
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        mock_store = MagicMock()
+        mock_store.set = AsyncMock(side_effect=RuntimeError("boom"))
+        mock_store.aclose = AsyncMock()
+        with (
+            patch(f"{_REDIS_MOD}.create_result_store", return_value=mock_store),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            await _store_result("task-1", '{"result": "ok"}')
+        mock_store.aclose.assert_awaited_once()
+
+
+class TestLoadDispatchParams:
+    """Tests for _load_dispatch_params function."""
+
+    async def test_returns_none_when_no_redis(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Returns None when no Redis env vars are set."""
+        monkeypatch.delenv("REDIS_URL", raising=False)
+        monkeypatch.delenv("REDIS_HOST", raising=False)
+        assert await _load_dispatch_params() is None
+
+    async def test_returns_params_from_queue(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Loads and returns dispatch params from Redis queue."""
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        dispatch = {
+            "task_type": "review",
+            "task_id": "t-1",
+            "repo_url": "u",
+            "branch": "b",
+            "user_prompt": "p",
+        }
+        mock_store = MagicMock()
+        mock_store.pop_task = AsyncMock(return_value=json.dumps(dispatch))
+        mock_store.aclose = AsyncMock()
+        with patch(f"{_REDIS_MOD}.create_result_store", return_value=mock_store):
+            result = await _load_dispatch_params()
+        assert result == dispatch
+        mock_store.aclose.assert_awaited_once()
+
+    async def test_returns_none_on_empty_queue(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Returns None when queue is empty."""
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        mock_store = MagicMock()
+        mock_store.pop_task = AsyncMock(return_value=None)
+        mock_store.aclose = AsyncMock()
+        with patch(f"{_REDIS_MOD}.create_result_store", return_value=mock_store):
+            assert await _load_dispatch_params() is None
+
+    async def test_returns_none_on_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Returns None and logs warning when pop_task raises."""
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        mock_store = MagicMock()
+        mock_store.pop_task = AsyncMock(side_effect=RuntimeError("boom"))
+        mock_store.aclose = AsyncMock()
+        with patch(f"{_REDIS_MOD}.create_result_store", return_value=mock_store):
+            assert await _load_dispatch_params() is None
+        mock_store.aclose.assert_awaited_once()


### PR DESCRIPTION
## What

Fixes ACA Job executions failing because `begin_start(template=...)` does a **full REPLACE** of the job template, wiping all base env vars, Key Vault secret refs, and the command field.

Replaces per-execution template overrides with a Redis dispatch queue: controller writes task params to Redis, starts the job without a template override, and the task runner reads params from Redis on startup.

Closes #236

## Why

ACA Jobs were completely non-functional. Every execution failed because the template override stripped the base configuration. This was a regression that blocked all ACA-based task execution.

## Changes

| File | Change |
|------|--------|
| `aca_executor.py` | Redis dispatch (`push_task`/`remove_task`), `begin_start()` without template, `jobs_executions.list()` for status, proper `ContainerAppsAPIClient` return type |
| `concurrency.py` | Added `push_task`/`pop_task`/`remove_task` to `ResultStore` protocol and `MemoryResultStore` |
| `redis_state.py` | `push_task` (LPUSH, fail-fast), `pop_task` (RPOP), `remove_task` (LREM) |
| `config.py` | `TaskRunnerSettings` — dedicated config model so task runner doesn't need controller env vars |
| `task_runner.py` | Uses `TaskRunnerSettings`, reads dispatch params from Redis queue, falls back to env vars for k8s compatibility |
| `copilot_session.py` | Accept `Settings \| TaskRunnerSettings` |
| `prompt_defaults.py` | Accept `Settings \| TaskRunnerSettings` |
| `Dockerfile` | Second `uv sync` after `COPY src/` to install the project package in site-packages |
| `.gitignore` | Added `infra/tfplan` |
| `test_aca_executor.py` | Updated for Redis dispatch, `jobs_executions.list()` mock, targeted `remove_task` cleanup test |
| `test_task_runner.py` | Redis dispatch path test |

## Known limitations

- Shared FIFO queue can mis-bind payloads under concurrent dispatch — tracked in #238 (p1-high). Safe for current serial Jira polling. Blocks adding concurrent dispatch sources.

## E2E test results (Azure dev environment)

Verified end-to-end on live Azure deployment:

1. ✅ Jira poller picked up DEMO-1 item (status: "AI Ready")
2. ✅ ACA Job `ca-job-task-runner` execution started
3. ✅ Task runner loaded dispatch params from Redis queue
4. ✅ Copilot session completed, patch generated
5. ✅ Code committed and pushed to `agent/demo-1` branch on GitLab
6. ✅ MR !4 created on `peteroden/copilot-demo`
7. ✅ Jira comment added, status transitioned to "In Review"

Controller revision: `ca-controller--0000006`

## Test results

```
417 passed in 36.59s
Coverage: 95.16% (threshold: 90%)
Lint: ruff check + ruff format + mypy --strict — all clean
```

## Code review

Cross-model review (GPT-5.3-Codex) findings:
- **High** (fixed): `pop_task` cleanup on start failure used positional RPOP — could remove wrong task. Fixed: `remove_task` uses LREM with specific payload value.
- **Medium** (fixed): `push_task` swallowed Redis errors — job could start without payload. Fixed: `push_task` now raises on failure (fail-fast).
- **High** (deferred): Shared FIFO queue concurrent dispatch — tracked in #238.

## Note on PR size

This PR is 390+/121- (over 200-line guideline) because it combines multiple tightly coupled fixes that were iterated on during live debugging. Splitting would create non-functional intermediate PRs.
