### PR TITLE
feat(credentials): thread per-project tokens through controller paths

### DIFF
--- a/src/gitlab_copilot_agent/gitlab_poller.py
+++ b/src/gitlab_copilot_agent/gitlab_poller.py
@@ -11,6 +11,7 @@ import structlog
 from gitlab_copilot_agent.concurrency import DeduplicationStore, DistributedLock
 from gitlab_copilot_agent.config import Settings
 from gitlab_copilot_agent.gitlab_client import (
+    GitLabClient,
     GitLabClientProtocol,
     MRListItem,
     NoteListItem,
@@ -27,6 +28,7 @@ from gitlab_copilot_agent.models import (
 )
 from gitlab_copilot_agent.mr_comment_handler import handle_copilot_comment, parse_copilot_command
 from gitlab_copilot_agent.orchestrator import handle_review
+from gitlab_copilot_agent.project_registry import ProjectRegistry
 from gitlab_copilot_agent.task_executor import TaskExecutor
 
 log = structlog.get_logger()
@@ -45,6 +47,7 @@ class GitLabPoller:
         dedup: DeduplicationStore,
         executor: TaskExecutor,
         repo_locks: DistributedLock | None = None,
+        project_registry: ProjectRegistry | None = None,
     ) -> None:
         self._client = gl_client
         self._settings = settings
@@ -52,6 +55,8 @@ class GitLabPoller:
         self._dedup = dedup
         self._executor = executor
         self._repo_locks = repo_locks
+        self._project_registry = project_registry
+        self._project_clients: dict[str, GitLabClientProtocol] = {}
         self._interval: int = 30
         self._task: asyncio.Task[None] | None = None
         self._watermark: str | None = None
@@ -87,14 +92,41 @@ class GitLabPoller:
     async def _poll_once(self) -> None:
         poll_start = datetime.now(UTC).isoformat()
         for pid in self._project_ids:
-            mrs = await self._client.list_project_mrs(
-                pid, state="opened", updated_after=self._watermark
-            )
+            client = self._client_for_project(pid)
+            mrs = await client.list_project_mrs(pid, state="opened", updated_after=self._watermark)
             for mr in mrs:
                 await self._process_mr(pid, mr)
-            await self._process_notes(pid, mrs)
+            await self._process_notes(pid, mrs, client)
         self._watermark = poll_start
         self._note_watermark = poll_start
+
+    def _resolve_token(self, project_id: int) -> str | None:
+        """Return per-project token from registry, or None for global fallback."""
+        if self._project_registry is not None:
+            resolved = self._project_registry.get_by_project_id(project_id)
+            if resolved is not None:
+                log.info(
+                    "credential_resolved",
+                    project_id=project_id,
+                    credential_ref=resolved.credential_ref,
+                    source="project_registry",
+                )
+                return resolved.token
+        log.info("credential_resolved", project_id=project_id, source="global_fallback")
+        return None
+
+    def _client_for_project(self, project_id: int) -> GitLabClientProtocol:
+        """Return a per-project GitLabClient if available, else the default client."""
+        if self._project_registry is not None:
+            resolved = self._project_registry.get_by_project_id(project_id)
+            if resolved is not None:
+                ref = resolved.credential_ref
+                if ref not in self._project_clients:
+                    self._project_clients[ref] = GitLabClient(
+                        self._settings.gitlab_url, resolved.token
+                    )
+                return self._project_clients[ref]
+        return self._client
 
     async def _process_mr(self, project_id: int, mr: MRListItem) -> None:
         if self._settings.gitlab_review_on_push:
@@ -126,12 +158,19 @@ class GitLabPoller:
                 oldrev=None,
             ),
         )
-        await handle_review(self._settings, payload, self._executor)
+        await handle_review(
+            self._settings,
+            payload,
+            self._executor,
+            project_token=self._resolve_token(project_id),
+        )
         await self._dedup.mark_seen(key, ttl_seconds=_DEDUP_TTL)
 
