### PR TITLE
chore: strengthen review gates and model requirements

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,15 +64,18 @@ These are non-negotiable. Violating any of these is a session failure.
 
 1. **NEVER merge PRs.** Create the PR, then stop. The user reviews and merges all PRs. No exceptions, no "it's a small change", no "CI passed so it's safe."
 2. **Run the full CI-equivalent locally before every commit.** If the project has a `make lint`, `make test`, or equivalent — run it. Do not run individual tools (e.g., just the formatter) as a shortcut. If CI fails on something you could have caught locally, that's a bug in your process.
-3. **Cross-model code review before every PR push.** No exceptions for "small" PRs. Invoke the `code-review` skill or a code-review agent using a different model than the one that wrote the code.
-4. **Verify your git branch before every commit.** Run `git branch --show-current` before committing, especially after rebase, stash, or checkout operations. Committing to the wrong branch wastes time and risks force-push accidents.
-5. **Smoke-test behavioral changes.** Unit tests passing is necessary but not sufficient. If you change logging, telemetry, startup behavior, or error handling — verify with a quick manual run if possible. Don't let the user discover broken behavior live.
+3. **Cross-model code review before every PR push.** No exceptions for "small" PRs. Invoke the `code-review` skill or a code-review agent using a different model than the one that wrote the code. See the code-review skill for approved model pairs.
+4. **OWASP security review before every PR push.** No exceptions. Invoke the `owasp-review` skill on every PR, just like code review. Security issues hide in unexpected places.
+5. **Verify your git branch before every commit.** Run `git branch --show-current` before committing, especially after rebase, stash, or checkout operations. Committing to the wrong branch wastes time and risks force-push accidents.
+6. **Smoke-test behavioral changes.** Unit tests passing is necessary but not sufficient. If you change logging, telemetry, startup behavior, or error handling — verify with a quick manual run if possible. Don't let the user discover broken behavior live.
+7. **Documentation alongside code, not after.** Every PR that changes module boundaries, data flow, security model, or public APIs must include documentation updates in the same PR. Do not defer docs to a follow-up unless the PR is already at the 200-line limit.
 
 ## PR Requirements
 
-- ≤200 diff lines (additions + deletions). If larger, split into stacked PRs.
+- ≤200 diff lines of **code** (additions + deletions). Documentation, code comments, and test fixtures do not count toward this limit.
 - Each stacked PR must be fully functional and standalone.
-- **Code review before push**: invoke a code review agent (ideally a different model than the one that wrote the code) on every PR. Fix all High/Critical findings before merge. Create follow-up issues for Medium findings.
+- **Code review before push**: invoke a code review agent (using the approved cross-vendor model — see code-review skill) on every PR. Fix all High/Critical findings before merge. Create follow-up issues for Medium findings.
+- **Security review before push**: invoke the `owasp-review` skill on every PR, same as code review.
 - PR description format:
   ```
   ## What

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -9,7 +9,10 @@ Every PR gets a code review before push. No exceptions.
 
 ## How to Review
 
-1. Use a **different model** than the one that wrote the code. Cross-model review consistently catches bugs that self-review misses.
+1. Use a **different vendor's model** than the one that wrote the code. Cross-vendor review consistently catches bugs that same-vendor review misses.
+   - If **Claude** wrote the code → review with `model: "gpt-5.4"`
+   - If **GPT** wrote the code → review with `model: "claude-opus-4.6"`
+   - Always pass the `model` parameter explicitly when invoking the code-review agent. Never rely on defaults.
 2. Review the branch diff against the base branch, not individual files.
 3. Focus on: bugs, security issues, logic errors, missing edge cases. Ignore style and formatting.
 
@@ -45,3 +48,15 @@ Before reviewing logic, verify the author ran both linter and formatter:
 1. Check the diff for formatting-only changes (inconsistent whitespace, import ordering). If present, reject — the author didn't run the formatter.
 2. If you can run commands, execute the project's lint and format-check commands on the changed files. Report any failures as **High** severity (broken CI pipeline).
 3. Only proceed to logic review after lint/format is clean.
+
+## Pre-Push Checklist
+
+The implementing agent MUST complete all items before `git push`. Track these as SQL todos with dependencies when working on stacked PRs.
+
+1. ✅ `uv run ruff check && uv run ruff format --check` passes (or project equivalent)
+2. ✅ `uv run pytest` passes with coverage threshold met (or project equivalent)
+3. ✅ Cross-vendor code review invoked (see model pairs above)
+4. ✅ OWASP review invoked (every PR, no exceptions)
+5. ✅ Architecture docs updated if PR changes module boundaries, data flow, or security model
+6. ✅ ADR created if PR makes a decision that would be hard to reverse
+7. ✅ `git branch --show-current` confirms correct branch


### PR DESCRIPTION
## What

Strengthen project instructions based on session retrospective findings from PRs #277–#282.

## Why

During the #270 implementation session, several process gaps were identified:
- Security reviews (OWASP) were only run when explicitly requested, not proactively
- Documentation was deferred until the user asked about it
- Code reviews didn't consistently use a different vendor's model
- PR size limits penalized including docs alongside code

## Changes

### copilot-instructions.md
- **New hard rule #4**: Mandatory OWASP review for PRs touching auth, tokens, credentials, external comms, or data storage
- **New hard rule #7**: Documentation alongside code — every PR that changes module boundaries, data flow, or security model must include doc updates
- **PR size limit**: 200 lines now applies to **code only** — docs, comments, and test fixtures are excluded
- **PR requirements**: Explicitly require security review before push

### code-review/SKILL.md
- **Explicit model pairs**: Claude → GPT-5.4, GPT → Claude Opus 4.6 (no ambiguity)
- **Pre-push checklist**: 7-item checklist implementing agents must complete before `git push`
- **Model parameter required**: Must always pass `model` explicitly, never rely on defaults

## How to Test

These are instruction/process changes — no runtime behavior affected. Verify by reading the updated files.