### PR TITLE
feat(jira): add credential registry for per-repo tokens

### DIFF
--- a/src/gitlab_copilot_agent/credential_registry.py
+++ b/src/gitlab_copilot_agent/credential_registry.py
@@ -1,0 +1,69 @@
+"""Credential registry — resolves credential aliases to GitLab tokens.
+
+Reads ``GITLAB_TOKEN`` (the default) and ``GITLAB_TOKEN__<ALIAS>`` env vars
+at construction time.  A binding's ``credential_ref`` is resolved to the
+matching token via :meth:`resolve`.
+
+No raw secrets are ever logged.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+import structlog
+
+log = structlog.get_logger()
+
+_ALIAS_PATTERN = re.compile(r"^GITLAB_TOKEN__(.+)$")
+
+
+class CredentialRegistry:
+    """Startup-loaded registry mapping credential aliases to tokens."""
+
+    def __init__(self, *, default_token: str, named_tokens: dict[str, str] | None = None) -> None:
+        self._tokens: dict[str, str] = {"default": default_token}
+        for alias, token in (named_tokens or {}).items():
+            self._tokens[alias.lower()] = token
+
+    @classmethod
+    def from_env(cls) -> CredentialRegistry:
+        """Build a registry from the current environment.
+
+        Reads ``GITLAB_TOKEN`` as the default credential, plus any
+        ``GITLAB_TOKEN__<ALIAS>`` env vars as named credentials.
+        """
+        default_token = os.environ.get("GITLAB_TOKEN", "")
+        if not default_token:
+            msg = "GITLAB_TOKEN is required"
+            raise ValueError(msg)
+
+        named: dict[str, str] = {}
+        for key, value in os.environ.items():
+            m = _ALIAS_PATTERN.match(key)
+            if m and value:
+                named[m.group(1).lower()] = value
+
+        registry = cls(default_token=default_token, named_tokens=named)
+        log.info(
+            "credential_registry_loaded",
+            aliases=sorted(registry.aliases()),
+        )
+        return registry
+
+    def resolve(self, credential_ref: str) -> str:
+        """Return the token for *credential_ref*, or raise ``KeyError``."""
+        ref = credential_ref.lower()
+        try:
+            return self._tokens[ref]
+        except KeyError:
+            msg = (
+                f"Unknown credential_ref '{credential_ref}'. "
+                f"Available: {', '.join(sorted(self._tokens))}"
+            )
+            raise KeyError(msg) from None
+
+    def aliases(self) -> set[str]:
+        """Return all registered credential aliases."""
+        return set(self._tokens)

--- a/tests/test_credential_registry.py
+++ b/tests/test_credential_registry.py
@@ -1,0 +1,94 @@
+"""Tests for credential registry — alias resolution and env var loading."""
+
+from __future__ import annotations
+
+import pytest
+
+from gitlab_copilot_agent.credential_registry import CredentialRegistry
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_TOKEN = "glpat-default-token"
+PLATFORM_TOKEN = "glpat-platform-token"
+OPS_TOKEN = "glpat-ops-token"
+
+
+# ---------------------------------------------------------------------------
+# Constructor
+# ---------------------------------------------------------------------------
+
+
+class TestConstructor:
+    def test_default_only(self) -> None:
+        reg = CredentialRegistry(default_token=DEFAULT_TOKEN)
+        assert reg.resolve("default") == DEFAULT_TOKEN
+        assert reg.aliases() == {"default"}
+
+    def test_named_tokens(self) -> None:
+        reg = CredentialRegistry(
+            default_token=DEFAULT_TOKEN,
+            named_tokens={"platform_team": PLATFORM_TOKEN},
+        )
+        assert reg.resolve("platform_team") == PLATFORM_TOKEN
+        assert reg.resolve("default") == DEFAULT_TOKEN
+
+    def test_alias_case_insensitive(self) -> None:
+        reg = CredentialRegistry(
+            default_token=DEFAULT_TOKEN,
+            named_tokens={"Platform_Team": PLATFORM_TOKEN},
+        )
+        assert reg.resolve("platform_team") == PLATFORM_TOKEN
+        assert reg.resolve("PLATFORM_TEAM") == PLATFORM_TOKEN
+
+
+# ---------------------------------------------------------------------------
+# resolve
+# ---------------------------------------------------------------------------
+
+
+class TestResolve:
+    def test_unknown_ref_raises(self) -> None:
+        reg = CredentialRegistry(default_token=DEFAULT_TOKEN)
+        with pytest.raises(KeyError, match="Unknown credential_ref 'missing'"):
+            reg.resolve("missing")
+
+    def test_error_lists_available(self) -> None:
+        reg = CredentialRegistry(
+            default_token=DEFAULT_TOKEN,
+            named_tokens={"ops": OPS_TOKEN},
+        )
+        with pytest.raises(KeyError, match="default.*ops"):
+            reg.resolve("nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# from_env
+# ---------------------------------------------------------------------------
+
+
+class TestFromEnv:
+    def test_loads_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GITLAB_TOKEN", DEFAULT_TOKEN)
+        reg = CredentialRegistry.from_env()
+        assert reg.resolve("default") == DEFAULT_TOKEN
+
+    def test_loads_named(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GITLAB_TOKEN", DEFAULT_TOKEN)
+        monkeypatch.setenv("GITLAB_TOKEN__PLATFORM_TEAM", PLATFORM_TOKEN)
+        monkeypatch.setenv("GITLAB_TOKEN__OPS", OPS_TOKEN)
+        reg = CredentialRegistry.from_env()
+        assert reg.resolve("platform_team") == PLATFORM_TOKEN
+        assert reg.resolve("ops") == OPS_TOKEN
+
+    def test_missing_default_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+        with pytest.raises(ValueError, match="GITLAB_TOKEN is required"):
+            CredentialRegistry.from_env()
+
+    def test_ignores_empty_named(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GITLAB_TOKEN", DEFAULT_TOKEN)
+        monkeypatch.setenv("GITLAB_TOKEN__EMPTY", "")
+        reg = CredentialRegistry.from_env()
+        assert reg.aliases() == {"default"}


### PR DESCRIPTION
## What

Add `CredentialRegistry` module for resolving credential aliases to GitLab tokens (PR 2a of #270).

## Why

The YAML mapping model (PR #277) introduced `credential_ref` per binding. This PR adds the registry that maps those aliases to actual tokens at runtime.

## Changes

- **`credential_registry.py`**: Reads `GITLAB_TOKEN` (default) and `GITLAB_TOKEN__<ALIAS>` env vars. Case-insensitive alias lookup. Never logs raw secrets.
- **`test_credential_registry.py`**: 9 tests covering constructor, `resolve()`, `from_env()`, error cases.

## Does NOT change

Any existing runtime code. This is a standalone module — the next PR will add `ProjectRegistry` and wire both into the startup flow.

Part of #270