### PR TITLE
feat(jira): add project registry with resolved project context

### DIFF
--- a/src/gitlab_copilot_agent/project_registry.py
+++ b/src/gitlab_copilot_agent/project_registry.py
@@ -1,0 +1,86 @@
+"""Project registry — resolves Jira→GitLab project context at startup."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import structlog
+
+from gitlab_copilot_agent.credential_registry import CredentialRegistry
+from gitlab_copilot_agent.gitlab_client import GitLabClient
+from gitlab_copilot_agent.mapping_models import RenderedMap
+
+log = structlog.get_logger()
+
+
+@dataclass(frozen=True, repr=False)
+class ResolvedProject:
+    """Fully resolved project context ready for runtime use."""
+
+    jira_project: str
+    repo: str
+    gitlab_project_id: int
+    clone_url: str
+    target_branch: str
+    credential_ref: str
+    token: str
+
+    def __repr__(self) -> str:
+        return (
+            f"ResolvedProject(jira_project={self.jira_project!r}, "
+            f"repo={self.repo!r}, gitlab_project_id={self.gitlab_project_id}, "
+            f"credential_ref={self.credential_ref!r}, token='***')"
+        )
+
+
+class ProjectRegistry:
+    """Immutable lookup of Jira key or GitLab project ID → ResolvedProject."""
+
+    def __init__(self, projects: list[ResolvedProject]) -> None:
+        self._by_jira = {p.jira_project: p for p in projects}
+        self._by_project_id: dict[int, ResolvedProject] = {}
+        for p in projects:
+            if p.gitlab_project_id in self._by_project_id:
+                other = self._by_project_id[p.gitlab_project_id]
+                raise ValueError(
+                    f"Duplicate gitlab_project_id {p.gitlab_project_id}: "
+                    f"{other.jira_project} and {p.jira_project}"
+                )
+            self._by_project_id[p.gitlab_project_id] = p
+
+    def get_by_jira(self, jira_key: str) -> ResolvedProject | None:
+        return self._by_jira.get(jira_key)
+
+    def get_by_project_id(self, project_id: int) -> ResolvedProject | None:
+        return self._by_project_id.get(project_id)
+
+    def jira_keys(self) -> set[str]:
+        return set(self._by_jira)
+
+    @classmethod
+    async def from_rendered_map(
+        cls,
+        rendered: RenderedMap,
+        credentials: CredentialRegistry,
+        gitlab_url: str,
+    ) -> ProjectRegistry:
+        projects: list[ResolvedProject] = []
+        base = gitlab_url.rstrip("/").split("://", 1)[-1]
+        for jira_key, binding in rendered.mappings.items():
+            token = credentials.resolve(binding.credential_ref)
+            client = GitLabClient(gitlab_url, token)
+            pid = await client.resolve_project(binding.repo)
+            projects.append(
+                ResolvedProject(
+                    jira_project=jira_key,
+                    repo=binding.repo,
+                    gitlab_project_id=pid,
+                    clone_url=f"https://{base}/{binding.repo}.git",
+                    target_branch=binding.target_branch,
+                    credential_ref=binding.credential_ref,
+                    token=token,
+                )
+            )
+        registry = cls(projects)
+        await log.ainfo("project_registry_loaded", count=len(projects))
+        return registry

--- a/tests/test_project_registry.py
+++ b/tests/test_project_registry.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gitlab_copilot_agent.credential_registry import CredentialRegistry
+from gitlab_copilot_agent.mapping_models import RenderedBinding, RenderedMap
+from gitlab_copilot_agent.project_registry import ProjectRegistry, ResolvedProject
+
+GITLAB_URL = "https://gitlab.example.com"
+DEFAULT_TOKEN = "glpat-default-token"  # noqa: S105
+PLATFORM_TOKEN = "glpat-platform-token"  # noqa: S105
+JIRA_PROJ = "PROJ"
+JIRA_OPS = "OPS"
+REPO_A = "group/service-a"
+REPO_B = "group/platform-tools"
+PID_A, PID_B = 42, 99
+
+
+def _proj(
+    jira: str = JIRA_PROJ,
+    repo: str = REPO_A,
+    pid: int = PID_A,
+    branch: str = "main",
+    cred: str = "default",
+    token: str = DEFAULT_TOKEN,
+) -> ResolvedProject:
+    return ResolvedProject(
+        jira_project=jira,
+        repo=repo,
+        gitlab_project_id=pid,
+        clone_url=f"{GITLAB_URL}/{repo}.git",
+        target_branch=branch,
+        credential_ref=cred,
+        token=token,
+    )
+
+
+def _registry() -> ProjectRegistry:
+    return ProjectRegistry(
+        [
+            _proj(),
+            _proj(
+                jira=JIRA_OPS,
+                repo=REPO_B,
+                pid=PID_B,
+                branch="develop",
+                cred="platform_team",
+                token=PLATFORM_TOKEN,
+            ),
+        ]
+    )
+
+
+class TestLookup:
+    def test_get_by_jira(self) -> None:
+        assert _registry().get_by_jira(JIRA_PROJ) is not None
+
+    def test_get_by_jira_missing(self) -> None:
+        assert _registry().get_by_jira("MISSING") is None
+
+    def test_get_by_project_id(self) -> None:
+        p = _registry().get_by_project_id(PID_B)
+        assert p is not None and p.jira_project == JIRA_OPS
+
+    def test_get_by_project_id_missing(self) -> None:
+        assert _registry().get_by_project_id(999) is None
+
+    def test_jira_keys(self) -> None:
+        assert _registry().jira_keys() == {JIRA_PROJ, JIRA_OPS}
+
+    def test_duplicate_project_id_raises(self) -> None:
+        with pytest.raises(ValueError, match="Duplicate gitlab_project_id"):
+            ProjectRegistry([_proj(jira="A"), _proj(jira="B")])
+
+    def test_repr_hides_token(self) -> None:
+        r = repr(_proj())
+        assert DEFAULT_TOKEN not in r and "***" in r
+
+
+def _binding(repo: str = REPO_A, branch: str = "main", cred: str = "default") -> RenderedBinding:
+    return RenderedBinding(repo=repo, target_branch=branch, credential_ref=cred)
+
+
+class TestFromRenderedMap:
+    async def test_resolves_with_multi_credential(self) -> None:
+        rendered = RenderedMap(
+            mappings={
+                JIRA_PROJ: _binding(),
+                JIRA_OPS: _binding(repo=REPO_B, branch="develop", cred="platform_team"),
+            }
+        )
+        creds = CredentialRegistry(
+            default_token=DEFAULT_TOKEN,
+            named_tokens={"platform_team": PLATFORM_TOKEN},
+        )
+        with patch("gitlab_copilot_agent.project_registry.GitLabClient") as MC:
+            MC.return_value = AsyncMock(
+                resolve_project=AsyncMock(side_effect=[PID_A, PID_B]),
+            )
+            reg = await ProjectRegistry.from_rendered_map(rendered, creds, GITLAB_URL)
+        p = reg.get_by_jira(JIRA_PROJ)
+        assert p is not None and p.gitlab_project_id == PID_A and p.token == DEFAULT_TOKEN
+        assert p.clone_url == f"https://gitlab.example.com/{REPO_A}.git"
+        o = reg.get_by_jira(JIRA_OPS)
+        assert o is not None and o.token == PLATFORM_TOKEN
+
+    async def test_unknown_credential_ref_raises(self) -> None:
+        rendered = RenderedMap(mappings={JIRA_PROJ: _binding(cred="nonexistent")})
+        creds = CredentialRegistry(default_token=DEFAULT_TOKEN)
+        with pytest.raises(KeyError, match="Unknown credential_ref"):
+            await ProjectRegistry.from_rendered_map(rendered, creds, GITLAB_URL)


### PR DESCRIPTION
## What

Add `ProjectRegistry` module that resolves rendered map bindings into full runtime context (PR 2b of #270).

## Why

The credential registry (PR #278) provides token resolution. This PR adds the project-level registry that combines credential lookup with GitLab API project resolution, producing `ResolvedProject` objects ready for runtime use.

## Changes

- **`project_registry.py`**: `ResolvedProject` dataclass (token-safe repr), `ProjectRegistry` class with Jira key + project ID lookups, async `from_rendered_map()` factory.
- **`test_project_registry.py`**: 9 tests — lookup, missing keys, duplicate project ID rejection, repr token masking, multi-credential resolution, unknown credential error.

## Code review findings addressed

- **High**: Duplicate GitLab project IDs now raise `ValueError` at construction (prevents silent overwrite)
- **Medium**: `ResolvedProject.__repr__` masks token field with `***`

## Does NOT change

Any existing runtime code. Next PR will wire registries into `main.py`, `jira_poller.py`, and `coding_orchestrator.py`.

Part of #270