### PR TITLE
feat(infra): add Azure Storage Account for task dispatch

### DIFF
--- a/infra/keyvault.tf
+++ b/infra/keyvault.tf
@@ -8,7 +8,7 @@ resource "random_string" "kv_suffix" {
 
 resource "azurerm_key_vault" "main" {
   # Key Vault names: 3-24 chars, globally unique. Truncate base to fit suffix.
-  name                = "kv-${substr(replace(var.resource_group_name, "rg-", ""), 0, 16)}-${random_string.kv_suffix.result}"
+  name                = "kv-${trimsuffix(substr(replace(var.resource_group_name, "rg-", ""), 0, 16), "-")}-${random_string.kv_suffix.result}"
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
   tenant_id           = data.azurerm_client_config.current.tenant_id

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -26,7 +26,8 @@ terraform {
 
 provider "azurerm" {
   features {}
-  subscription_id = var.subscription_id
+  subscription_id     = var.subscription_id
+  storage_use_azuread = true # Azure Policy enforces shared_access_key_enabled=false
 }
 
 resource "azurerm_resource_group" "main" {

--- a/infra/networking.tf
+++ b/infra/networking.tf
@@ -43,6 +43,14 @@ resource "azurerm_subnet" "keyvault" {
   address_prefixes     = [var.kv_subnet_prefix]
 }
 
+# Storage private endpoint subnet
+resource "azurerm_subnet" "storage" {
+  name                 = "snet-storage"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = [var.storage_subnet_prefix]
+}
+
 # --- NSGs ---
 
 resource "azurerm_network_security_group" "infra" {
@@ -87,6 +95,19 @@ resource "azurerm_network_security_group" "infra" {
     destination_port_range     = "443"
     source_address_prefix      = var.infra_subnet_prefix
     destination_address_prefix = var.kv_subnet_prefix
+  }
+
+  # Allow outbound to Storage via private endpoint
+  security_rule {
+    name                       = "AllowStorageOutbound"
+    priority                   = 130
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = var.infra_subnet_prefix
+    destination_address_prefix = var.storage_subnet_prefix
   }
 
   # Deny all other outbound

--- a/infra/storage.tf
+++ b/infra/storage.tf
@@ -1,0 +1,134 @@
+# --- Storage Account for task dispatch (Queue + Blob + Table) ---
+
+resource "azurerm_storage_account" "tasks" {
+  name                          = substr(replace(lower("st${var.resource_group_name}"), "-", ""), 0, 24)
+  resource_group_name           = azurerm_resource_group.main.name
+  location                      = azurerm_resource_group.main.location
+  account_tier                  = "Standard"
+  account_replication_type      = "LRS"
+  min_tls_version               = "TLS1_2"
+  shared_access_key_enabled     = false # Azure Policy enforces this; KEDA needs MI auth (Phase 3)
+  public_network_access_enabled = true  # Terraform needs data plane access; tighten in Phase 3
+
+  tags = var.tags
+}
+
+resource "azurerm_storage_queue" "tasks" {
+  name               = "task-queue"
+  storage_account_id = azurerm_storage_account.tasks.id
+}
+
+resource "azurerm_storage_container" "tasks" {
+  name               = "task-data"
+  storage_account_id = azurerm_storage_account.tasks.id
+}
+
+# azapi used because azurerm_storage_table makes data-plane ACL calls that
+# fail when shared_access_key_enabled=false (Azure Policy).
+resource "azapi_resource" "dedup_table" {
+  type      = "Microsoft.Storage/storageAccounts/tableServices/tables@2023-05-01"
+  name      = "dedup"
+  parent_id = "${azurerm_storage_account.tasks.id}/tableServices/default"
+}
+
+# Auto-delete blobs after 7 days (results + claim-check params)
+resource "azurerm_storage_management_policy" "task_cleanup" {
+  storage_account_id = azurerm_storage_account.tasks.id
+
+  rule {
+    name    = "delete-old-task-data"
+    enabled = true
+
+    filters {
+      prefix_match = ["task-data/"]
+      blob_types   = ["blockBlob"]
+    }
+
+    actions {
+      base_blob {
+        delete_after_days_since_modification_greater_than = 7
+      }
+    }
+  }
+}
+
+# --- Private Endpoints (blob, queue, table) ---
+
+locals {
+  storage_sub_resources = {
+    blob  = "privatelink.blob.core.windows.net"
+    queue = "privatelink.queue.core.windows.net"
+    table = "privatelink.table.core.windows.net"
+  }
+}
+
+resource "azurerm_private_dns_zone" "storage" {
+  for_each            = local.storage_sub_resources
+  name                = each.value
+  resource_group_name = azurerm_resource_group.main.name
+  tags                = var.tags
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "storage" {
+  for_each              = local.storage_sub_resources
+  name                  = "${each.key}-vnet-link"
+  resource_group_name   = azurerm_resource_group.main.name
+  private_dns_zone_name = azurerm_private_dns_zone.storage[each.key].name
+  virtual_network_id    = azurerm_virtual_network.main.id
+}
+
+resource "azurerm_private_endpoint" "storage" {
+  for_each            = local.storage_sub_resources
+  name                = "pe-${each.key}-${var.resource_group_name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  subnet_id           = azurerm_subnet.storage.id
+
+  private_service_connection {
+    name                           = "${each.key}-connection"
+    private_connection_resource_id = azurerm_storage_account.tasks.id
+    subresource_names              = [each.key]
+    is_manual_connection           = false
+  }
+
+  private_dns_zone_group {
+    name                 = "${each.key}-dns"
+    private_dns_zone_ids = [azurerm_private_dns_zone.storage[each.key].id]
+  }
+
+  tags = var.tags
+}
+
+# --- RBAC: Controller identity ---
+
+resource "azurerm_role_assignment" "controller_queue_sender" {
+  scope                = azurerm_storage_account.tasks.id
+  role_definition_name = "Storage Queue Data Message Sender"
+  principal_id         = azurerm_user_assigned_identity.controller.principal_id
+}
+
+resource "azurerm_role_assignment" "controller_blob" {
+  scope                = azurerm_storage_account.tasks.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.controller.principal_id
+}
+
+resource "azurerm_role_assignment" "controller_table" {
+  scope                = azurerm_storage_account.tasks.id
+  role_definition_name = "Storage Table Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.controller.principal_id
+}
+
+# --- RBAC: Job identity ---
+
+resource "azurerm_role_assignment" "job_queue_processor" {
+  scope                = azurerm_storage_account.tasks.id
+  role_definition_name = "Storage Queue Data Message Processor"
+  principal_id         = azurerm_user_assigned_identity.job.principal_id
+}
+
+resource "azurerm_role_assignment" "job_blob" {
+  scope                = azurerm_storage_account.tasks.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.job.principal_id
+}

--- a/infra/variables-apps.tf
+++ b/infra/variables-apps.tf
@@ -26,6 +26,12 @@ variable "kv_subnet_prefix" {
   default     = "10.0.3.0/24"
 }
 
+variable "storage_subnet_prefix" {
+  description = "CIDR for the Storage Account private endpoint subnet"
+  type        = string
+  default     = "10.0.4.0/24"
+}
+
 # --- Redis ---
 
 variable "redis_sku" {


### PR DESCRIPTION
## What

Add Azure Storage Account infrastructure for task dispatch migration (ADR-0005, Issue #241).

## Why

Replace custom Redis FIFO queue with Azure Storage Queue for reliable, scalable task dispatch. This is Phase 1 (infra only) — no application code changes.

## Resources Added

- **Storage Account** (Standard LRS, TLS 1.2, no shared access keys, private endpoints only)
- **Storage Queue** (`task-queue`) for task dispatch
- **Blob Container** (`task-data`) for claim-check params and results
- **Table** (`dedup`) for deduplication via `azapi_resource` (see note below)
- **7-day blob lifecycle cleanup policy**
- **3 Private Endpoints** (blob, queue, table) via `for_each`
- **3 Private DNS Zones + VNet Links** for all storage sub-resources
- **Storage Subnet** (`snet-storage`, 10.0.4.0/24) + NSG rule (priority 130)
- **5 RBAC Assignments**:
  - Controller → Queue Sender + Blob Contributor + Table Contributor
  - Job → Queue Processor + Blob Contributor

## Notable Decisions

| Decision | Rationale |
|----------|-----------|
| `shared_access_key_enabled = false` | Azure Policy enforces this at subscription level |
| `storage_use_azuread = true` on provider | Required for data plane auth when shared keys are disabled |
| Table via `azapi_resource` | AzureRM `azurerm_storage_table` makes data-plane ACL calls that fail without shared keys |
| `public_network_access_enabled = true` | Terraform provider needs data plane access; tighten in Phase 3 |
| SA name truncated to 24 chars | Azure Storage Account naming limit (3-24 lowercase alphanumeric) |
| KV name `trimsuffix` fix | Pre-existing bug: `substr` can leave trailing hyphens for longer RG names |

## Deployment Test Results

Deployed to isolated test environment (`rg-copilot-storage-test`) with targeted apply (storage resources only, no Redis/Container Apps):

| Resource | Status |
|----------|--------|
| Storage Account (`strgcopilotstoragetest`) | ✅ Standard_LRS, TLS 1.2, no shared keys |
| Queue (`task-queue`) | ✅ Created |
| Blob Container (`task-data`) | ✅ Created |
| Table (`dedup`) | ✅ Created via azapi |
| PE Blob | ✅ Approved, snet-storage |
| PE Queue | ✅ Approved, snet-storage |
| PE Table | ✅ Approved, snet-storage |
| RBAC: Controller → Queue Sender + Blob + Table | ✅ 3 assignments |
| RBAC: Job → Queue Processor + Blob | ✅ 2 assignments |
| Lifecycle Policy (7-day) | ✅ Applied |

Test RG cleaned up after verification.

## Code Review

Cross-model review (GPT-5.3-Codex) completed. One High finding (SA name length) fixed before push.

Closes phase 1 of #241