### PR TITLE
fix(agents): replace blanket network ban with safelisted registries

### DIFF
--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -1,6 +1,6 @@
 ---
 name: developer
-description: Implementation agent — writes code, tests, and documentation. Operates in yolo mode within a sandboxed devcontainer. No network access, no package installation.
+description: Implementation agent — writes code, tests, and documentation. Operates in yolo mode within a sandboxed devcontainer. Safelisted network access only, no ad-hoc package installation.
 tools: ["read", "edit", "search", "execute", "create"]
 ---
 
@@ -8,7 +8,32 @@ You are a Developer Agent. You own implementation — code, tests, and documenta
 
 ## Tier: Yolo
 
-You operate in a sandboxed devcontainer with no network access and no host access. You cannot install packages or access the internet. Use only pre-installed tools.
+You operate in a sandboxed devcontainer with no host access. Network access is limited to safelisted registries (see below). You must not install packages ad-hoc — all dependencies must go through declarative config.
+
+### Allowed Network Destinations
+
+You may access **only** these registries and documentation sites:
+
+| Destination | Purpose |
+|---|---|
+| `registry.terraform.io`, `releases.hashicorp.com` | Terraform provider downloads (`terraform init`) |
+| `pypi.org`, `files.pythonhosted.org` | Python packages via `uv sync` (lockfile only) |
+| `learn.microsoft.com`, `azure.microsoft.com` | Azure documentation reference |
+| `developer.atlassian.com` | Jira/Atlassian API documentation reference |
+| `docs.gitlab.com` | GitLab API documentation reference |
+
+All other network access is prohibited. Do not `curl`, `wget`, or fetch from arbitrary URLs.
+
+### Adding Dependencies
+
+When a task requires a new dependency, update the declarative config and install from it — never install ad-hoc:
+
+- **Python**: add to `pyproject.toml`, then `uv sync`
+- **Node**: add to `package.json`, then `npm ci`
+- **System tools**: add to `devcontainer.json` features or `postCreateCommand`
+- **Terraform**: add to `.tf` files, then `terraform init`
+
+Never run `pip install`, `npm install <pkg>`, or `apt install` directly.
 
 ## CRITICAL: Devcontainer Enforcement
 
@@ -36,7 +61,8 @@ If `.devcontainer/devcontainer.json` does not exist, STOP and tell the human to 
 - Decide what to build (that's Product).
 - Decide how to architect it (that's Architect).
 - Manage other agents or task sequencing (that's Orchestrator).
-- Access the network or install packages.
+- Access non-safelisted network endpoints (see Allowed Network Destinations above).
+- Install packages ad-hoc (`pip install`, `apt install`, `npm install <pkg>`). Use declarative config instead.
 - Merge to main.
 
 ## Behavioral Rules

--- a/.github/skills/devcontainer-setup/SKILL.md
+++ b/.github/skills/devcontainer-setup/SKILL.md
@@ -7,20 +7,19 @@ Every project must have a devcontainer. Agents execute all commands inside devco
 
 ## Devcontainer Tiers
 
-### Yolo (Developer Agent) — No Network
+### Yolo (Developer Agent) — Safelisted Network
 
-For sandboxed development. The agent cannot reach the internet or install packages at runtime.
+For sandboxed development. The agent limits network access to safelisted registries (Terraform, PyPI, Azure/Jira/GitLab docs) per its agent instructions. No ad-hoc package installation at runtime.
 
 ```jsonc
 // .devcontainer/devcontainer.json
 {
   "name": "${project-name}-yolo",
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
-  "runArgs": ["--network=none"],
   "features": {
     // Add only what the project needs
   },
-  "postCreateCommand": "echo 'Yolo devcontainer ready — no network access'",
+  "postCreateCommand": "echo 'Yolo devcontainer ready'",
   "customizations": {
     "vscode": {
       "extensions": ["GitHub.copilot"]
@@ -107,6 +106,20 @@ The devcontainer must support:
 - [ ] Debugger attachment
 - [ ] Auto-install dependencies on container start
 - [ ] Local config via `.env` (not production credentials)
+
+## Dependency Installation Policy
+
+**All dependencies must be reproducible.** Agents must never install packages ad-hoc at runtime.
+
+| ✅ Allowed | ❌ Prohibited |
+|---|---|
+| Add to `pyproject.toml` / `package.json` then run `uv sync` / `npm ci` | `pip install`, `npm install <pkg>`, `apt install` at runtime |
+| Add devcontainer features in `devcontainer.json` | Manual tool installation in a running container |
+| Add system packages to `postCreateCommand` | One-off `curl \| bash` installs |
+| `terraform init` (downloads providers per lockfile) | |
+| `uv sync` / `npm ci` (installs from lockfile) | |
+
+When a task requires a new dependency: update the declarative config (`pyproject.toml`, `devcontainer.json`, `Dockerfile`), rebuild the container if needed, then use the dependency. The container must be reproducible from its config files alone.
 
 ## postCreateCommand Examples
 

--- a/.github/skills/worktree-setup/SKILL.md
+++ b/.github/skills/worktree-setup/SKILL.md
@@ -19,11 +19,11 @@ Branch naming follows conventional format:
 
 ## Start the Devcontainer
 
-For a **yolo (developer) agent** — no network:
+For a **yolo (developer) agent** — safelisted network only:
 ```bash
 devcontainer up --workspace-folder ../worktrees/<branch-name>
 ```
-Ensure the devcontainer.json uses `"network": "none"` for yolo agents.
+The devcontainer should not use `"network": "none"`. Developer agents self-limit to safelisted registries per their agent instructions.
 
 For an **interactive agent** — with network:
 ```bash


### PR DESCRIPTION
## What

Replace the unenforceable "no network access" restriction in the developer agent with an explicit safelist of allowed network destinations. Add a dependency installation policy enforcing reproducible, declarative dependency management. Update devcontainer-setup and worktree-setup skills to match.

## Why

The blanket network ban caused developer agents to silently skip `terraform init` and other registry-dependent operations, requiring fallback to general-purpose agents for all infrastructure tasks (issue #301).

## Changes

- **`developer.agent.md`**: Replace "no network" with safelist table (Terraform, PyPI, Azure/Jira/GitLab docs). Add "Adding Dependencies" section requiring declarative config for all new deps.
- **`devcontainer-setup/SKILL.md`**: Update yolo tier (remove `--network=none`). Add "Dependency Installation Policy" section with allowed/prohibited table.
- **`worktree-setup/SKILL.md`**: Remove `"network": "none"` mandate for yolo agents.

## How to Test

1. Dispatch a developer agent for a Terraform task — should no longer self-limit on registry access
2. Dispatch a developer agent to add a Python dependency — should update `pyproject.toml` + `uv sync`, not `pip install`
3. Verify agent still refuses arbitrary `curl`/`wget` to non-safelisted URLs

## Design Decisions

- **Safelist is behavioral, not technical.** The project devcontainer never used `--network=none` (runs curl/uv/npm in postCreateCommand). The safelist is an agent instruction, not a firewall rule. The devcontainer sandbox provides real isolation.
- **`releases.hashicorp.com` included** because Terraform downloads provider binaries from there, not just `registry.terraform.io`.
- **Safelist scoped to current project stack.** Other ecosystems (npm, cargo) not included — expand when those stacks are used.

## OWASP Self-Review

All N/A or improvement (agent instruction files, not application code). Explicit allowlist is a security improvement over an unenforceable blanket ban.

Closes #301