### PR TITLE
fix(aca): use keyed dispatch by execution name instead of shared FIFO queue

### DIFF
--- a/src/gitlab_copilot_agent/aca_executor.py
+++ b/src/gitlab_copilot_agent/aca_executor.py
@@ -22,7 +22,8 @@ log = structlog.get_logger()
 _JOB_POLL_INTERVAL = 5  # seconds; ACA API is slower than k8s, use longer interval
 _EXECUTION_LOCK_TTL = 900  # sentinel TTL to prevent duplicate executions
 _EXECUTION_LOCK_PREFIX = "aca_exec:"
-_DISPATCH_QUEUE = "task_dispatch_queue"
+_DISPATCH_KEY_PREFIX = "dispatch:"
+_DISPATCH_TTL = 600  # 10 min — enough for job startup + param read
 
 
 def _build_dispatch_payload(task: TaskParams) -> str:
@@ -84,18 +85,13 @@ class ContainerAppsTaskExecutor:
             log.info("aca_execution_already_started", task_id=task.task_id)
             return await self._wait_for_result(existing, task)
 
-        # Write task params to Redis so the job can read them on startup.
-        # ACA begin_start(template=...) does a full REPLACE (not merge),
-        # so we pass no template and let the base job template run as-is.
+        # Start execution first to get the execution name, then write
+        # dispatch params keyed by that name. The job reads its own
+        # CONTAINER_APP_JOB_EXECUTION_NAME env var to find its payload.
+        execution_name = await asyncio.to_thread(self._start_execution, task)
+        dispatch_key = f"{_DISPATCH_KEY_PREFIX}{execution_name}"
         payload = _build_dispatch_payload(task)
-        await self._store.push_task(_DISPATCH_QUEUE, payload)
-
-        try:
-            execution_name = await asyncio.to_thread(self._start_execution, task)
-        except Exception:
-            # Compensating cleanup: remove the specific queued payload on failure
-            await self._store.remove_task(_DISPATCH_QUEUE, payload)
-            raise
+        await self._store.set(dispatch_key, payload, ttl=_DISPATCH_TTL)
 
         await self._store.set(lock_key, execution_name, ttl=_EXECUTION_LOCK_TTL)
         return await self._wait_for_result(execution_name, task)

--- a/src/gitlab_copilot_agent/task_runner.py
+++ b/src/gitlab_copilot_agent/task_runner.py
@@ -31,7 +31,8 @@ ENV_REDIS_PORT = "REDIS_PORT"
 ENV_AZURE_CLIENT_ID = "AZURE_CLIENT_ID"
 VALID_TASK_TYPES: frozenset[str] = frozenset({"review", "coding", "echo"})
 _RESULT_TTL = 3600  # 1 hour
