### PR TITLE
fix(ci): pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           version: "0.6.x"
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - name: Install dependencies
@@ -29,11 +29,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           version: "0.6.x"
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - name: Install dependencies
@@ -44,15 +44,15 @@ jobs:
   helm-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: azure/setup-helm@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
       - name: Helm lint
         run: helm lint helm/gitlab-copilot-agent/ --set gitlab.url=https://ci.test --set gitlab.token=ci --set gitlab.webhookSecret=ci
 
   docker-digest-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Verify FROM lines are digest-pinned
         run: |
           bad_lines=$(grep -E '^FROM ' Dockerfile | grep -v '@sha256:' || true)
@@ -65,7 +65,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Build Docker image
         run: docker build -t gitlab-copilot-agent:ci .
 
@@ -73,8 +73,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
         with:
           terraform_version: "1.9.x"
       - name: Terraform fmt
@@ -85,7 +85,7 @@ jobs:
         run: |
           terraform init -backend=false
           terraform validate
-      - uses: terraform-linters/setup-tflint@v4
+      - uses: terraform-linters/setup-tflint@90f302c255ef959cbfb4bd10581afecdb7ece3e6 # v4
         with:
           tflint_version: "v0.53.0"
       - name: TFLint

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
         language: [python, actions]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@9792ccaef0455e446c567163589397e8c3ac2e0d # v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,11 +34,11 @@ jobs:
       ARM_USE_OIDC: "true"
       ARM_USE_AZUREAD: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Step 1: Build and push image to GHCR (no infra dependency)
       - name: GHCR login
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -55,13 +55,13 @@ jobs:
 
       # Step 2: Provision infrastructure (single terraform apply)
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,9 +11,9 @@ jobs:
     # expected until hostAliases, writable volumes, and env propagation are fixed.
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: azure/setup-kubectl@v4
+      - uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
         with:
           version: "v1.29.0"
 
@@ -23,7 +23,7 @@ jobs:
           k3d version
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
       - name: Create cluster
         run: |
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: e2e-pod-logs
           path: /tmp/e2e-logs/


### PR DESCRIPTION
## What

Pin all GitHub Actions to immutable commit SHAs instead of mutable version tags.

## Why

Actions pinned to tags (`@v4`) are vulnerable to supply chain attacks — a compromised upstream action with the same tag could inject malicious code into CI/CD. SHA-pinned references are immutable.

## Changes

- **`.github/workflows/ci.yml`**: 13 action references pinned
- **`.github/workflows/deploy.yml`**: 4 action references pinned
- **`.github/workflows/e2e.yml`**: 4 action references pinned
- **`.github/workflows/codeql.yml`**: 1 remaining `actions/checkout` pinned (other actions already SHA-pinned)

Format: `uses: action@<sha> # v<major>`

Also upgrades `astral-sh/setup-uv` from v4 to v5 in e2e.yml for consistency with ci.yml.

### Already SHA-pinned (unchanged)

- `codeql.yml`: `github/codeql-action` (init + analyze)
- `dependabot-auto-merge.yml`: `dependabot/fetch-metadata`

## How to test

CI should pass — same action versions, just immutable references.

## Review notes

- OWASP review: found missing pin in codeql.yml — fixed
- Cross-vendor code review: all 22 SHA-to-tag mappings verified correct

Closes #298