### PR TITLE
fix(task-runner): write error result blob on task failure

### DIFF
--- a/src/gitlab_copilot_agent/aca_executor.py
+++ b/src/gitlab_copilot_agent/aca_executor.py
@@ -44,6 +44,10 @@ def _parse_result(raw: str, task_type: str) -> TaskResult:
         if isinstance(data, dict) and "result_type" in data:
             if data["result_type"] == "coding":
                 return CodingResult.model_validate(data)
+            if data["result_type"] == "error":
+                summary = data.get("summary", "Task failed (unknown error)")
+                log.error("task_error_result", summary=summary)
+                return ReviewResult(summary=summary)
             return ReviewResult.model_validate(data)
     except (json.JSONDecodeError, ValueError):
         pass

--- a/src/gitlab_copilot_agent/k8s_executor.py
+++ b/src/gitlab_copilot_agent/k8s_executor.py
@@ -101,6 +101,10 @@ def _parse_result(raw: str, task_type: str) -> TaskResult:
         if isinstance(data, dict) and "result_type" in data:
             if data["result_type"] == "coding":
                 return CodingResult.model_validate(data)
+            if data["result_type"] == "error":
+                summary = data.get("summary", "Task failed (unknown error)")
+                log.error("task_error_result", summary=summary)
+                return ReviewResult(summary=summary)
             return ReviewResult.model_validate(data)
     except (json.JSONDecodeError, ValueError):
         pass

--- a/src/gitlab_copilot_agent/task_runner.py
+++ b/src/gitlab_copilot_agent/task_runner.py
@@ -236,12 +236,13 @@ async def run_task() -> int:  # noqa: C901 — dispatch routing requires branchi
                 await task_queue.aclose()
 
     settings = TaskRunnerSettings()
-    _validate_repo_url(repo_url, settings.gitlab_url)
-    await bound_log.ainfo("task_start", repo=_sanitize_url(repo_url), branch=branch)
-    repo_path = await git_clone(
-        repo_url, branch, settings.gitlab_token, clone_dir=settings.clone_dir
-    )
+    repo_path: Path | None = None
     try:
+        _validate_repo_url(repo_url, settings.gitlab_url)
+        await bound_log.ainfo("task_start", repo=_sanitize_url(repo_url), branch=branch)
+        repo_path = await git_clone(
+            repo_url, branch, settings.gitlab_token, clone_dir=settings.clone_dir
+        )
         if task_type == "coding":
             from gitlab_copilot_agent.coding_engine import ensure_git_exclude
 
@@ -269,11 +270,21 @@ async def run_task() -> int:  # noqa: C901 — dispatch routing requires branchi
         import traceback
 
         await bound_log.aerror("task_failed", error=str(exc), traceback=traceback.format_exc())
+        error_result = json.dumps(
+            {"result_type": "error", "error": True, "summary": f"Task failed: {exc}"}
+        )
+        try:
+            await _store_result(task_id, error_result, settings)
+            if task_queue and queue_msg:
+                await task_queue.complete(queue_msg)
+        except Exception:
+            await bound_log.awarning("error_result_write_failed", exc_info=True)
         return 1
     finally:
         if task_queue:
             await task_queue.aclose()
-        shutil.rmtree(repo_path, ignore_errors=True)
+        if repo_path is not None:
+            shutil.rmtree(repo_path, ignore_errors=True)
 
 
 def main() -> None:
@@ -282,3 +293,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/tests/test_aca_executor.py
+++ b/tests/test_aca_executor.py
@@ -240,3 +240,11 @@ class TestParseResult:
         result = _parse_result("", "review")
         assert isinstance(result, ReviewResult)
         assert result.summary == ""
+
+    def test_error_result_returns_review_with_message(self) -> None:
+        from gitlab_copilot_agent.aca_executor import _parse_result
+
+        raw = json.dumps({"result_type": "error", "error": True, "summary": "Task failed: boom"})
+        result = _parse_result(raw, "coding")
+        assert isinstance(result, ReviewResult)
+        assert "Task failed: boom" in result.summary

