### PR TITLE
fix(ci): deploy container images by digest, not mutable tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,13 +45,20 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push to GHCR
+        id: ghcr_push
         env:
           IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
           IMAGE="ghcr.io/${{ github.repository }}:${IMAGE_TAG}"
           docker build -t "$IMAGE" .
           docker push "$IMAGE"
-          echo "✓ Pushed $IMAGE"
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE" | cut -d'@' -f2)
+          if [[ ! "$DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+            echo "::error::Failed to extract valid digest. Got: ${DIGEST}"
+            exit 1
+          fi
+          echo "image_digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "✓ Pushed $IMAGE (${DIGEST})"
 
       # Step 2: Provision infrastructure (single terraform apply)
       - name: Azure login (OIDC)
@@ -120,11 +127,13 @@ jobs:
         env:
           TF_VAR_kv_bootstrap_secrets: '{"gitlab-token":"${{ secrets.GITLAB_TOKEN }}","github-token":"${{ secrets.GH_PAT_FOR_COPILOT }}","jira-api-token":"${{ secrets.JIRA_API_TOKEN }}"}'
           TF_VAR_image_tag: ${{ inputs.image_tag }}
+          TF_VAR_image_digest: ${{ steps.ghcr_push.outputs.image_digest }}
           TFVARS_FILE: ${{ inputs.environment }}.tfvars
         run: |
           terraform apply -auto-approve \
             -var-file="${TFVARS_FILE}" \
-            -var="image_tag=${TF_VAR_image_tag}"
+            -var="image_tag=${TF_VAR_image_tag}" \
+            -var="image_digest=${TF_VAR_image_digest}"
 
       - name: Disable TF state storage public access
         if: always()

--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -48,8 +48,8 @@ resource "azurerm_private_endpoint" "acr" {
 # ACR import is a server-side copy — no Docker daemon needed.
 resource "null_resource" "acr_import" {
   triggers = {
-    image_tag = var.image_tag
-    acr_name  = azurerm_container_registry.main.name
+    image_digest = var.image_digest
+    acr_name     = azurerm_container_registry.main.name
   }
 
   provisioner "local-exec" {
@@ -57,16 +57,17 @@ resource "null_resource" "acr_import" {
     command     = <<-EOT
       set -euo pipefail
       az acr import -n "$ACR_NAME" \
-        --source "ghcr.io/$GHCR_IMAGE:$IMAGE_TAG" \
+        --source "ghcr.io/$GHCR_IMAGE@$IMAGE_DIGEST" \
         --image "gitlab-copilot-agent:$IMAGE_TAG" \
         --force
-      echo "Imported ghcr.io/$GHCR_IMAGE:$IMAGE_TAG"
+      echo "Imported ghcr.io/$GHCR_IMAGE@$IMAGE_DIGEST → gitlab-copilot-agent:$IMAGE_TAG"
     EOT
     interpreter = ["bash", "-c"]
     environment = {
-      ACR_NAME   = azurerm_container_registry.main.name
-      GHCR_IMAGE = var.ghcr_image
-      IMAGE_TAG  = var.image_tag
+      ACR_NAME     = azurerm_container_registry.main.name
+      GHCR_IMAGE   = var.ghcr_image
+      IMAGE_TAG    = var.image_tag
+      IMAGE_DIGEST = var.image_digest
     }
   }
 
@@ -99,7 +100,7 @@ resource "azurerm_role_assignment" "deployer_acr" {
 }
 
 locals {
-  acr_image = "${azurerm_container_registry.main.login_server}/gitlab-copilot-agent:${var.image_tag}"
+  acr_image = "${azurerm_container_registry.main.login_server}/gitlab-copilot-agent:${var.image_tag}@${var.image_digest}"
 }
 
 # --- Container Apps Environment ---

--- a/infra/variables-apps.tf
+++ b/infra/variables-apps.tf
@@ -33,6 +33,16 @@ variable "image_tag" {
   type        = string
 }
 
+variable "image_digest" {
+  description = "Image digest (sha256:...) from GHCR push. Used for immutable ACR import and ACA deployment."
+  type        = string
+
+  validation {
+    condition     = can(regex("^sha256:[a-f0-9]{64}$", var.image_digest))
+    error_message = "image_digest must be a sha256 digest (sha256:<64 hex chars>)."
+  }
+}
+
 variable "ghcr_image" {
   description = "GHCR image path (without tag), e.g. peteroden/gitlab-copilot-agent"
   type        = string


### PR DESCRIPTION
## What

Capture GHCR image digest after push and use it for immutable ACR import and ACA deployment.

## Why

GHCR→ACR import and ACA deployment used mutable image tags. A compromised GHCR image with the same tag could be deployed without detection.

## Changes

- **`.github/workflows/deploy.yml`**:
  - Capture digest after `docker push` via `docker inspect`
  - Validate digest format (`sha256:<64 hex>`) before proceeding
  - Pass `image_digest` to Terraform apply
- **`infra/variables-apps.tf`**:
  - New `image_digest` variable with format validation
- **`infra/container-apps.tf`**:
  - ACR import uses `@digest` as source (immutable pull from GHCR)
  - Trigger changed from `image_tag` to `image_digest`
  - `acr_image` uses `tag@digest` format (tag for readability, digest for integrity)

## Design decisions

- **`tag@digest` format**: Valid OCI spec, supported by ACA/containerd. Tag provides human readability in Azure Portal; digest is authoritative.
- **Unconditional validation**: Workflow fails fast if digest extraction returns garbage.

## How to test

1. `cd infra && terraform init -backend=false && terraform validate`
2. Deploy workflow: verify digest appears in GITHUB_OUTPUT
3. After apply: verify ACR image was imported by digest, ACA container uses digest reference

## Review notes

- OWASP review: addressed LOW finding (added validation regex)
- Cross-vendor code review: addressed HIGH finding (added digest extraction error handling)

Closes #299