### PR TITLE
feat(infra): add Azure Monitor Private Link Scope for network isolation

### DIFF
--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -5,6 +5,9 @@ resource "azurerm_log_analytics_workspace" "main" {
   sku                 = "PerGB2018"
   retention_in_days   = 30
 
+  internet_ingestion_enabled = false
+  internet_query_enabled     = false
+
   tags = var.tags
 }
 
@@ -14,6 +17,115 @@ resource "azurerm_application_insights" "main" {
   resource_group_name = azurerm_resource_group.main.name
   workspace_id        = azurerm_log_analytics_workspace.main.id
   application_type    = "web"
+
+  internet_ingestion_enabled = false
+  internet_query_enabled     = false
+
+  tags = var.tags
+}
+
+# --- Azure Monitor Private Link Scope (AMPLS) ---
+
+resource "azurerm_monitor_private_link_scope" "main" {
+  name                  = "ampls-${var.resource_group_name}"
+  resource_group_name   = azurerm_resource_group.main.name
+  ingestion_access_mode = "PrivateOnly"
+  query_access_mode     = "PrivateOnly"
+
+  tags = var.tags
+}
+
+resource "azurerm_monitor_private_link_scoped_service" "law" {
+  name                = "ampls-law"
+  resource_group_name = azurerm_resource_group.main.name
+  scope_name          = azurerm_monitor_private_link_scope.main.name
+  linked_resource_id  = azurerm_log_analytics_workspace.main.id
+}
+
+resource "azurerm_monitor_private_link_scoped_service" "ai" {
+  name                = "ampls-ai"
+  resource_group_name = azurerm_resource_group.main.name
+  scope_name          = azurerm_monitor_private_link_scope.main.name
+  linked_resource_id  = azurerm_application_insights.main.id
+}
+
+# Private DNS zones required for AMPLS
+resource "azurerm_private_dns_zone" "monitor" {
+  name                = "privatelink.monitor.azure.com"
+  resource_group_name = azurerm_resource_group.main.name
+  tags                = var.tags
+}
+
+resource "azurerm_private_dns_zone" "oms" {
+  name                = "privatelink.oms.opinsights.azure.com"
+  resource_group_name = azurerm_resource_group.main.name
+  tags                = var.tags
+}
+
+resource "azurerm_private_dns_zone" "ods" {
+  name                = "privatelink.ods.opinsights.azure.com"
+  resource_group_name = azurerm_resource_group.main.name
+  tags                = var.tags
+}
+
+resource "azurerm_private_dns_zone" "agentsvc" {
+  name                = "privatelink.agentsvc.azure-automation.net"
+  resource_group_name = azurerm_resource_group.main.name
+  tags                = var.tags
+}
+
+# VNet links for each DNS zone
+resource "azurerm_private_dns_zone_virtual_network_link" "monitor" {
+  name                  = "monitor-vnet-link"
+  resource_group_name   = azurerm_resource_group.main.name
+  private_dns_zone_name = azurerm_private_dns_zone.monitor.name
+  virtual_network_id    = azurerm_virtual_network.main.id
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "oms" {
+  name                  = "oms-vnet-link"
+  resource_group_name   = azurerm_resource_group.main.name
+  private_dns_zone_name = azurerm_private_dns_zone.oms.name
+  virtual_network_id    = azurerm_virtual_network.main.id
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "ods" {
+  name                  = "ods-vnet-link"
+  resource_group_name   = azurerm_resource_group.main.name
+  private_dns_zone_name = azurerm_private_dns_zone.ods.name
+  virtual_network_id    = azurerm_virtual_network.main.id
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "agentsvc" {
+  name                  = "agentsvc-vnet-link"
+  resource_group_name   = azurerm_resource_group.main.name
+  private_dns_zone_name = azurerm_private_dns_zone.agentsvc.name
+  virtual_network_id    = azurerm_virtual_network.main.id
+}
+
+# AMPLS private endpoint
+resource "azurerm_private_endpoint" "ampls" {
+  name                = "pe-ampls-${var.resource_group_name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  subnet_id           = azurerm_subnet.monitoring.id
+
+  private_service_connection {
+    name                           = "ampls-connection"
+    private_connection_resource_id = azurerm_monitor_private_link_scope.main.id
+    subresource_names              = ["azuremonitor"]
+    is_manual_connection           = false
+  }
+
+  private_dns_zone_group {
+    name = "ampls-dns"
+    private_dns_zone_ids = [
+      azurerm_private_dns_zone.monitor.id,
+      azurerm_private_dns_zone.oms.id,
+      azurerm_private_dns_zone.ods.id,
+      azurerm_private_dns_zone.agentsvc.id,
+    ]
+  }
 
   tags = var.tags
 }

--- a/infra/networking.tf
+++ b/infra/networking.tf
@@ -43,6 +43,14 @@ resource "azurerm_subnet" "storage" {
   address_prefixes     = [var.storage_subnet_prefix]
 }
 
+# Monitoring (AMPLS) private endpoint subnet
+resource "azurerm_subnet" "monitoring" {
+  name                 = "snet-monitoring"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = [var.monitoring_subnet_prefix]
+}
+
 # --- NSGs ---
 
 resource "azurerm_network_security_group" "infra" {
@@ -87,6 +95,19 @@ resource "azurerm_network_security_group" "infra" {
     destination_port_range     = "443"
     source_address_prefix      = var.infra_subnet_prefix
     destination_address_prefix = var.storage_subnet_prefix
+  }
+
+  # Allow outbound to Monitoring (AMPLS) via private endpoint
+  security_rule {
+    name                       = "AllowMonitoringOutbound"
+    priority                   = 140
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = var.infra_subnet_prefix
+    destination_address_prefix = var.monitoring_subnet_prefix
   }
 
   # Deny all other outbound

--- a/infra/variables-apps.tf
+++ b/infra/variables-apps.tf
@@ -26,6 +26,12 @@ variable "storage_subnet_prefix" {
   default     = "10.0.4.0/24"
 }
 
+variable "monitoring_subnet_prefix" {
+  description = "CIDR for the monitoring (AMPLS) private endpoint subnet"
+  type        = string
+  default     = "10.0.5.0/24"
+}
+
 # --- Container Apps ---
 
 variable "image_tag" {


### PR DESCRIPTION
## What

Add Azure Monitor Private Link Scope (AMPLS) to route all monitoring traffic through the VNet, eliminating the last publicly accessible data-plane endpoints.

## Why

Log Analytics Workspace and Application Insights were the only two resources still publicly accessible. Telemetry containing application logs (MR content, code review context, Copilot interactions) was traversing the public internet.

## Changes

- **`infra/variables-apps.tf`**: New `monitoring_subnet_prefix` variable (`10.0.5.0/24`)
- **`infra/networking.tf`**: Monitoring subnet (`snet-monitoring`) + NSG rule `AllowMonitoringOutbound` (priority 140)
- **`infra/monitoring.tf`**:
  - AMPLS resource with `PrivateOnly` ingestion/query access modes
  - Scoped services for LAW and App Insights
  - 4 private DNS zones (monitor, OMS, ODS, agentsvc) + VNet links
  - Private endpoint `pe-ampls-*` with DNS zone group
  - Disabled public ingestion/query on LAW and App Insights

## How to test

1. `cd infra && terraform init -backend=false && terraform validate`
2. After apply: verify App Insights Live Metrics still receives telemetry
3. Verify LAW/AI reject queries from public internet

## Review notes

- OWASP review completed — addressed HIGH finding (added `PrivateOnly` access modes)
- Cross-vendor code review completed
- Follows existing PE patterns from storage.tf and keyvault.tf

Part of #296