### PR TITLE
fix(infra): scope task-runner Key Vault access to specific secrets

### DIFF
--- a/infra/keyvault.tf
+++ b/infra/keyvault.tf
@@ -167,9 +167,16 @@ resource "azurerm_role_assignment" "controller_kv" {
   principal_id         = azurerm_user_assigned_identity.controller.principal_id
 }
 
-# Job: Key Vault Secrets User (scoped to vault; per-secret RBAC is not yet GA)
-resource "azurerm_role_assignment" "job_kv" {
-  scope                = azurerm_key_vault.main.id
+# Job: Key Vault Secrets User — scoped to task-runner secrets only.
+# The job identity must NOT read controller-only secrets (gitlab-token, jira-api-token).
+resource "azurerm_role_assignment" "job_kv_github_token" {
+  scope                = "${azurerm_key_vault.main.id}/secrets/github-token"
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azurerm_user_assigned_identity.job.principal_id
+}
+
+resource "azurerm_role_assignment" "job_kv_copilot_api_key" {
+  scope                = "${azurerm_key_vault.main.id}/secrets/copilot-api-key"
   role_definition_name = "Key Vault Secrets User"
   principal_id         = azurerm_user_assigned_identity.job.principal_id
 }


### PR DESCRIPTION
## What

Replace vault-wide `Key Vault Secrets User` role for the job (task-runner) identity with per-secret scoped RBAC assignments.

## Why

The task-runner had access to all Key Vault secrets including controller-only ones (`gitlab-token`, `jira-api-token`). This violates least privilege — the task-runner only needs `github-token` or `copilot-api-key`.

## Changes

- **`infra/keyvault.tf`**: Replace single `azurerm_role_assignment.job_kv` (vault-wide) with two per-secret assignments:
  - `job_kv_github_token` → scoped to `{vault}/secrets/github-token`
  - `job_kv_copilot_api_key` → scoped to `{vault}/secrets/copilot-api-key`

## Design decision

Both secrets are granted unconditionally regardless of `copilot_auth` mode. Only one secret exists in KV at a time, so granting access to a non-existent secret is harmless. This avoids conditional RBAC complexity for zero security benefit.

## How to test

1. `cd infra && terraform init -backend=false && terraform validate`
2. After apply: verify task-runner can still read its secrets
3. Verify task-runner gets 403 when attempting to read `gitlab-token`

## Review notes

- OWASP review: clean (no findings)
- Cross-vendor code review: suggested conditional RBAC — declined as noted above

Closes #297