### PR TITLE
fix(coding): use .git/info/exclude instead of .gitignore

### DIFF
--- a/src/gitlab_copilot_agent/coding_engine.py
+++ b/src/gitlab_copilot_agent/coding_engine.py
@@ -66,17 +66,18 @@ def build_jira_coding_prompt(issue_key: str, summary: str, description: str | No
     )
 
 
-def ensure_gitignore(repo_root: str) -> bool:
-    """Ensure .gitignore at *repo_root* contains standard Python ignore patterns.
+def ensure_git_exclude(repo_root: str) -> bool:
+    """Write standard Python ignore patterns to ``.git/info/exclude``.
+
+    Uses the per-clone exclude file instead of ``.gitignore`` so that the
+    patterns never appear in ``git diff`` or pollute the user's repository.
 
     Returns True if the file was created or modified.
-    Refuses to write if .gitignore is a symlink or resolves outside repo_root.
     """
-    path = Path(repo_root) / ".gitignore"
-    root_resolved = Path(repo_root).resolve()
-    if path.is_symlink() or (path.exists() and not path.resolve().is_relative_to(root_resolved)):
+    exclude = Path(repo_root) / ".git" / "info" / "exclude"
+    if not exclude.parent.is_dir():
         return False
-    content = path.read_text() if path.exists() else ""
+    content = exclude.read_text() if exclude.exists() else ""
     existing = set(content.splitlines())
     missing = [p for p in _PYTHON_GITIGNORE_PATTERNS if p not in existing]
     if not missing:
@@ -84,7 +85,7 @@ def ensure_gitignore(repo_root: str) -> bool:
     suffix = "\n".join(missing) + "\n"
     if content and not content.endswith("\n"):
         suffix = "\n" + suffix
-    path.write_text(content + suffix)
+    exclude.write_text(content + suffix)
     return True
 
 
@@ -99,7 +100,7 @@ async def run_coding_task(
     description: str | None,
 ) -> TaskResult:
     """Run a Copilot agent session to implement changes from a Jira issue."""
-    ensure_gitignore(repo_path)
+    ensure_git_exclude(repo_path)
     task = TaskParams(
         task_type="coding",
         task_id=issue_key,

--- a/src/gitlab_copilot_agent/task_runner.py
+++ b/src/gitlab_copilot_agent/task_runner.py
@@ -252,9 +252,9 @@ async def run_task() -> int:
     )
     try:
         if task_type == "coding":
-            from gitlab_copilot_agent.coding_engine import ensure_gitignore
+            from gitlab_copilot_agent.coding_engine import ensure_git_exclude
 
-            ensure_gitignore(str(repo_path))
+            ensure_git_exclude(str(repo_path))
         prompt = get_prompt(settings, "review" if task_type == "review" else "coding")
         summary = await run_copilot_session(
             settings,

--- a/tests/test_coding_engine.py
+++ b/tests/test_coding_engine.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock
 from gitlab_copilot_agent.coding_engine import (
     _PYTHON_GITIGNORE_PATTERNS,
     CODING_SYSTEM_PROMPT,
-    ensure_gitignore,
+    ensure_git_exclude,
     run_coding_task,
 )
 from gitlab_copilot_agent.prompt_defaults import get_prompt
@@ -19,33 +19,43 @@ def test_prompt_includes_gitignore_and_linter_instructions() -> None:
     assert "__pycache__" in CODING_SYSTEM_PROMPT
 
 
-class TestEnsureGitignore:
+def _init_git_repo(path: Path) -> Path:
+    """Create a minimal git repo so .git/info/exclude exists."""
+    import subprocess
+
+    subprocess.run(["git", "init", str(path)], capture_output=True, check=True)
+    return path
+
+
+class TestEnsureGitExclude:
     def test_creates_when_missing(self, tmp_path: Path) -> None:
-        assert ensure_gitignore(str(tmp_path)) is True
-        content = (tmp_path / ".gitignore").read_text()
+        _init_git_repo(tmp_path)
+        assert ensure_git_exclude(str(tmp_path)) is True
+        content = (tmp_path / ".git" / "info" / "exclude").read_text()
         for pattern in _PYTHON_GITIGNORE_PATTERNS:
             assert pattern in content
 
     def test_noop_when_complete(self, tmp_path: Path) -> None:
-        (tmp_path / ".gitignore").write_text("\n".join(_PYTHON_GITIGNORE_PATTERNS) + "\n")
-        assert ensure_gitignore(str(tmp_path)) is False
+        _init_git_repo(tmp_path)
+        exclude = tmp_path / ".git" / "info" / "exclude"
+        exclude.write_text("\n".join(_PYTHON_GITIGNORE_PATTERNS) + "\n")
+        assert ensure_git_exclude(str(tmp_path)) is False
 
     def test_appends_missing(self, tmp_path: Path) -> None:
-        (tmp_path / ".gitignore").write_text("__pycache__/\n")
-        ensure_gitignore(str(tmp_path))
-        content = (tmp_path / ".gitignore").read_text()
+        _init_git_repo(tmp_path)
+        exclude = tmp_path / ".git" / "info" / "exclude"
+        exclude.write_text("__pycache__/\n")
+        ensure_git_exclude(str(tmp_path))
+        content = exclude.read_text()
         for pattern in _PYTHON_GITIGNORE_PATTERNS:
             assert pattern in content
 
-    def test_refuses_symlink(self, tmp_path: Path) -> None:
-        target = tmp_path / "elsewhere.txt"
-        target.write_text("original")
-        (tmp_path / ".gitignore").symlink_to(target)
-        assert ensure_gitignore(str(tmp_path)) is False
-        assert target.read_text() == "original"
+    def test_returns_false_without_git_dir(self, tmp_path: Path) -> None:
+        assert ensure_git_exclude(str(tmp_path)) is False
 
 
 async def test_run_coding_task_delegates_to_executor(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
     mock_executor = AsyncMock()
     mock_executor.execute.return_value = "Changes completed"
 
@@ -64,4 +74,4 @@ async def test_run_coding_task_delegates_to_executor(tmp_path: Path) -> None:
     task = mock_executor.execute.call_args[0][0]
     assert task.system_prompt == get_prompt(make_settings(), "coding")
     assert "PROJ-789" in task.user_prompt
-    assert (tmp_path / ".gitignore").exists()
+    assert (tmp_path / ".git" / "info" / "exclude").exists()

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -142,7 +142,7 @@ class TestRunTask:
             patch(f"{_M}._build_coding_result", AsyncMock(return_value=coding_json)),
             patch(f"{_M}._store_result", AsyncMock()),
             patch(f"{_M}.shutil.rmtree"),
-            patch("gitlab_copilot_agent.coding_engine.ensure_gitignore"),
+            patch("gitlab_copilot_agent.coding_engine.ensure_git_exclude"),
         ):
             assert await run_task() == 0
             assert ms.call_args[1]["task_type"] == "coding"


### PR DESCRIPTION
## What

Replace `ensure_gitignore()` with `ensure_git_exclude()` to write Python ignore patterns to `.git/info/exclude` instead of the repo `.gitignore`.

## Why

Copilot sometimes generates patches that include `.gitignore` as a "new file" diff. When the controller already has `.gitignore` on disk, `git apply` fails with "already exists in working directory". The root cause: `ensure_gitignore()` was modifying the working tree before Copilot ran, and if the repo had no `.gitignore`, `git diff --cached` would produce a "new file" header.

`.git/info/exclude` is the correct mechanism — it works identically to `.gitignore` but is local to the clone, never tracked, and invisible to `git diff`.

## E2E Test Results

Deployed to dev and verified end-to-end:
1. Moved Jira DEMO-1 to "AI Ready"
2. Jira poller picked up → ACA job dispatched → Copilot coded → patch applied → MR created
3. GitLab MR: https://gitlab.com/79793676/-/merge_requests/5
4. Jira status moved to "In Review"

Previously this flow failed with `git apply failed: error: .gitignore: already exists in working directory`.

## Changes

- `src/gitlab_copilot_agent/coding_engine.py`: Rename `ensure_gitignore` → `ensure_git_exclude`, write to `.git/info/exclude`
- `src/gitlab_copilot_agent/task_runner.py`: Update import
- `tests/test_coding_engine.py`: Update tests for `.git/info/exclude` path
- `tests/test_task_runner.py`: Update mock name

Closes #242