--- a/tests/test_k8s_executor.py
+++ b/tests/test_k8s_executor.py
@@ -38,6 +38,9 @@ LOCK_KEY = f"aca_exec:{TASK_ID}"
 FAST_POLL_INTERVAL = 0.05  # speed up polling in tests
 CODING_JSON_RESULT = json.dumps({"result_type": "coding", "summary": "coded it"})
 REVIEW_JSON_RESULT = json.dumps({"result_type": "review", "summary": "looks good"})
+ERROR_JSON_RESULT = json.dumps(
+    {"result_type": "error", "error": True, "summary": "Task failed: boom"}
+)
 PLAIN_TEXT_RESULT = "plain text output"
 INVALID_JSON = "{not-valid-json"
 MALFORMED_LOCK = "garbage"
@@ -259,3 +262,8 @@ class TestParseResult:
         result = _parse_result(raw, "coding")
         assert isinstance(result, CodingResult)
         assert result.summary == raw
+
+    def test_error_result_returns_review_with_message(self) -> None:
+        result = _parse_result(ERROR_JSON_RESULT, "coding")
+        assert isinstance(result, ReviewResult)
+        assert "Task failed: boom" in result.summary

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -103,9 +103,13 @@ class TestRunTask:
         monkeypatch.setenv(ENV_REPO_URL, BAD_HOST)
         with (
             patch(f"{_M}._dequeue_task", AsyncMock(return_value=None)),
-            pytest.raises(RuntimeError, match="does not match"),
+            patch(f"{_M}._store_result", AsyncMock()) as store,
         ):
-            await run_task()
+            assert await run_task() == 1
+            store.assert_awaited_once()
+            stored = json.loads(store.call_args[0][1])
+            assert stored["result_type"] == "error"
+            assert "does not match" in stored["summary"]
 
     async def test_coding(self, task_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv(ENV_TASK_TYPE, "coding")
@@ -124,6 +128,21 @@ class TestRunTask:
             assert await run_task() == 0
             assert ms.call_args[1]["task_type"] == "coding"
             assert ms.call_args[1]["validate_response"] is not None
+
+    async def test_failure_writes_error_result(self, task_env: None) -> None:
+        with (
+            patch(f"{_M}._dequeue_task", AsyncMock(return_value=None)),
+            patch(f"{_M}.git_clone", AsyncMock(return_value=Path("/tmp/r"))),
+            patch(f"{_M}.run_copilot_session", AsyncMock(side_effect=RuntimeError("boom"))),
+            patch(f"{_M}._store_result", AsyncMock()) as store,
+            patch(f"{_M}.shutil.rmtree"),
+        ):
+            assert await run_task() == 1
+            store.assert_awaited_once()
+            stored = json.loads(store.call_args[0][1])
+            assert stored["result_type"] == "error"
+            assert stored["error"] is True
+            assert "boom" in stored["summary"]
 
 
 VALID_AGENT_OUTPUT = (


### PR DESCRIPTION
## What

When the task runner fails (git clone error, Copilot timeout, validation failure), it now writes a structured error result to blob storage instead of just logging and exiting. This lets the controller detect the failure immediately instead of polling until timeout.

## Changes

**Task runner** (`task_runner.py`):
- Moved `_validate_repo_url` and `git_clone` inside the try/except block so all failure modes are covered
- On exception: writes `{"result_type": "error", "error": true, "summary": "Task failed: ..."}` to the result store
- Completes the queue message on failure (prevents wasteful KEDA retries)
- Handles `_store_result` failure gracefully (logs warning, still exits 1)

**Both executors** (`k8s_executor.py`, `aca_executor.py`):
- `_parse_result` handles `result_type == "error"` → returns `ReviewResult` with error summary
- Logs `task_error_result` at ERROR level so failures appear in controller logs (not just ephemeral pod logs)

**Tests**: 3 new tests covering error result write, URL mismatch error path, and error result parsing in both executors.

Closes #252

## How to test

```bash
uv run pytest -x
```