-_DISPATCH_QUEUE = "task_dispatch_queue"
+_DISPATCH_READ_RETRIES = 5
+_DISPATCH_READ_DELAY = 2.0  # seconds between retries
 
 _RETRY_PROMPT = (
     "Your response did not include the required JSON output block. "
@@ -72,12 +73,18 @@ async def _store_result(task_id: str, result: str) -> None:
 
 
 async def _load_dispatch_params() -> dict[str, str] | None:
-    """Try to load task params from the Redis dispatch queue.
+    """Load task params from Redis keyed by ACA execution name.
 
-    The queue stores full JSON payloads (atomic pop = data retrieval).
-    Returns a dict with task_type, task_id, repo_url, branch, system_prompt,
-    user_prompt — or None if no dispatched task is available.
+    The controller stores dispatch params at ``dispatch:{execution_name}``
+    after starting the job. The job discovers its own execution name via
+    the ``CONTAINER_APP_JOB_EXECUTION_NAME`` env var (injected by ACA).
+
+    Retries with backoff because the controller writes the key after
+    begin_start() returns — the job may start before the write completes.
     """
+    exec_name = os.environ.get("CONTAINER_APP_JOB_EXECUTION_NAME", "").strip()
+    if not exec_name:
+        return None
     redis_url = os.environ.get(ENV_REDIS_URL, "").strip()
     redis_host = os.environ.get(ENV_REDIS_HOST, "").strip()
     if not redis_url and not redis_host:
@@ -92,12 +99,22 @@ async def _load_dispatch_params() -> dict[str, str] | None:
         azure_client_id=os.environ.get(ENV_AZURE_CLIENT_ID),
     )
     try:
-        raw = await store.pop_task(_DISPATCH_QUEUE)
-        if raw is None:
-            return None
-        params: dict[str, str] = json.loads(raw)
-        await log.ainfo("dispatch_params_loaded", task_id=params.get("task_id"))
-        return params
+        dispatch_key = f"dispatch:{exec_name}"
+        # Retry: controller writes key after begin_start(), job may beat it
+        for attempt in range(_DISPATCH_READ_RETRIES):
+            raw = await store.get(dispatch_key)
+            if raw is not None:
+                params: dict[str, str] = json.loads(raw)
+                await log.ainfo(
+                    "dispatch_params_loaded",
+                    task_id=params.get("task_id"),
+                    execution=exec_name,
+                )
+                return params
+            if attempt < _DISPATCH_READ_RETRIES - 1:
+                await asyncio.sleep(_DISPATCH_READ_DELAY)
+        await log.awarning("dispatch_key_not_found", key=dispatch_key)
+        return None
     except Exception:
         await log.awarning("dispatch_load_failed", exc_info=True)
         return None

--- a/tests/test_aca_executor.py
+++ b/tests/test_aca_executor.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import json
 import sys
 import types
@@ -130,7 +129,6 @@ class MemoryResultStore:
 
     def __init__(self) -> None:
         self._data: dict[str, str] = {}
-        self._queues: dict[str, list[str]] = {}
 
     async def get(self, key: str) -> str | None:
         return self._data.get(key)
@@ -139,16 +137,13 @@ class MemoryResultStore:
         self._data[key] = value
 
     async def push_task(self, queue: str, payload: str) -> None:
-        self._queues.setdefault(queue, []).append(payload)
+        pass  # unused in keyed dispatch, kept for protocol compliance
 
     async def pop_task(self, queue: str) -> str | None:
-        items = self._queues.get(queue, [])
-        return items.pop(0) if items else None
+        return None
 
     async def remove_task(self, queue: str, payload: str) -> None:
-        items = self._queues.get(queue, [])
-        with contextlib.suppress(ValueError):
-            items.remove(payload)
+        pass
 
     async def aclose(self) -> None:
         pass
@@ -264,11 +259,14 @@ class TestJobExecution:
         assert result.summary == "LGTM"
 
     @patch("gitlab_copilot_agent.aca_executor._JOB_POLL_INTERVAL", 0.01)
-    async def test_dispatches_params_via_redis_not_template(
+    async def test_dispatches_params_via_keyed_redis(
         self, jobs_mock: MagicMock, jobs_executions_mock: MagicMock
     ) -> None:
-        """Verify task params go to Redis and begin_start has no template."""
-        from gitlab_copilot_agent.aca_executor import ContainerAppsTaskExecutor
+        """Verify task params are stored keyed by execution name."""
+        from gitlab_copilot_agent.aca_executor import (
+            _DISPATCH_KEY_PREFIX,
+            ContainerAppsTaskExecutor,
+        )
 
         poller = MagicMock()
         exec_result = MagicMock()
@@ -284,7 +282,6 @@ class TestJobExecution:
         store = MemoryResultStore()
         review_json = json.dumps({"result_type": "review", "summary": "ok"})
 
-        # Set result after dispatch but before poll completes
         async def _set_result_later() -> None:
             await asyncio.sleep(0.01)
             await store.set(TASK_ID, review_json)
@@ -299,29 +296,31 @@ class TestJobExecution:
         _, kwargs = jobs_mock.begin_start.call_args
         assert "template" not in kwargs
 
+        # Dispatch payload stored keyed by execution name
+        dispatch_key = f"{_DISPATCH_KEY_PREFIX}{EXECUTION_NAME}"
+        raw = await store.get(dispatch_key)
+        assert raw is not None
+        params = json.loads(raw)
+        assert params["task_id"] == TASK_ID
+        assert params["repo_url"] == REPO_URL
+
     @patch("gitlab_copilot_agent.aca_executor._JOB_POLL_INTERVAL", 0.01)
-    async def test_cleans_up_queue_on_start_failure(self, jobs_mock: MagicMock) -> None:
-        """If begin_start fails, only the failed task's payload is removed."""
+    async def test_start_failure_does_not_leave_dispatch_key(self, jobs_mock: MagicMock) -> None:
+        """If begin_start fails, no dispatch key is written."""
         from gitlab_copilot_agent.aca_executor import (
-            _DISPATCH_QUEUE,
+            _DISPATCH_KEY_PREFIX,
             ContainerAppsTaskExecutor,
         )
 
         jobs_mock.begin_start.side_effect = RuntimeError("ACA API error")
-
         store = MemoryResultStore()
-        # Pre-seed an unrelated payload to prove remove_task is targeted
-        await store.push_task(_DISPATCH_QUEUE, '{"other": "task"}')
-
         executor = ContainerAppsTaskExecutor(settings=_make_settings(), result_store=store)
 
         with pytest.raises(RuntimeError, match="ACA API error"):
             await executor.execute(_make_task())
 
-        # The pre-existing payload must survive — only the failed one is removed
-        surviving = await store.pop_task(_DISPATCH_QUEUE)
-        assert surviving == '{"other": "task"}'
-        assert await store.pop_task(_DISPATCH_QUEUE) is None
+        # No dispatch keys should exist — payload is written AFTER begin_start
+        assert all(not k.startswith(_DISPATCH_KEY_PREFIX) for k in store._data)
 
     async def test_coding_result_includes_patch(
         self, jobs_mock: MagicMock, jobs_executions_mock: MagicMock

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -264,14 +264,21 @@ class TestStoreResult:
 class TestLoadDispatchParams:
     """Tests for _load_dispatch_params function."""
 
+    async def test_returns_none_when_no_exec_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Returns None when CONTAINER_APP_JOB_EXECUTION_NAME is not set."""
+        monkeypatch.delenv("CONTAINER_APP_JOB_EXECUTION_NAME", raising=False)
+        assert await _load_dispatch_params() is None
+
     async def test_returns_none_when_no_redis(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Returns None when no Redis env vars are set."""
+        monkeypatch.setenv("CONTAINER_APP_JOB_EXECUTION_NAME", "exec-123")
         monkeypatch.delenv("REDIS_URL", raising=False)
         monkeypatch.delenv("REDIS_HOST", raising=False)
         assert await _load_dispatch_params() is None
 
-    async def test_returns_params_from_queue(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Loads and returns dispatch params from Redis queue."""
+    async def test_returns_params_by_execution_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Loads dispatch params keyed by execution name."""
+        monkeypatch.setenv("CONTAINER_APP_JOB_EXECUTION_NAME", "exec-123")
         monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
         dispatch = {
             "task_type": "review",
@@ -281,27 +288,50 @@ class TestLoadDispatchParams:
             "user_prompt": "p",
         }
         mock_store = MagicMock()
-        mock_store.pop_task = AsyncMock(return_value=json.dumps(dispatch))
+        mock_store.get = AsyncMock(return_value=json.dumps(dispatch))
         mock_store.aclose = AsyncMock()
         with patch(f"{_REDIS_MOD}.create_result_store", return_value=mock_store):
             result = await _load_dispatch_params()
         assert result == dispatch
+        mock_store.get.assert_awaited_once_with("dispatch:exec-123")
         mock_store.aclose.assert_awaited_once()
 
-    async def test_returns_none_on_empty_queue(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Returns None when queue is empty."""
+    @patch(f"{_M}._DISPATCH_READ_RETRIES", 3)
+    @patch(f"{_M}._DISPATCH_READ_DELAY", 0.0)
+    async def test_retries_then_returns_none_when_key_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Retries before returning None when dispatch key not found."""
+        monkeypatch.setenv("CONTAINER_APP_JOB_EXECUTION_NAME", "exec-123")
         monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
         mock_store = MagicMock()
-        mock_store.pop_task = AsyncMock(return_value=None)
+        mock_store.get = AsyncMock(return_value=None)
         mock_store.aclose = AsyncMock()
         with patch(f"{_REDIS_MOD}.create_result_store", return_value=mock_store):
             assert await _load_dispatch_params() is None
+        assert mock_store.get.await_count == 3
+
+    @patch(f"{_M}._DISPATCH_READ_RETRIES", 3)
+    @patch(f"{_M}._DISPATCH_READ_DELAY", 0.0)
+    async def test_succeeds_on_retry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Returns params after initial miss + successful retry."""
+        monkeypatch.setenv("CONTAINER_APP_JOB_EXECUTION_NAME", "exec-123")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        dispatch = {"task_type": "review", "task_id": "t-1"}
+        mock_store = MagicMock()
+        mock_store.get = AsyncMock(side_effect=[None, json.dumps(dispatch)])
+        mock_store.aclose = AsyncMock()
+        with patch(f"{_REDIS_MOD}.create_result_store", return_value=mock_store):
+            result = await _load_dispatch_params()
+        assert result == dispatch
+        assert mock_store.get.await_count == 2
 
     async def test_returns_none_on_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Returns None and logs warning when pop_task raises."""
+        """Returns None and logs warning when get raises."""
+        monkeypatch.setenv("CONTAINER_APP_JOB_EXECUTION_NAME", "exec-123")
         monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
         mock_store = MagicMock()
-        mock_store.pop_task = AsyncMock(side_effect=RuntimeError("boom"))
+        mock_store.get = AsyncMock(side_effect=RuntimeError("boom"))
         mock_store.aclose = AsyncMock()
         with patch(f"{_REDIS_MOD}.create_result_store", return_value=mock_store):
             assert await _load_dispatch_params() is None


### PR DESCRIPTION
## What

Replaces the shared Redis FIFO queue (`LPUSH`/`RPOP`) with per-execution keyed dispatch. Each ACA Job execution gets its own Redis key (`dispatch:{execution_name}`), eliminating the concurrency bug where jobs could pop another task's payload.

Closes #238

## How

**Controller** (`aca_executor.py`):
1. `begin_start()` → gets `execution_name`
2. `SET dispatch:{execution_name} payload TTL=600`

**Task runner** (`task_runner.py`):
1. Reads `CONTAINER_APP_JOB_EXECUTION_NAME` env var (injected by ACA)
2. `GET dispatch:{execution_name}` with retry (5 attempts, 2s delay)
3. Falls back to env vars for k8s compatibility

## Why this works

The old FIFO queue had no correlation between queue position and execution identity. Under concurrent dispatch, jobs could pop the wrong payload. The keyed approach guarantees each execution reads only its own payload — the key includes the execution name.

## Code review

Cross-model review (GPT-5.3-Codex):
- **High** (fixed): Startup race — job could start before controller writes the key. Fixed with retry/backoff (5 × 2s = 10s window).
- **Medium** (tracked): Redis write failure after `begin_start()` could orphan an execution. Follow-up issue needed — not blocking since current behavior fails loudly (timeout) rather than silently.

## Test results

```
433 passed in 36.92s
Coverage: 90.82% (threshold: 90%)
Lint: ruff check + ruff format + mypy --strict — all clean
```

## Diff

150 lines across 4 files. No infra changes.