### PR TITLE
fix: graceful shutdown with timeout-wrapped cleanup and structured logging

### DIFF
--- a/src/gitlab_copilot_agent/config.py
+++ b/src/gitlab_copilot_agent/config.py
@@ -92,6 +92,9 @@ class Settings(BaseSettings):
         default=None,
         description="Base directory for repo clones. Defaults to system temp.",
     )
+    shutdown_timeout: int = Field(
+        default=30, gt=0, description="Graceful shutdown timeout in seconds"
+    )
 
     # Task execution
     task_executor: Literal["local", "kubernetes", "container_apps"] = Field(

--- a/src/gitlab_copilot_agent/main.py
+++ b/src/gitlab_copilot_agent/main.py
@@ -1,5 +1,6 @@
 """FastAPI application entrypoint."""
 
+import asyncio
 import glob
 import os
 import shutil
@@ -190,19 +191,37 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await log.ainfo("service started", gitlab_url=settings.gitlab_url)
     yield
 
+    # -- Graceful shutdown with per-step timeouts --
+    steps: list[tuple[str, object]] = []
     if poller:
-        await poller.stop()
+        steps.append(("jira_poller_stop", poller.stop()))
     if gl_poller:
-        await gl_poller.stop()
+        steps.append(("gitlab_poller_stop", gl_poller.stop()))
     if jira_client:
-        await jira_client.close()
-    try:
-        await dedup_store.aclose()
-    except Exception:
-        await log.aexception("dedup_store_close_failed")
-    await repo_locks.aclose()
-    await log.ainfo("service stopped")
-    shutdown_telemetry()
+        steps.append(("jira_client_close", jira_client.close()))
+    steps.append(("dedup_store_close", dedup_store.aclose()))
+    steps.append(("repo_locks_close", repo_locks.aclose()))
+    steps.append(("telemetry_flush", asyncio.to_thread(shutdown_telemetry)))
+
+    num_steps = len(steps)
+    per_step = settings.shutdown_timeout / max(num_steps, 1)
+    timed_out: list[str] = []
+
+    await log.ainfo("shutdown_started", steps=num_steps, per_step_timeout=round(per_step, 1))
+    for name, coro in steps:
+        try:
+            await asyncio.wait_for(coro, timeout=per_step)  # type: ignore[arg-type]
+            await log.ainfo("shutdown_step_done", step=name)
+        except TimeoutError:
+            timed_out.append(name)
+            await log.awarning("shutdown_step_timeout", step=name, timeout=round(per_step, 1))
+        except Exception:
+            await log.awarning("shutdown_step_error", step=name, exc_info=True)
+
+    await log.ainfo(
+        "shutdown_complete",
+        timed_out_steps=timed_out if timed_out else None,
+    )
 
 
 app = FastAPI(title="GitLab Copilot Agent", lifespan=lifespan)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -103,11 +103,11 @@ async def test_lifespan_with_jira_creates_shared_lock_manager(
 
 
 EXPECTED_SHUTDOWN_ORDER = [
-    "poller.stop",
-    "jira.close",
-    "dedup.aclose",
-    "repo_locks.aclose",
-    "shutdown_telemetry",
+    "jira_poller_stop",
+    "jira_client_close",
+    "dedup_store_close",
+    "repo_locks_close",
+    "telemetry_flush",
 ]
 
 
@@ -116,24 +116,21 @@ async def test_shutdown_call_ordering(
     env_vars: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Verify shutdown calls happen in the correct order.
-
-    Expected: poller.stop → jira.close → dedup.aclose → repo_locks.aclose → shutdown_telemetry.
-    """
+    """Verify shutdown calls happen in the correct order with structured logging."""
     call_order: list[str] = []
 
     mock_poller = AsyncMock()
     mock_poller.start = AsyncMock()
-    mock_poller.stop = AsyncMock(side_effect=lambda: call_order.append("poller.stop"))
+    mock_poller.stop = AsyncMock(side_effect=lambda: call_order.append("jira_poller_stop"))
 
     mock_jira = AsyncMock()
-    mock_jira.close = AsyncMock(side_effect=lambda: call_order.append("jira.close"))
+    mock_jira.close = AsyncMock(side_effect=lambda: call_order.append("jira_client_close"))
 
     mock_dedup = AsyncMock()
-    mock_dedup.aclose = AsyncMock(side_effect=lambda: call_order.append("dedup.aclose"))
+    mock_dedup.aclose = AsyncMock(side_effect=lambda: call_order.append("dedup_store_close"))
 
     mock_locks = AsyncMock()
-    mock_locks.aclose = AsyncMock(side_effect=lambda: call_order.append("repo_locks.aclose"))
+    mock_locks.aclose = AsyncMock(side_effect=lambda: call_order.append("repo_locks_close"))
 
     monkeypatch.setenv("JIRA_URL", JIRA_URL)
     monkeypatch.setenv("JIRA_EMAIL", JIRA_EMAIL)
@@ -152,7 +149,7 @@ async def test_shutdown_call_ordering(
         patch("gitlab_copilot_agent.main.create_dedup", return_value=mock_dedup),
         patch(
             "gitlab_copilot_agent.main.shutdown_telemetry",
-            side_effect=lambda: call_order.append("shutdown_telemetry"),
+            side_effect=lambda: call_order.append("telemetry_flush"),
         ),
     ):
         async with lifespan(test_app):
@@ -162,18 +159,18 @@ async def test_shutdown_call_ordering(
 
 
 @pytest.mark.asyncio
-async def test_shutdown_continues_when_dedup_close_fails(
+async def test_shutdown_continues_when_step_fails(
     env_vars: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Verify repo_locks and telemetry shut down even if dedup.aclose() raises."""
+    """Verify remaining steps run even if one step raises."""
     call_order: list[str] = []
 
     mock_dedup = AsyncMock()
-    mock_dedup.aclose = AsyncMock(side_effect=RuntimeError("redis gone"))
+    mock_dedup.aclose = AsyncMock(side_effect=RuntimeError("connection lost"))
 
     mock_locks = AsyncMock()
-    mock_locks.aclose = AsyncMock(side_effect=lambda: call_order.append("repo_locks.aclose"))
+    mock_locks.aclose = AsyncMock(side_effect=lambda: call_order.append("repo_locks_close"))
 
     test_app = FastAPI()
 
@@ -182,14 +179,52 @@ async def test_shutdown_continues_when_dedup_close_fails(
         patch("gitlab_copilot_agent.main.create_dedup", return_value=mock_dedup),
         patch(
             "gitlab_copilot_agent.main.shutdown_telemetry",
-            side_effect=lambda: call_order.append("shutdown_telemetry"),
+            side_effect=lambda: call_order.append("telemetry_flush"),
         ),
     ):
         async with lifespan(test_app):
             pass
 
-    assert "repo_locks.aclose" in call_order
-    assert "shutdown_telemetry" in call_order
+    assert "repo_locks_close" in call_order
+    assert "telemetry_flush" in call_order
+
+
+@pytest.mark.asyncio
+async def test_shutdown_continues_when_step_times_out(
+    env_vars: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify remaining steps run even if one step hangs past the timeout."""
+    import asyncio
+
+    call_order: list[str] = []
+
+    monkeypatch.setenv("SHUTDOWN_TIMEOUT", "2")
+
+    async def _hang_forever() -> None:
+        await asyncio.sleep(999)
+
+    mock_dedup = AsyncMock()
+    mock_dedup.aclose = _hang_forever
+
+    mock_locks = AsyncMock()
+    mock_locks.aclose = AsyncMock(side_effect=lambda: call_order.append("repo_locks_close"))
+
+    test_app = FastAPI()
+
+    with (
+        patch("gitlab_copilot_agent.main.create_lock", return_value=mock_locks),
+        patch("gitlab_copilot_agent.main.create_dedup", return_value=mock_dedup),
+        patch(
+            "gitlab_copilot_agent.main.shutdown_telemetry",
+            side_effect=lambda: call_order.append("telemetry_flush"),
+        ),
+    ):
+        async with lifespan(test_app):
+            pass
+
+    assert "repo_locks_close" in call_order
+    assert "telemetry_flush" in call_order
 
 
 # -- Allowlist tests --


### PR DESCRIPTION
## What

Wraps each shutdown cleanup step in `asyncio.wait_for()` with per-step timeouts so Ctrl+C / SIGTERM always completes cleanly. Steps that hang or raise are logged and skipped — remaining steps still execute.

## Changes

**`main.py`** — Shutdown block rewritten as a loop over named steps, each with `asyncio.wait_for(coro, timeout=per_step)`. `shutdown_telemetry()` (sync) wrapped in `asyncio.to_thread()`.

**`config.py`** — Added `shutdown_timeout: int = Field(default=30, gt=0)` to `Settings`.

**`test_main.py`** — Updated 3 shutdown tests:
- Order test: verifies steps execute in sequence with new step names
- Error test: one step raises → remaining steps still run
- Timeout test: one step hangs → times out → remaining steps still run (uses `SHUTDOWN_TIMEOUT=2` for speed)

Structured log events: `shutdown_started`, `shutdown_step_done`, `shutdown_step_timeout`, `shutdown_step_error`, `shutdown_complete`.

Closes #178

## Test results

```
413 passed in 31.57s
Coverage: 91.25% (threshold: 90%)
ruff check: All checks passed
mypy: Success, no issues found in 33 source files
```

## Code review

Cross-model review (GPT-5.1-Codex) found 1 issue, fixed before push:
- **Medium**: `SHUTDOWN_TIMEOUT=0` would cause all steps to time out immediately. Fixed by adding `gt=0` validation to the config field.

## How to test

```bash
uv run pytest -x
# Manual: run the service, Ctrl+C, observe structured shutdown logs
```