-    async def _process_notes(self, project_id: int, mrs: list[MRListItem]) -> None:
+    async def _process_notes(
+        self, project_id: int, mrs: list[MRListItem], client: GitLabClientProtocol
+    ) -> None:
         for mr in mrs:
-            notes = await self._client.list_mr_notes(
+            notes = await client.list_mr_notes(
                 project_id, mr.iid, created_after=self._note_watermark
             )
             for note in notes:
@@ -148,7 +187,11 @@ class GitLabPoller:
                     continue
                 payload = _build_note_payload(note, mr, project_id, self._settings)
                 await handle_copilot_comment(
-                    self._settings, payload, self._executor, self._repo_locks
+                    self._settings,
+                    payload,
+                    self._executor,
+                    self._repo_locks,
+                    project_token=self._resolve_token(project_id),
                 )
                 await self._dedup.mark_seen(note_key, ttl_seconds=_DEDUP_TTL)
 

--- a/src/gitlab_copilot_agent/main.py
+++ b/src/gitlab_copilot_agent/main.py
@@ -160,6 +160,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     poller: JiraPoller | None = None
     gl_poller: GitLabPoller | None = None
     jira_client: JiraClient | None = None
+    project_registry: ProjectRegistry | None = None
     if settings.jira:
         jira_client = JiraClient(settings.jira.url, settings.jira.email, settings.jira.api_token)
         rendered = RenderedMap.model_validate_json(settings.jira.project_map_json)
@@ -182,6 +183,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         app.state.jira_poller = poller
         await log.ainfo("jira_poller_started", interval=settings.jira.poll_interval)
 
+    app.state.project_registry = project_registry
+
     if settings.gitlab_poll and allowed_project_ids:
         gl_client_poll = GitLabClient(settings.gitlab_url, settings.gitlab_token)
         gl_poller = GitLabPoller(
@@ -191,6 +194,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             dedup=dedup_store,
             executor=app.state.executor,
             repo_locks=repo_locks,
+            project_registry=project_registry,
         )
         gl_poller._interval = settings.gitlab_poll_interval
         await gl_poller.start()
@@ -282,6 +286,11 @@ async def config_reload(
         await log.aerror("config_reload_failed", error=str(exc))
         return {"status": "error", "detail": "Invalid configuration — check server logs"}
     await poller.reload_registry(registry)
+    app.state.project_registry = registry
+    gl_poller: GitLabPoller | None = getattr(app.state, "gl_poller", None)
+    if gl_poller is not None:
+        gl_poller._project_registry = registry
+        gl_poller._project_clients.clear()
     return {
         "status": "ok",
         "jira_keys": sorted(registry.jira_keys()),

--- a/src/gitlab_copilot_agent/mr_comment_handler.py
+++ b/src/gitlab_copilot_agent/mr_comment_handler.py
@@ -53,6 +53,7 @@ async def handle_copilot_comment(
     payload: NoteWebhookPayload,
     executor: TaskExecutor,
     repo_locks: DistributedLock | None = None,
+    project_token: str | None = None,
 ) -> None:
     """Handle a /copilot command from an MR comment."""
     mr = payload.merge_request
@@ -67,7 +68,8 @@ async def handle_copilot_comment(
         bound_log = log.bind(project_id=project.id, mr_iid=mr.iid)
         await bound_log.ainfo("copilot_command_received", instruction=instruction[:100])
 
-        gl_client = GitLabClient(settings.gitlab_url, settings.gitlab_token)
+        token = project_token or settings.gitlab_token
+        gl_client = GitLabClient(settings.gitlab_url, token)
         repo_path: Path | None = None
 
         async def _execute() -> None:
@@ -76,7 +78,7 @@ async def handle_copilot_comment(
                 repo_path = await git_clone(
                     project.git_http_url,
                     mr.source_branch,
-                    settings.gitlab_token,
+                    token,
                     clone_dir=settings.clone_dir,
                 )
                 task = TaskParams(
@@ -99,7 +101,7 @@ async def handle_copilot_comment(
                     repo_path, f"fix: {instruction[:50]}", AGENT_AUTHOR_NAME, AGENT_AUTHOR_EMAIL
                 )
                 if has_changes:
-                    await git_push(repo_path, "origin", mr.source_branch, settings.gitlab_token)
+                    await git_push(repo_path, "origin", mr.source_branch, token)
                     await gl_client.post_mr_comment(
                         project.id, mr.iid, f"✅ Changes pushed.\n\n{result.summary}"
                     )

--- a/src/gitlab_copilot_agent/orchestrator.py
+++ b/src/gitlab_copilot_agent/orchestrator.py
@@ -26,7 +26,10 @@ _tracer = get_tracer(__name__)
 
 
 async def handle_review(
-    settings: Settings, payload: MergeRequestWebhookPayload, executor: TaskExecutor
+    settings: Settings,
+    payload: MergeRequestWebhookPayload,
+    executor: TaskExecutor,
+    project_token: str | None = None,
 ) -> None:
     """Full review pipeline: clone → review → parse → post comments."""
     mr = payload.object_attributes
@@ -40,14 +43,15 @@ async def handle_review(
 
         bound_log.info("review_started")
 
-        gl_client = GitLabClient(settings.gitlab_url, settings.gitlab_token)
+        token = project_token or settings.gitlab_token
+        gl_client = GitLabClient(settings.gitlab_url, token)
         repo_path: Path | None = None
 
         try:
             repo_path = await gl_client.clone_repo(
                 project.git_http_url,
                 mr.source_branch,
-                settings.gitlab_token,
+                token,
                 clone_dir=settings.clone_dir,
             )
 
@@ -80,7 +84,7 @@ async def handle_review(
                 inline_comments=len(parsed.comments),
             )
 
-            gl = gitlab.Gitlab(settings.gitlab_url, private_token=settings.gitlab_token)
+            gl = gitlab.Gitlab(settings.gitlab_url, private_token=token)
 
             await post_review(
                 gl, project.id, mr.iid, mr_details.diff_refs, parsed, mr_details.changes

--- a/src/gitlab_copilot_agent/webhook.py
+++ b/src/gitlab_copilot_agent/webhook.py
@@ -10,12 +10,33 @@ from gitlab_copilot_agent.metrics import webhook_errors_total, webhook_received_
 from gitlab_copilot_agent.models import MergeRequestWebhookPayload, NoteWebhookPayload
 from gitlab_copilot_agent.mr_comment_handler import handle_copilot_comment, parse_copilot_command
 from gitlab_copilot_agent.orchestrator import handle_review
+from gitlab_copilot_agent.project_registry import ProjectRegistry
 
 log = structlog.get_logger()
 
 router = APIRouter()
 
 HANDLED_ACTIONS = frozenset({"open", "update"})
+
+
+def _resolve_project_token(
+    project_id: int,
+    registry: ProjectRegistry | None,
+    fallback_token: str,
+) -> str:
+    """Return per-project token from registry, or fall back to global token."""
+    if registry is not None:
+        resolved = registry.get_by_project_id(project_id)
+        if resolved is not None:
+            log.info(
+                "credential_resolved",
+                project_id=project_id,
+                credential_ref=resolved.credential_ref,
+                source="project_registry",
+            )
+            return resolved.token
+    log.info("credential_resolved", project_id=project_id, source="global_fallback")
+    return fallback_token
 
 
 def _validate_webhook_token(received: str | None, expected: str | None) -> None:
@@ -30,13 +51,15 @@ async def _process_review(request: Request, payload: MergeRequestWebhookPayload)
     settings = request.app.state.settings
     executor = request.app.state.executor
     review_tracker: ReviewedMRTracker = request.app.state.review_tracker
+    registry: ProjectRegistry | None = getattr(request.app.state, "project_registry", None)
     mr = payload.object_attributes
     project_id = payload.project.id
     head_sha = mr.last_commit.id
+    project_token = _resolve_project_token(project_id, registry, settings.gitlab_token)
     bound = log.bind(project_id=project_id, mr_iid=mr.iid, head_sha=head_sha)
     bound.info("background_review_starting")
     try:
-        await handle_review(settings, payload, executor)
+        await handle_review(settings, payload, executor, project_token=project_token)
         review_tracker.mark(project_id, mr.iid, head_sha)
         bound.info("background_review_completed")
     except Exception:
@@ -48,6 +71,8 @@ async def _process_copilot_comment(request: Request, payload: NoteWebhookPayload
     settings = request.app.state.settings
     executor = request.app.state.executor
     repo_locks = request.app.state.repo_locks
+    registry: ProjectRegistry | None = getattr(request.app.state, "project_registry", None)
+    project_token = _resolve_project_token(payload.project.id, registry, settings.gitlab_token)
     bound = log.bind(
         project_id=payload.project.id,
         mr_iid=payload.merge_request.iid if payload.merge_request else None,
@@ -55,7 +80,9 @@ async def _process_copilot_comment(request: Request, payload: NoteWebhookPayload
     )
     bound.info("background_copilot_comment_starting")
     try:
-        await handle_copilot_comment(settings, payload, executor, repo_locks)
+        await handle_copilot_comment(
+            settings, payload, executor, repo_locks, project_token=project_token
+        )
         bound.info("background_copilot_comment_completed")
     except Exception:
         webhook_errors_total.add(1, {"handler": "copilot_comment"})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,6 +145,7 @@ async def client(env_vars: None) -> AsyncIterator[AsyncClient]:
     app.state.dedup_store = MemoryDedup()
     app.state.review_tracker = ReviewedMRTracker()
     app.state.allowed_project_ids = None
+    app.state.project_registry = None
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         yield c

--- a/tests/test_gitlab_poller.py
+++ b/tests/test_gitlab_poller.py
@@ -10,6 +10,7 @@ import pytest
 from gitlab_copilot_agent.concurrency import MemoryDedup
 from gitlab_copilot_agent.gitlab_client import MRAuthor, MRListItem, NoteListItem
 from gitlab_copilot_agent.gitlab_poller import GitLabPoller
+from gitlab_copilot_agent.project_registry import ProjectRegistry, ResolvedProject
 from tests.conftest import GITLAB_URL, MR_IID, PROJECT_ID, make_settings
 
 # -- Constants --
@@ -20,6 +21,7 @@ MR_AUTHOR = MRAuthor(id=99, username="dev")
 NOTE_AUTHOR = MRAuthor(id=42, username="reviewer")
 NOTE_ID = 777
 COPILOT_BODY = "/copilot review this"
+PER_PROJECT_TOKEN = "project-specific-token"
 _HANDLE_REVIEW = "gitlab_copilot_agent.gitlab_poller.handle_review"
 _HANDLE_COMMENT = "gitlab_copilot_agent.gitlab_poller.handle_copilot_comment"
 
@@ -244,3 +246,88 @@ async def test_start_initializes_watermark() -> None:
     await poller.start()
     assert poller._watermark is not None
     await poller.stop()
+
+
+# -- Per-project credential tests --
+
+
+def _make_project_registry(project_id: int = PROJECT_ID) -> ProjectRegistry:
+    return ProjectRegistry(
+        [
+            ResolvedProject(
+                jira_project="PROJ",
+                repo=PATH_WITH_NS,
+                gitlab_project_id=project_id,
+                clone_url=f"{GITLAB_URL}/{PATH_WITH_NS}.git",
+                target_branch="main",
+                credential_ref="default",
+                token=PER_PROJECT_TOKEN,
+            )
+        ]
+    )
+
+
+@pytest.mark.asyncio
+@patch(_HANDLE_REVIEW, new_callable=AsyncMock)
+async def test_poll_passes_per_project_token_to_review(mock_hr: AsyncMock) -> None:
+    """Poller passes per-project token from registry to handle_review."""
+    registry = _make_project_registry()
+    poller, cl, _ = _poller()
+    poller._project_registry = registry
+    # Pre-populate client cache so no real GitLabClient is created
+    poller._project_clients["default"] = cl
+    cl.list_project_mrs.return_value = [_mr_item()]
+    await poller._poll_once()
+    mock_hr.assert_called_once()
+    _, kwargs = mock_hr.call_args
+    assert kwargs["project_token"] == PER_PROJECT_TOKEN
+
+
+@pytest.mark.asyncio
+@patch(_HANDLE_REVIEW, new_callable=AsyncMock)
+async def test_poll_falls_back_to_none_when_not_in_registry(mock_hr: AsyncMock) -> None:
+    """Poller passes None token when project not in registry (global fallback)."""
+    registry = _make_project_registry(project_id=9999)
+    poller, cl, _ = _poller()
+    poller._project_registry = registry
+    cl.list_project_mrs.return_value = [_mr_item()]
+    await poller._poll_once()
+    mock_hr.assert_called_once()
+    _, kwargs = mock_hr.call_args
+    assert kwargs["project_token"] is None
+
+
+@pytest.mark.asyncio
+@patch(_HANDLE_COMMENT, new_callable=AsyncMock)
+@patch(_HANDLE_REVIEW, new_callable=AsyncMock)
+async def test_poll_passes_per_project_token_to_comment_handler(
+    mock_hr: AsyncMock, mock_hc: AsyncMock
+) -> None:
+    """Poller passes per-project token from registry to handle_copilot_comment."""
+    registry = _make_project_registry()
+    poller, cl, _ = _poller()
+    poller._project_registry = registry
+    poller._project_clients["default"] = cl
+    cl.list_project_mrs.return_value = [_mr_item()]
+    cl.list_mr_notes.return_value = [_note_item()]
+    await poller._poll_once()
+    mock_hc.assert_called_once()
+    _, kwargs = mock_hc.call_args
+    assert kwargs["project_token"] == PER_PROJECT_TOKEN
+
+
+@pytest.mark.asyncio
+@patch(_HANDLE_REVIEW, new_callable=AsyncMock)
+async def test_poll_uses_per_project_client_for_discovery(mock_hr: AsyncMock) -> None:
+    """Poller uses per-project client for MR discovery, not the default client."""
+    registry = _make_project_registry()
+    poller, default_cl, _ = _poller()
+    poller._project_registry = registry
+    project_cl = AsyncMock()
+    project_cl.list_project_mrs.return_value = [_mr_item()]
+    project_cl.list_mr_notes.return_value = []
+    poller._project_clients["default"] = project_cl
+    await poller._poll_once()
+    # Per-project client used for discovery, not the default
+    project_cl.list_project_mrs.assert_called_once()
+    default_cl.list_project_mrs.assert_not_called()

--- a/tests/test_hot_reload.py
+++ b/tests/test_hot_reload.py
@@ -127,6 +127,8 @@ async def test_reload_endpoint_returns_keys(
     assert data["status"] == "ok"
     assert "PROJ" in data["jira_keys"]
     mock_poller.reload_registry.assert_awaited_once()
+    # Verify app.state.project_registry was also updated
+    assert app.state.project_registry is not None
 
 
 async def test_reload_endpoint_rejects_unauthenticated(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -57,6 +57,7 @@ async def test_lifespan_without_jira_starts_and_stops(env_vars: None) -> None:
         assert isinstance(test_app.state.repo_locks, RepoLockManager)
         assert isinstance(test_app.state.dedup_store, MemoryDedup)
         assert isinstance(test_app.state.executor, LocalTaskExecutor)
+        assert test_app.state.project_registry is None
 
 
 @pytest.mark.asyncio
@@ -92,11 +93,13 @@ async def test_lifespan_with_jira_creates_shared_lock_manager(
         patch("gitlab_copilot_agent.main.CredentialRegistry"),
         patch("gitlab_copilot_agent.main.ProjectRegistry") as mock_registry_cls,
     ):
-        mock_registry_cls.from_rendered_map = AsyncMock(return_value=AsyncMock())
+        mock_registry = AsyncMock()
+        mock_registry_cls.from_rendered_map = AsyncMock(return_value=mock_registry)
         async with lifespan(test_app):
             mock_poller.start.assert_called_once()
             assert test_app.state.repo_locks is not None
             assert isinstance(test_app.state.repo_locks, RepoLockManager)
+            assert test_app.state.project_registry is mock_registry
             mock_orch_class.assert_called_once()
             args, _kwargs = mock_orch_class.call_args
             assert isinstance(args[3], LocalTaskExecutor)
@@ -287,11 +290,16 @@ async def test_lifespan_starts_gitlab_poller(
 
     with (
         patch("gitlab_copilot_agent.main.GitLabClient", return_value=mock_gl),
-        patch("gitlab_copilot_agent.main.GitLabPoller", return_value=mock_poller),
+        patch(
+            "gitlab_copilot_agent.main.GitLabPoller", return_value=mock_poller
+        ) as mock_poller_cls,
     ):
         async with lifespan(test_app):
             mock_poller.start.assert_called_once()
             assert test_app.state.gl_poller is mock_poller
+            # Verify project_registry=None passed (no Jira configured)
+            _, kwargs = mock_poller_cls.call_args
+            assert kwargs.get("project_registry") is None
         mock_poller.stop.assert_called_once()
 
 

--- a/tests/test_mr_comment_handler.py
+++ b/tests/test_mr_comment_handler.py
@@ -12,7 +12,9 @@ from gitlab_copilot_agent.models import (
 )
 from gitlab_copilot_agent.mr_comment_handler import handle_copilot_comment, parse_copilot_command
 from gitlab_copilot_agent.task_executor import CodingResult
-from tests.conftest import MR_IID, PROJECT_ID, make_settings
+from tests.conftest import GITLAB_TOKEN, MR_IID, PROJECT_ID, make_settings
+
+PER_PROJECT_TOKEN = "project-specific-token"
 
 
 def test_parse_copilot_command_valid() -> None:
@@ -69,3 +71,72 @@ async def test_handle_full_pipeline(
     mock_executor.execute.assert_awaited_once()
     mock_push.assert_awaited_once()
     mock_gl.post_mr_comment.assert_awaited_once()
+
+
+@patch("gitlab_copilot_agent.mr_comment_handler.GitLabClient")
+@patch("gitlab_copilot_agent.mr_comment_handler.git_push")
+@patch("gitlab_copilot_agent.mr_comment_handler.git_commit")
+@patch("gitlab_copilot_agent.mr_comment_handler.git_clone")
+async def test_handle_uses_per_project_token(
+    mock_clone: AsyncMock,
+    mock_commit: AsyncMock,
+    mock_push: AsyncMock,
+    mock_gl_class: AsyncMock,
+    tmp_path: Path,
+) -> None:
+    """When project_token is passed, it is used instead of settings.gitlab_token."""
+    mock_clone.return_value = tmp_path
+    mock_executor = AsyncMock()
+    mock_executor.execute.return_value = CodingResult(summary="done")
+    mock_commit.return_value = True
+    mock_gl = AsyncMock()
+    mock_gl_class.return_value = mock_gl
+
+    await handle_copilot_comment(
+        make_settings(),
+        _make_note_payload(),
+        executor=mock_executor,
+        project_token=PER_PROJECT_TOKEN,
+    )
+
+    # GitLabClient created with per-project token
+    mock_gl_class.assert_called_once()
+    _, gl_args = mock_gl_class.call_args
+    assert mock_gl_class.call_args[0][1] == PER_PROJECT_TOKEN
+    # git_clone called with per-project token
+    clone_args = mock_clone.call_args
+    assert clone_args[0][2] == PER_PROJECT_TOKEN
+    # git_push called with per-project token
+    push_args = mock_push.call_args
+    assert push_args[0][3] == PER_PROJECT_TOKEN
+
+
+@patch("gitlab_copilot_agent.mr_comment_handler.GitLabClient")
+@patch("gitlab_copilot_agent.mr_comment_handler.git_push")
+@patch("gitlab_copilot_agent.mr_comment_handler.git_commit")
+@patch("gitlab_copilot_agent.mr_comment_handler.git_clone")
+async def test_handle_falls_back_to_settings_token(
+    mock_clone: AsyncMock,
+    mock_commit: AsyncMock,
+    mock_push: AsyncMock,
+    mock_gl_class: AsyncMock,
+    tmp_path: Path,
+) -> None:
+    """When project_token is None, falls back to settings.gitlab_token."""
+    mock_clone.return_value = tmp_path
+    mock_executor = AsyncMock()
+    mock_executor.execute.return_value = CodingResult(summary="done")
+    mock_commit.return_value = True
+    mock_gl = AsyncMock()
+    mock_gl_class.return_value = mock_gl
+
+    await handle_copilot_comment(
+        make_settings(),
+        _make_note_payload(),
+        executor=mock_executor,
+        project_token=None,
+    )
+
+    # GitLabClient created with global token from settings
+    mock_gl_class.assert_called_once()
+    assert mock_gl_class.call_args[0][1] == GITLAB_TOKEN

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -7,9 +7,22 @@ import pytest
 from httpx import AsyncClient
 
 from gitlab_copilot_agent.main import app
-from tests.conftest import HEADERS, MR_IID, MR_PAYLOAD, PROJECT_ID, make_mr_payload, make_settings
+from gitlab_copilot_agent.project_registry import ProjectRegistry, ResolvedProject
+from tests.conftest import (
+    GITLAB_TOKEN,
+    GITLAB_URL,
+    HEADERS,
+    MR_IID,
+    MR_PAYLOAD,
+    PROJECT_ID,
+    make_mr_payload,
+    make_settings,
+)
 
 NON_ALLOWED_PROJECT_ID = 999
+
+# Per-project credential constants
+PER_PROJECT_TOKEN = "project-specific-token"
 
 
 @pytest.mark.parametrize("token", [None, "wrong-token"])
@@ -208,3 +221,87 @@ async def test_webhook_rejects_when_project_not_in_allowlist(client: AsyncClient
         assert resp.json() == {"status": "ignored", "reason": "project not in allowlist"}
     finally:
         app.state.allowed_project_ids = None
+
+
+# -- Per-project credential tests --
+
+
+def _make_project_registry(project_id: int = PROJECT_ID) -> ProjectRegistry:
+    return ProjectRegistry(
+        [
+            ResolvedProject(
+                jira_project="PROJ",
+                repo="group/project",
+                gitlab_project_id=project_id,
+                clone_url=f"{GITLAB_URL}/group/project.git",
+                target_branch="main",
+                credential_ref="default",
+                token=PER_PROJECT_TOKEN,
+            )
+        ]
+    )
+
+
+async def test_webhook_review_uses_per_project_token(client: AsyncClient) -> None:
+    """MR review resolves per-project token from registry."""
+    app.state.project_registry = _make_project_registry()
+    mock_handle = AsyncMock()
+    try:
+        with patch("gitlab_copilot_agent.webhook.handle_review", mock_handle):
+            resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
+            assert resp.json() == {"status": "queued"}
+            await asyncio.sleep(0.1)
+
+        mock_handle.assert_awaited_once()
+        _, kwargs = mock_handle.call_args
+        assert kwargs["project_token"] == PER_PROJECT_TOKEN
+    finally:
+        app.state.project_registry = None
+
+
+async def test_webhook_review_falls_back_to_global_token(client: AsyncClient) -> None:
+    """MR review falls back to global token when project not in registry."""
+    app.state.project_registry = _make_project_registry(project_id=9999)
+    mock_handle = AsyncMock()
+    try:
+        with patch("gitlab_copilot_agent.webhook.handle_review", mock_handle):
+            resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
+            assert resp.json() == {"status": "queued"}
+            await asyncio.sleep(0.1)
+
+        mock_handle.assert_awaited_once()
+        _, kwargs = mock_handle.call_args
+        assert kwargs["project_token"] == GITLAB_TOKEN
+    finally:
+        app.state.project_registry = None
+
+
+async def test_webhook_copilot_uses_per_project_token(client: AsyncClient) -> None:
+    """Copilot comment resolves per-project token from registry."""
+    app.state.project_registry = _make_project_registry()
+    mock_handle = AsyncMock()
+    try:
+        with patch("gitlab_copilot_agent.webhook.handle_copilot_comment", mock_handle):
+            resp = await client.post("/webhook", json=_note_body(), headers=HEADERS)
+            assert resp.json() == {"status": "queued"}
+            await asyncio.sleep(0.1)
+
+        mock_handle.assert_awaited_once()
+        _, kwargs = mock_handle.call_args
+        assert kwargs["project_token"] == PER_PROJECT_TOKEN
+    finally:
+        app.state.project_registry = None
+
+
+async def test_webhook_review_works_without_registry(client: AsyncClient) -> None:
+    """MR review works when no project registry is configured."""
+    assert app.state.project_registry is None
+    mock_handle = AsyncMock()
+    with patch("gitlab_copilot_agent.webhook.handle_review", mock_handle):
+        resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
+        assert resp.json() == {"status": "queued"}
+        await asyncio.sleep(0.1)
+
+    mock_handle.assert_awaited_once()
+    _, kwargs = mock_handle.call_args
+    assert kwargs["project_token"] == GITLAB_TOKEN


### PR DESCRIPTION
## What

Thread per-project credentials from `ProjectRegistry` through all secondary runtime paths that previously used the global `settings.gitlab_token`.

Part of #283

## Why

PRs #277–#282 introduced the YAML-first mapping architecture with `CredentialRegistry` and `ProjectRegistry`. The primary Jira→coding flow already uses per-binding tokens. However, four secondary paths still used the global token: webhook-triggered reviews, `/copilot` commands, GitLab poller, and the `/config/reload` endpoint.

## Changes

| File | Change |
|------|--------|
| `orchestrator.py` | Add `project_token: str \| None` param to `handle_review()`. Use instead of `settings.gitlab_token` |
| `mr_comment_handler.py` | Add `project_token: str \| None` param to `handle_copilot_comment()`. Use for client, clone, push |
| `webhook.py` | Add `_resolve_project_token()` helper. Resolve from `app.state.project_registry` before calling handlers |
| `gitlab_poller.py` | Accept `ProjectRegistry`. Use per-project clients (cached by `credential_ref`) for MR/note discovery. Pass resolved token to handlers |
| `main.py` | Store `project_registry` in `app.state`. Pass to `GitLabPoller`. Update on `/config/reload` |

All paths fall back to `settings.gitlab_token` when a project is not in the registry (projects in `GITLAB_PROJECTS` but not in `JIRA_PROJECT_MAP`).

## Testing

- 10 new tests covering per-project token resolution, fallback to global token, per-project client discovery, and `/config/reload` propagation
- All 471 tests pass, 91.82% coverage

## OWASP Self-Review

- [x] Broken Access Control — Existing project allowlist validates project IDs before credential lookup. Webhook secret is the auth boundary.
- [x] Cryptographic Failures — Tokens never logged. `ResolvedProject.__repr__` masks values.
- [x] Injection — `project_id` used as integer dict key only, never in commands/queries.
- [x] Insecure Design — Global fallback is intentional for unmapped projects (per issue requirements). Audit logging added for credential source.
- [x] Security Misconfiguration — `/config/reload` now updates all consumers (webhook, poller, Jira poller).
- [x] Security Logging — Credential resolution logged with `project_id`, `credential_ref`, and `source` (never token values).
- [x] SSRF — N/A (no new URL construction from user input)
- [x] Container Security — N/A (no container changes)
