### PR TITLE
feat(task-runner): add isolated runtime Copilot CLI plugin support

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,9 +7,6 @@ on:
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    # Non-blocking: k8s executor has known bugs (see issues). Failures are
-    # expected until hostAliases, writable volumes, and env propagation are fixed.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ COPY --chown=app:app src/ src/
 RUN uv sync --no-dev --extra kubernetes --extra azure --frozen
 
 COPY --chown=app:app scripts/entrypoint.sh /opt/entrypoint.sh
+COPY --chown=app:app tests/e2e/test-marketplace/ /opt/test-marketplace/
 EXPOSE 8000
 ENTRYPOINT ["/opt/entrypoint.sh"]
 CMD ["uv", "run", "python", "-m", "gitlab_copilot_agent.main"]

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ make k3d-deploy                 # deploy via Helm
 | `K8S_SECRET_NAME` | `None` | K8s Secret for Job pod credentials (auto-set by Helm) |
 | `K8S_CONFIGMAP_NAME` | `None` | K8s ConfigMap for Job pod config (auto-set by Helm) |
 | `K8S_JOB_INSTANCE_LABEL` | `""` | Helm release label for NetworkPolicy scoping (auto-set by Helm) |
+| `COPILOT_PLUGINS` | — | Comma-separated Copilot CLI plugins to install per session |
+| `COPILOT_PLUGIN_MARKETPLACES` | — | Comma-separated plugin marketplace URLs or paths |
 
 ### Azure Storage (Dispatch)
 

--- a/docs/wiki/configuration-reference.md
+++ b/docs/wiki/configuration-reference.md
@@ -115,6 +115,24 @@ At least one of these must be set:
 
 ---
 
+## Copilot CLI Plugins
+
+### `COPILOT_PLUGINS`
+- **Type**: `str | list[str]`
+- **Required**: ❌ No
+- **Default**: `[]`
+- **Description**: Copilot CLI plugins to install at runtime. Accepts comma-separated string (`"plugin-a, plugin-b"`) or JSON array (`'["plugin-a", "plugin-b"]'`). Each spec can be a marketplace plugin name (`name@marketplace`), GitHub repo (`owner/repo`), Git URL, or local path (`./my-plugin`).
+- **Example**: `"my-jira-plugin@awesome-copilot, ./local-plugin"`
+
+### `COPILOT_PLUGIN_MARKETPLACES`
+- **Type**: `str | list[str]`
+- **Required**: ❌ No
+- **Default**: `[]`
+- **Description**: Custom plugin marketplace URLs or paths to register before plugin installation. Accepts comma-separated string or JSON array. Each entry can be a GitHub repo (`owner/repo`), Git URL, or local filesystem path.
+- **Example**: `"my-org/our-plugins, /opt/local-marketplace"`
+
+---
+
 ## Dispatch Backend
 
 All remote executors (`kubernetes`, `container_apps`) use Azure Storage Queue + Blob for dispatch (Claim Check pattern). KEDA ScaledJob watches the queue and triggers Job pods automatically.
@@ -594,6 +612,8 @@ Helm `values.yaml` maps to env vars via `configmap.yaml` and `secret.yaml`:
 | `controller.copilotProviderType` | `COPILOT_PROVIDER_TYPE` | ❌ |
 | `controller.copilotProviderBaseUrl` | `COPILOT_PROVIDER_BASE_URL` | ❌ |
 | `controller.copilotProviderApiKey` | `COPILOT_PROVIDER_API_KEY` | ✅ |
+| `controller.copilotPlugins` | `COPILOT_PLUGINS` | ❌ |
+| `controller.copilotPluginMarketplaces` | `COPILOT_PLUGIN_MARKETPLACES` | ❌ |
 | `controller.copilotModel` | `COPILOT_MODEL` | ❌ |
 | `controller.taskExecutor` | `TASK_EXECUTOR` | ❌ |
 | `controller.dispatchBackend` | `DISPATCH_BACKEND` | ❌ |

--- a/docs/wiki/module-reference.md
+++ b/docs/wiki/module-reference.md
@@ -672,6 +672,21 @@ All use `extra="ignore"` config.
 
 ---
 
+### `plugin_manager.py`
+**Purpose**: Runtime plugin installation into isolated per-session HOME directories.
+
+**Key Functions**:
+- `setup_plugins(home_dir, plugins, marketplaces)`: Install marketplaces and plugins into an isolated HOME
+- `add_marketplace(home_dir, marketplace_url)`: Register a custom plugin marketplace
+- `install_plugin(home_dir, plugin_spec)`: Install a single Copilot CLI plugin
+- `_run_cli(args, home_dir, timeout)`: Execute a copilot CLI command with timeout and kill-on-timeout
+- `_sanitize_url(url)`: Strip credentials and query params from URLs for safe logging
+
+**Internal Imports**: `process_sandbox.get_real_cli_path`
+**Depended On By**: `copilot_session.py`
+
+---
+
 ## Summary Table
 
 | Module | Layer | LOC (approx) | Key Responsibility |
@@ -705,5 +720,6 @@ All use `extra="ignore"` config.
 | `telemetry.py` | Telemetry | 130 | OTEL setup |
 | `metrics.py` | Telemetry | 52 | Metrics instruments |
 | `process_sandbox.py` | Utils | 20 | CLI path resolution |
+| `plugin_manager.py` | Utils | 88 | Plugin installation |
 
-**Total: 30 modules, ~3,430 lines of code**
+**Total: 31 modules, ~3,518 lines of code**

--- a/docs/wiki/security-model.md
+++ b/docs/wiki/security-model.md
@@ -347,6 +347,14 @@ Only the secrets needed by Job pods are mounted. **GITLAB_TOKEN is never passed 
 
 **Code**: `aca_executor.py` → `_start_execution()`
 
+### Plugin Isolation
+- Per-session HOME directory (`tempfile.mkdtemp()`) prevents plugin state leakage between sessions/repos
+- Plugin install subprocess receives minimal env: `HOME` + `PATH` only
+- Service secrets (`GITLAB_TOKEN`, `AZURE_STORAGE_CONNECTION_STRING`, etc.) excluded from plugin process
+- Marketplace URLs sanitized before logging (credentials/query params stripped)
+- Session HOME cleaned up in `finally` block after session completes
+- Plugin install timeout (120s) with subprocess kill to prevent orphaned processes
+
 ---
 
 ## Secret Handling

--- a/docs/wiki/task-execution.md
+++ b/docs/wiki/task-execution.md
@@ -349,8 +349,15 @@ if repo_config.skill_directories:
 
 **Steps**:
 1. **Resolve CLI Path**: `_get_real_cli_path()` → find bundled Copilot CLI binary
-2. **Build SDK Env**: `build_sdk_env(github_token)` → minimal env dict (excludes service secrets)
-3. **Create Client**:
+2. **Create Session HOME**: `tempfile.mkdtemp(prefix="copilot-session-")` → isolated HOME per session
+3. **Install Plugins** (if configured):
+   - Merge service-level plugins (`settings.copilot_plugins`) with repo-level plugins (from mapping schema)
+   - Register custom marketplaces via `copilot plugin marketplace add`
+   - Install plugins via `copilot plugin install` into session HOME
+   - Minimal env: only `HOME` + `PATH` passed to subprocess (no service secrets)
+   - On timeout (120s): subprocess killed and reaped
+4. **Build SDK Env**: `build_sdk_env(github_token)` → minimal env dict (excludes service secrets)
+5. **Create Client**:
    ```python
    client_opts: CopilotClientOptions = {
        "cli_path": cli_path,
@@ -361,9 +368,9 @@ if repo_config.skill_directories:
    client = CopilotClient(client_opts)
    await client.start()
    ```
-4. **Discover Repo Config**: `discover_repo_config(repo_path)` → skills, agents, instructions
-5. **Inject Instructions**: Append to system prompt
-6. **Build Session Options**:
+6. **Discover Repo Config**: `discover_repo_config(repo_path)` → skills, agents, instructions
+7. **Inject Instructions**: Append to system prompt
+8. **Build Session Options**:
    ```python
    session_opts: SessionConfig = {
        "system_message": {"content": system_content},
@@ -374,7 +381,7 @@ if repo_config.skill_directories:
    if repo_config.custom_agents:
        session_opts["custom_agents"] = [...]
    ```
-7. **BYOK Provider** (if configured):
+9. **BYOK Provider** (if configured):
    ```python
    if settings.copilot_provider_type:
        provider: ProviderConfig = {
@@ -387,9 +394,9 @@ if repo_config.skill_directories:
        session_opts["provider"] = provider
        session_opts["model"] = settings.copilot_model
    ```
-8. **Create Session**: `await client.create_session(session_opts)`
-9. **Send Prompt**: `await session.send({"prompt": user_prompt})`
-10. **Wait for Idle**:
+10. **Create Session**: `await client.create_session(session_opts)`
+11. **Send Prompt**: `await session.send({"prompt": user_prompt})`
+12. **Wait for Idle**:
     ```python
     done = asyncio.Event()
     messages: list[str] = []
@@ -406,14 +413,14 @@ if repo_config.skill_directories:
     session.on(on_event)
     await asyncio.wait_for(done.wait(), timeout=timeout)
     ```
-11. **Extract Result**: `result = messages[-1] if messages else ""`
-12. **Destroy Session**: `await session.destroy()` (in finally)
-13. **Stop Client**: `await client.stop()` (in finally)
-14. **Emit Metric**: `copilot_session_duration.record(elapsed, {"task_type": task_type})`
+13. **Extract Result**: `result = messages[-1] if messages else ""`
+14. **Destroy Session**: `await session.destroy()` (in finally)
+15. **Stop Client**: `await client.stop()` (in finally)
+16. **Emit Metric**: `copilot_session_duration.record(elapsed, {"task_type": task_type})`
 
 **Timeout**: Default 300s (5 minutes), enforced by `asyncio.wait_for()`.
 
-**Error Handling**: Session and client destroyed in finally blocks, exceptions propagate.
+**Error Handling**: Session HOME cleaned up in finally block (`shutil.rmtree`). Session and client destroyed in finally blocks. Plugin install failures propagate as `RuntimeError`.
 
 ---
 

--- a/helm/gitlab-copilot-agent/templates/configmap.yaml
+++ b/helm/gitlab-copilot-agent/templates/configmap.yaml
@@ -23,6 +23,12 @@ data:
   {{- with .Values.controller.copilotProviderBaseUrl }}
   COPILOT_PROVIDER_BASE_URL: {{ . | quote }}
   {{- end }}
+  {{- with .Values.controller.copilotPlugins }}
+  COPILOT_PLUGINS: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.controller.copilotPluginMarketplaces }}
+  COPILOT_PLUGIN_MARKETPLACES: {{ . | quote }}
+  {{- end }}
   {{- with .Values.telemetry.otlpEndpoint }}
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ . | quote }}
   {{- end }}

--- a/helm/gitlab-copilot-agent/templates/scaledjob.yaml
+++ b/helm/gitlab-copilot-agent/templates/scaledjob.yaml
@@ -29,7 +29,8 @@ spec:
         containers:
           - name: task
             image: "{{ .Values.jobRunner.image | default (printf "%s:%s" .Values.image.repository (.Values.image.tag | default "latest")) }}"
-            command: [".venv/bin/python", "-m", "gitlab_copilot_agent.task_runner"]
+            command: ["/opt/entrypoint.sh"]
+            args: [".venv/bin/python", "-m", "gitlab_copilot_agent.task_runner"]
             envFrom:
               - configMapRef:
                   name: {{ include "app.fullname" . }}

--- a/helm/gitlab-copilot-agent/values.yaml
+++ b/helm/gitlab-copilot-agent/values.yaml
@@ -9,6 +9,8 @@ controller:
   copilotProviderType: ""
   copilotProviderBaseUrl: ""
   copilotProviderApiKey: ""
+  copilotPlugins: ""
+  copilotPluginMarketplaces: ""
   resources:
     limits: { cpu: 500m, memory: 512Mi }
     requests: { cpu: 100m, memory: 256Mi }

--- a/scripts/gen-k3d-values.sh
+++ b/scripts/gen-k3d-values.sh
@@ -9,7 +9,7 @@ cat <<EOF
 image: {repository: gitlab-copilot-agent, tag: local}
 gitlab: {url: "${GITLAB_URL}", token: "${GITLAB_TOKEN}", webhookSecret: "${GITLAB_WEBHOOK_SECRET}"}
 github: {token: "${GITHUB_TOKEN:-}"}
-controller: {taskExecutor: "${TASK_EXECUTOR:-kubernetes}", copilotProviderType: "${COPILOT_PROVIDER_TYPE:-}", copilotProviderBaseUrl: "${COPILOT_PROVIDER_BASE_URL:-}", copilotProviderApiKey: "${COPILOT_PROVIDER_API_KEY:-}"}
+controller: {taskExecutor: "${TASK_EXECUTOR:-kubernetes}", copilotProviderType: "${COPILOT_PROVIDER_TYPE:-}", copilotProviderBaseUrl: "${COPILOT_PROVIDER_BASE_URL:-}", copilotProviderApiKey: "${COPILOT_PROVIDER_API_KEY:-}", copilotPlugins: "${COPILOT_PLUGINS:-}", copilotPluginMarketplaces: "${COPILOT_PLUGIN_MARKETPLACES:-}"}
 jira:
   url: "${JIRA_URL:-}"
   email: "${JIRA_EMAIL:-}"

--- a/src/gitlab_copilot_agent/aca_executor.py
+++ b/src/gitlab_copilot_agent/aca_executor.py
@@ -33,6 +33,7 @@ def _build_dispatch_payload(task: TaskParams, repo_blob_key: str | None) -> str:
             "repo_blob_key": repo_blob_key,
             "system_prompt": task.system_prompt,
             "user_prompt": task.user_prompt,
+            "plugins": task.plugins,
         }
     )
 

--- a/src/gitlab_copilot_agent/coding_engine.py
+++ b/src/gitlab_copilot_agent/coding_engine.py
@@ -98,6 +98,7 @@ async def run_coding_task(
     issue_key: str,
     summary: str,
     description: str | None,
+    plugins: list[str] | None = None,
 ) -> TaskResult:
     """Run a Copilot agent session to implement changes from a Jira issue."""
     ensure_git_exclude(repo_path)
@@ -110,5 +111,6 @@ async def run_coding_task(
         user_prompt=build_jira_coding_prompt(issue_key, summary, description),
         settings=settings,
         repo_path=repo_path,
+        plugins=plugins or [],
     )
     return await executor.execute(task)

--- a/src/gitlab_copilot_agent/coding_orchestrator.py
+++ b/src/gitlab_copilot_agent/coding_orchestrator.py
@@ -108,6 +108,7 @@ class CodingOrchestrator:
                         issue.key,
                         issue.fields.summary,
                         description,
+                        plugins=project_mapping.plugins,
                     )
                     await bound_log.ainfo("coding_complete", summary=result.summary[:200])
                     await apply_coding_result(result, repo_path)

--- a/src/gitlab_copilot_agent/config.py
+++ b/src/gitlab_copilot_agent/config.py
@@ -2,7 +2,7 @@
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings
 
 
@@ -53,6 +53,13 @@ class Settings(BaseSettings):
     copilot_provider_api_key: str | None = Field(default=None, description="BYOK provider API key")
     github_token: str | None = Field(
         default=None, description="GitHub token for Copilot auth (if not using BYOK)"
+    )
+    copilot_plugins: str | list[str] = Field(
+        default_factory=list,
+        description="Service-level Copilot CLI plugins to install at runtime",
+    )
+    copilot_plugin_marketplaces: str | list[str] = Field(
+        default_factory=list, description="Custom plugin marketplace URLs"
     )
 
     # System prompts (override or append to built-in defaults)
@@ -193,6 +200,19 @@ class Settings(BaseSettings):
         default=None, description="JSON: Jira project key → GitLab project config"
     )
 
+    @field_validator("copilot_plugins", "copilot_plugin_marketplaces", mode="before")
+    @classmethod
+    def _parse_comma_list(cls, v: object) -> object:
+        if isinstance(v, str):
+            v = v.strip()
+            if not v:
+                return []
+            # Try JSON first, fall back to comma-separated
+            if v.startswith("["):
+                return v  # let pydantic handle JSON
+            return [item.strip() for item in v.split(",") if item.strip()]
+        return v
+
     @property
     def jira(self) -> JiraSettings | None:
         """Return JiraSettings if all required Jira fields are set, else None."""
@@ -281,6 +301,13 @@ class TaskRunnerSettings(BaseSettings):
     copilot_provider_base_url: str | None = Field(default=None, description="BYOK provider URL")
     copilot_provider_api_key: str | None = Field(default=None, description="BYOK provider API key")
     github_token: str | None = Field(default=None, description="GitHub token for Copilot auth")
+    copilot_plugins: str | list[str] = Field(
+        default_factory=list,
+        description="Service-level Copilot CLI plugins to install at runtime",
+    )
+    copilot_plugin_marketplaces: str | list[str] = Field(
+        default_factory=list, description="Custom plugin marketplace URLs"
+    )
 
     # System prompts
     system_prompt: str | None = Field(default=None, description="Global base prompt")
@@ -319,6 +346,19 @@ class TaskRunnerSettings(BaseSettings):
     queue_visibility_buffer: int = Field(
         default=60, description="Extra seconds added to job timeout for queue visibility"
     )
+
+    @field_validator("copilot_plugins", "copilot_plugin_marketplaces", mode="before")
+    @classmethod
+    def _parse_comma_list(cls, v: object) -> object:
+        if isinstance(v, str):
+            v = v.strip()
+            if not v:
+                return []
+            # Try JSON first, fall back to comma-separated
+            if v.startswith("["):
+                return v  # let pydantic handle JSON
+            return [item.strip() for item in v.split(",") if item.strip()]
+        return v
 
     @model_validator(mode="after")
     def _check_auth(self) -> "TaskRunnerSettings":

--- a/src/gitlab_copilot_agent/copilot_session.py
+++ b/src/gitlab_copilot_agent/copilot_session.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import os
+import shutil
+import tempfile
 import time
 from collections.abc import Callable
 from typing import Any, cast
@@ -43,6 +45,25 @@ def build_sdk_env(github_token: str | None) -> dict[str, str]:
     return env
 
 
+def _as_list(value: str | list[str]) -> list[str]:
+    """Narrow a settings field (str | list[str] for pydantic-settings) to list[str]."""
+    return value if isinstance(value, list) else []
+
+
+def _merge_plugins(
+    service_plugins: list[str],
+    repo_plugins: list[str] | None,
+) -> list[str]:
+    """Merge service-level and repo-level plugins, preserving order and deduplicating."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for spec in [*service_plugins, *(repo_plugins or [])]:
+        if spec not in seen:
+            seen.add(spec)
+            result.append(spec)
+    return result
+
+
 async def run_copilot_session(
     settings: Settings | TaskRunnerSettings,
     repo_path: str,
@@ -51,6 +72,7 @@ async def run_copilot_session(
     timeout: int = 300,
     task_type: str = "review",
     validate_response: Callable[[str], str | None] | None = None,
+    plugins: list[str] | None = None,
 ) -> str:
     """Run a Copilot agent session and return the last assistant message.
 
@@ -70,95 +92,117 @@ async def run_copilot_session(
     ):
         cli_path = get_real_cli_path()
         try:
-            client_opts: CopilotClientOptions = {
-                "cli_path": cli_path,
-                "env": build_sdk_env(settings.github_token),
-            }
-            if settings.github_token:
-                client_opts["github_token"] = settings.github_token
-
-            client = CopilotClient(client_opts)
-            await client.start()
-
+            # Per-session HOME isolation — plugins and SDK state never leak between sessions
+            session_home = tempfile.mkdtemp(prefix="copilot-session-")
             try:
-                repo_config = discover_repo_config(repo_path)
+                # Merge service-level + repo-level plugins (deduplicated, order-preserved)
+                effective_plugins = _merge_plugins(_as_list(settings.copilot_plugins), plugins)
+                marketplaces = _as_list(settings.copilot_plugin_marketplaces)
+                if effective_plugins or marketplaces:
+                    from gitlab_copilot_agent.plugin_manager import setup_plugins
 
-                system_content = system_prompt
-                if repo_config.instructions:
-                    system_content += (
-                        f"\n\n## Project-Specific Instructions\n\n{repo_config.instructions}\n"
+                    await setup_plugins(
+                        session_home,
+                        effective_plugins,
+                        marketplaces or None,
                     )
 
-                session_opts: SessionConfig = {
-                    "system_message": {"content": system_content},
-                    "working_directory": repo_path,
+                sdk_env = build_sdk_env(settings.github_token)
+                sdk_env["HOME"] = session_home
+
+                client_opts: CopilotClientOptions = {
+                    "cli_path": cli_path,
+                    "env": sdk_env,
                 }
+                if settings.github_token:
+                    client_opts["github_token"] = settings.github_token
 
-                if repo_config.skill_directories:
-                    session_opts["skill_directories"] = repo_config.skill_directories
-                    await log.ainfo("skills_loaded", directories=repo_config.skill_directories)
-                if repo_config.custom_agents:
-                    session_opts["custom_agents"] = [
-                        cast(CustomAgentConfig, a.model_dump(exclude_none=True))
-                        for a in repo_config.custom_agents
-                    ]
-                    await log.ainfo(
-                        "agents_loaded",
-                        agents=[a.name for a in repo_config.custom_agents],
-                    )
-                if repo_config.instructions:
-                    await log.ainfo("instructions_loaded")
+                client = CopilotClient(client_opts)
+                await client.start()
 
-                if settings.copilot_provider_type:
-                    provider: ProviderConfig = {
-                        "type": cast(Any, settings.copilot_provider_type),
-                    }
-                    if settings.copilot_provider_base_url:
-                        provider["base_url"] = settings.copilot_provider_base_url
-                    if settings.copilot_provider_api_key:
-                        provider["api_key"] = settings.copilot_provider_api_key
-                    if settings.copilot_provider_type == "azure":
-                        provider["azure"] = {"api_version": "2024-10-21"}
-                    session_opts["provider"] = provider
-                    session_opts["model"] = settings.copilot_model
-
-                session_opts["on_permission_request"] = PermissionHandler.approve_all
-                session = await client.create_session(session_opts)
                 try:
-                    done = asyncio.Event()
-                    messages: list[str] = []
+                    repo_config = discover_repo_config(repo_path)
 
-                    def on_event(event: Any) -> None:  # pyright: ignore[reportExplicitAny]
-                        match getattr(event, "type", None):
-                            case t if t and t.value == "assistant.message":
-                                content = getattr(event.data, "content", "")
-                                if content:
-                                    messages.append(content)
-                            case t if t and t.value == "session.idle":
-                                done.set()
-                            case _:
-                                pass
+                    system_content = system_prompt
+                    if repo_config.instructions:
+                        system_content += (
+                            f"\n\n## Project-Specific Instructions\n\n{repo_config.instructions}\n"
+                        )
 
-                    session.on(on_event)
-                    await session.send({"prompt": user_prompt})
-                    await asyncio.wait_for(done.wait(), timeout=timeout)
+                    session_opts: SessionConfig = {
+                        "system_message": {"content": system_content},
+                        "working_directory": repo_path,
+                    }
 
-                    result = messages[-1] if messages else ""
+                    if repo_config.skill_directories:
+                        session_opts["skill_directories"] = repo_config.skill_directories
+                        await log.ainfo("skills_loaded", directories=repo_config.skill_directories)
+                    if repo_config.custom_agents:
+                        session_opts["custom_agents"] = [
+                            cast(CustomAgentConfig, a.model_dump(exclude_none=True))
+                            for a in repo_config.custom_agents
+                        ]
+                        await log.ainfo(
+                            "agents_loaded",
+                            agents=[a.name for a in repo_config.custom_agents],
+                        )
+                    if repo_config.instructions:
+                        await log.ainfo("instructions_loaded")
 
-                    if validate_response is not None:
-                        follow_up = validate_response(result)
-                        if follow_up:
-                            await log.ainfo("copilot_session_retry", reason="validate_response")
-                            done.clear()
-                            messages.clear()
-                            await session.send({"prompt": follow_up})
-                            await asyncio.wait_for(done.wait(), timeout=timeout)
-                            result = messages[-1] if messages else result
+                    if settings.copilot_provider_type:
+                        provider: ProviderConfig = {
+                            "type": cast(Any, settings.copilot_provider_type),
+                        }
+                        if settings.copilot_provider_base_url:
+                            provider["base_url"] = settings.copilot_provider_base_url
+                        if settings.copilot_provider_api_key:
+                            provider["api_key"] = settings.copilot_provider_api_key
+                        if settings.copilot_provider_type == "azure":
+                            provider["azure"] = {"api_version": "2024-10-21"}
+                        session_opts["provider"] = provider
+                        session_opts["model"] = settings.copilot_model
+
+                    session_opts["on_permission_request"] = PermissionHandler.approve_all
+                    session = await client.create_session(session_opts)
+                    try:
+                        done = asyncio.Event()
+                        messages: list[str] = []
+
+                        def on_event(event: Any) -> None:  # pyright: ignore[reportExplicitAny]
+                            match getattr(event, "type", None):
+                                case t if t and t.value == "assistant.message":
+                                    content = getattr(event.data, "content", "")
+                                    if content:
+                                        messages.append(content)
+                                case t if t and t.value == "session.idle":
+                                    done.set()
+                                case _:
+                                    pass
+
+                        session.on(on_event)
+                        await session.send({"prompt": user_prompt})
+                        await asyncio.wait_for(done.wait(), timeout=timeout)
+
+                        result = messages[-1] if messages else ""
+
+                        if validate_response is not None:
+                            follow_up = validate_response(result)
+                            if follow_up:
+                                await log.ainfo(
+                                    "copilot_session_retry", reason="validate_response"
+                                )
+                                done.clear()
+                                messages.clear()
+                                await session.send({"prompt": follow_up})
+                                await asyncio.wait_for(done.wait(), timeout=timeout)
+                                result = messages[-1] if messages else result
+                    finally:
+                        await session.destroy()
                 finally:
-                    await session.destroy()
+                    await client.stop()
+                return result
             finally:
-                await client.stop()
-            return result
+                shutil.rmtree(session_home, ignore_errors=True)
         finally:
             elapsed = time.monotonic() - session_start
             copilot_session_duration.record(elapsed, {"task_type": task_type})

--- a/src/gitlab_copilot_agent/k8s_executor.py
+++ b/src/gitlab_copilot_agent/k8s_executor.py
@@ -77,6 +77,7 @@ class KubernetesTaskExecutor:
                 "repo_blob_key": repo_blob_key,
                 "system_prompt": task.system_prompt,
                 "user_prompt": task.user_prompt,
+                "plugins": task.plugins,
             }
         )
         await self._task_queue.enqueue(task.task_id, payload)

--- a/src/gitlab_copilot_agent/mapping_models.py
+++ b/src/gitlab_copilot_agent/mapping_models.py
@@ -28,6 +28,9 @@ class Defaults(BaseModel):
         default="default",
         description="Default credential alias; maps to GITLAB_TOKEN",
     )
+    plugins: list[str] = Field(
+        default_factory=list, description="Default Copilot CLI plugins for all bindings"
+    )
 
 
 class Binding(BaseModel):
@@ -50,6 +53,10 @@ class Binding(BaseModel):
     credential_ref: str | None = Field(
         default=None,
         description="Override the default credential alias for this binding",
+    )
+    plugins: list[str] | None = Field(
+        default=None,
+        description="Repo-specific Copilot CLI plugins (overrides defaults when set)",
     )
 
     @model_validator(mode="after")
@@ -118,6 +125,7 @@ class MappingFile(BaseModel):
                 repo=b.repo,
                 target_branch=b.target_branch or self.defaults.target_branch,
                 credential_ref=b.credential_ref or self.defaults.credential_ref,
+                plugins=b.plugins if b.plugins is not None else self.defaults.plugins,
             )
         return RenderedMap(mappings=rendered_bindings)
 
@@ -130,6 +138,9 @@ class RenderedBinding(BaseModel):
     repo: str = Field(description="GitLab repo path")
     target_branch: str = Field(description="Resolved MR target branch")
     credential_ref: str = Field(description="Resolved credential alias")
+    plugins: list[str] = Field(
+        default_factory=list, description="Effective Copilot CLI plugins for this binding"
+    )
 
 
 class RenderedMap(BaseModel):

--- a/src/gitlab_copilot_agent/plugin_manager.py
+++ b/src/gitlab_copilot_agent/plugin_manager.py
@@ -1,0 +1,87 @@
+"""Copilot CLI plugin manager — runtime plugin installation into isolated HOME."""
+
+import asyncio
+import os
+from urllib.parse import urlparse
+
+import structlog
+
+from gitlab_copilot_agent.process_sandbox import get_real_cli_path
+
+log = structlog.get_logger()
+
+_INSTALL_TIMEOUT = 120  # seconds per plugin install
+
+
+def _sanitize_url(url: str) -> str:
+    """Strip credentials and query params from a URL for safe logging."""
+    parsed = urlparse(url)
+    return f"{parsed.scheme}://{parsed.hostname}{parsed.path}" if parsed.hostname else url
+
+
+async def _run_cli(args: list[str], *, home_dir: str, timeout: float = _INSTALL_TIMEOUT) -> bytes:
+    """Run a copilot CLI command, killing the subprocess on timeout."""
+    cli = get_real_cli_path()
+    env = {"HOME": home_dir, "PATH": os.environ.get("PATH", "")}
+    proc = await asyncio.create_subprocess_exec(
+        cli,
+        *args,
+        env=env,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        _stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except TimeoutError:
+        proc.kill()
+        await proc.wait()
+        raise RuntimeError(
+            f"Plugin command timed out after {timeout}s: copilot {' '.join(args)}"
+        ) from None
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"Plugin command failed (rc={proc.returncode}): copilot {' '.join(args)}: "
+            f"{stderr.decode().strip()}"
+        )
+    return stderr
+
+
+async def add_marketplace(home_dir: str, marketplace_url: str) -> None:
+    """Register a custom plugin marketplace in the given HOME."""
+    await _run_cli(["plugin", "marketplace", "add", marketplace_url], home_dir=home_dir)
+    await log.ainfo("marketplace_added", url=_sanitize_url(marketplace_url))
+
+
+async def install_plugin(home_dir: str, plugin_spec: str) -> None:
+    """Install a single Copilot CLI plugin into the given HOME."""
+    await _run_cli(["plugin", "install", plugin_spec], home_dir=home_dir)
+    await log.ainfo("plugin_installed", plugin=plugin_spec)
+
+
+async def setup_plugins(
+    home_dir: str,
+    plugins: list[str],
+    marketplaces: list[str] | None = None,
+) -> None:
+    """Install marketplaces and plugins into an isolated HOME directory.
+
+    Called once per Copilot session with a fresh temp HOME.
+    """
+    if not plugins and not marketplaces:
+        return
+
+    for url in marketplaces or []:
+        await add_marketplace(home_dir, url)
+
+    seen: set[str] = set()
+    for spec in plugins:
+        if spec in seen:
+            continue
+        seen.add(spec)
+        await install_plugin(home_dir, spec)
+
+    await log.ainfo(
+        "plugin_setup_complete",
+        plugin_count=len(seen),
+        marketplace_count=len(marketplaces or []),
+    )

--- a/src/gitlab_copilot_agent/project_registry.py
+++ b/src/gitlab_copilot_agent/project_registry.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 import structlog
+from pydantic import BaseModel, ConfigDict, Field
 
 from gitlab_copilot_agent.credential_registry import CredentialRegistry
 from gitlab_copilot_agent.gitlab_client import GitLabClient
@@ -13,24 +12,19 @@ from gitlab_copilot_agent.mapping_models import RenderedMap
 log = structlog.get_logger()
 
 
-@dataclass(frozen=True, repr=False)
-class ResolvedProject:
+class ResolvedProject(BaseModel):
     """Fully resolved project context ready for runtime use."""
 
-    jira_project: str
-    repo: str
-    gitlab_project_id: int
-    clone_url: str
-    target_branch: str
-    credential_ref: str
-    token: str
+    model_config = ConfigDict(frozen=True)
 
-    def __repr__(self) -> str:
-        return (
-            f"ResolvedProject(jira_project={self.jira_project!r}, "
-            f"repo={self.repo!r}, gitlab_project_id={self.gitlab_project_id}, "
-            f"credential_ref={self.credential_ref!r}, token='***')"
-        )
+    jira_project: str = Field(description="Jira project key")
+    repo: str = Field(description="GitLab repo path_with_namespace")
+    gitlab_project_id: int = Field(description="Numeric GitLab project ID")
+    clone_url: str = Field(description="Git HTTP clone URL")
+    target_branch: str = Field(description="Default target branch")
+    credential_ref: str = Field(description="Credential registry key")
+    token: str = Field(description="Resolved GitLab token", repr=False)
+    plugins: list[str] = Field(default_factory=list, description="Copilot CLI plugin specs")
 
 
 class ProjectRegistry:
@@ -79,6 +73,7 @@ class ProjectRegistry:
                     target_branch=binding.target_branch,
                     credential_ref=binding.credential_ref,
                     token=token,
+                    plugins=binding.plugins,
                 )
             )
         registry = cls(projects)

--- a/src/gitlab_copilot_agent/task_executor.py
+++ b/src/gitlab_copilot_agent/task_executor.py
@@ -21,6 +21,9 @@ class TaskParams(BaseModel):
     user_prompt: str = Field(description="User prompt for the Copilot session")
     settings: Settings = Field(description="Application settings")
     repo_path: str | None = Field(default=None, description="Local path to cloned repo")
+    plugins: list[str] = Field(
+        default_factory=list, description="Effective Copilot CLI plugins for this task"
+    )
 
 
 class ReviewResult(BaseModel):
@@ -70,6 +73,7 @@ class LocalTaskExecutor:
             system_prompt=task.system_prompt,
             user_prompt=task.user_prompt,
             task_type=task.task_type,
+            plugins=task.plugins or None,
         )
         if task.task_type == "review":
             return ReviewResult(summary=summary)

--- a/src/gitlab_copilot_agent/task_runner.py
+++ b/src/gitlab_copilot_agent/task_runner.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 
 import structlog
+from pydantic import BaseModel, ConfigDict, Field
 
 from gitlab_copilot_agent.coding_engine import parse_agent_output
 from gitlab_copilot_agent.concurrency import QueueMessage, TaskQueue
@@ -26,6 +27,20 @@ ENV_TASK_TYPE, ENV_TASK_ID = "TASK_TYPE", "TASK_ID"
 ENV_TASK_PAYLOAD = "TASK_PAYLOAD"
 VALID_TASK_TYPES: frozenset[str] = frozenset({"review", "coding", "echo"})
 _RESULT_TTL = 3600  # 1 hour
+
+
+class QueueTaskPayload(BaseModel):
+    """Typed representation of a task dequeued from Azure Storage Queue."""
+
+    model_config = ConfigDict(strict=True)
+
+    task_type: str = Field(description="Task type: review, coding, or echo")
+    task_id: str = Field(description="Unique task identifier for idempotency")
+    repo_blob_key: str | None = Field(default=None, description="Blob key for repo tarball")
+    system_prompt: str = Field(default="", description="System prompt for Copilot session")
+    user_prompt: str = Field(description="User prompt for Copilot session")
+    plugins: list[str] | None = Field(default=None, description="Per-repo plugin specs")
+
 
 _RETRY_PROMPT = (
     "Your response did not include the required JSON output block. "
@@ -63,7 +78,7 @@ async def _store_result(
         await store.aclose()
 
 
-async def _dequeue_task() -> tuple[dict[str, str], QueueMessage, TaskQueue] | None:
+async def _dequeue_task() -> tuple[QueueTaskPayload, QueueMessage, TaskQueue] | None:
     """Dequeue a task from Azure Storage Queue (if configured).
 
     Creates TaskRunnerSettings internally; returns None if settings
@@ -97,8 +112,8 @@ async def _dequeue_task() -> tuple[dict[str, str], QueueMessage, TaskQueue] | No
         await queue.aclose()
         return None
 
-    params: dict[str, str] = json.loads(msg.payload)
-    return params, msg, queue
+    payload = QueueTaskPayload.model_validate_json(msg.payload)
+    return payload, msg, queue
 
 
 def _get_required_env(name: str) -> str:
@@ -190,11 +205,12 @@ async def run_task() -> int:  # noqa: C901 — dispatch routing requires branchi
 
     queue_result = await _dequeue_task()
     if queue_result is not None:
-        params_dict, queue_msg, task_queue = queue_result
-        task_type = params_dict["task_type"]
-        task_id = params_dict["task_id"]
-        repo_blob_key = params_dict.get("repo_blob_key")
-        user_prompt = params_dict["user_prompt"]
+        payload, queue_msg, task_queue = queue_result
+        task_type = payload.task_type
+        task_id = payload.task_id
+        repo_blob_key = payload.repo_blob_key
+        user_prompt = payload.user_prompt
+        plugins = payload.plugins
     else:
         try:
             task_type = _get_required_env(ENV_TASK_TYPE)
@@ -202,6 +218,7 @@ async def run_task() -> int:  # noqa: C901 — dispatch routing requires branchi
             payload_raw = _get_required_env(ENV_TASK_PAYLOAD)
             user_prompt = str(_parse_task_payload(payload_raw).get("prompt", payload_raw))
             repo_blob_key = None
+            plugins = None
         except RuntimeError as exc:
             await log.aerror("missing_env_var", error=str(exc))
             return 1
@@ -257,6 +274,7 @@ async def run_task() -> int:  # noqa: C901 — dispatch routing requires branchi
             user_prompt,
             task_type=task_type,
             validate_response=_coding_response_validator if task_type == "coding" else None,
+            plugins=plugins,
         )
         if task_type == "coding":
             assert pre_session_sha is not None

--- a/tests/e2e/.env.e2e
+++ b/tests/e2e/.env.e2e
@@ -16,3 +16,5 @@ JIRA_API_TOKEN=e2e-fake-jira-token
 JIRA_PROJECT_MAP='{"mappings": {"DEMO": {"repo": "repo", "target_branch": "main", "credential_ref": "default"}}}'
 JIRA_TRIGGER_STATUS="AI Ready"
 JIRA_POLL_INTERVAL=5
+COPILOT_PLUGINS=/opt/test-marketplace/plugins/e2e-greeter
+COPILOT_PLUGIN_MARKETPLACES=/opt/test-marketplace

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # E2E test: deploy agent to k3d, run all test flows against mock services.
 # Tests: 1. Webhook MR review, 2. Jira polling, 3. /copilot command,
-#        4. GitLab polling, 5. Hot-reload config, 6. Graceful shutdown.
+#        4. GitLab polling, 5. Hot-reload config, 6. Plugin install, 7. Graceful shutdown.
 # Usage: ./tests/e2e/run.sh [agent-url] [mock-gitlab-url] [mock-jira-url]
 set -euo pipefail
 
@@ -213,8 +213,40 @@ UNAUTH=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$AGENT_URL/config/reloa
     -d '{"mappings": {}}')
 [ "$UNAUTH" = "401" ] && echo " ✅" || { echo " ❌ (expected 401, got $UNAUTH)"; exit 1; }
 
-# === TEST 6: Graceful Shutdown ===
-echo ""; echo "--- Test 6: Graceful Shutdown ---"
+# === TEST 6: Plugin Installation Verification ===
+echo ""; echo "--- Test 6: Plugin Installation ---"
+# Clear discussions for this test
+curl -sf -X DELETE "$MOCK_GITLAB_URL/discussions" > /dev/null
+
+echo -n "Sending webhook (plugin-enabled session)..."
+send_webhook '{
+    "object_kind": "merge_request",
+    "user": {"id": 1, "username": "e2e-test"},
+    "project": {"id": 999, "path_with_namespace": "test/e2e-repo",
+                "git_http_url": "http://host.k3d.internal:9999/repo.git"},
+    "object_attributes": {"iid": 99, "title": "Plugin test MR", "description": "Verify plugins",
+        "action": "open", "source_branch": "main", "target_branch": "main",
+        "last_commit": {"id": "plugin123", "message": "plugin test"}, "url": "http://mock/mr/99", "oldrev": null}
+}'
+
+# Wait for the task to complete (review posted)
+poll_until "$MOCK_GITLAB_URL/discussions" \
+    "import sys,json; d=json.load(sys.stdin); print(len(d) if d else 0)" \
+    "Waiting for plugin-enabled review" || { kubectl logs -l app.kubernetes.io/name=gitlab-copilot-agent --tail=50 2>/dev/null || true; exit 1; }
+
+# Check job pod logs for plugin setup evidence
+echo -n "Checking pod logs for plugin installation..."
+PLUGIN_LOG=$(kubectl logs -l app.kubernetes.io/component=job --tail=200 2>/dev/null || echo "")
+if echo "$PLUGIN_LOG" | grep -q "plugin_installed\|plugin_setup_complete\|e2e-greeter"; then
+    echo " ✅ (plugin setup confirmed in logs)"
+elif echo "$PLUGIN_LOG" | grep -q "plugin"; then
+    echo " ✅ (plugin activity detected in logs)"
+else
+    echo " ⚠️ (no plugin log evidence — check COPILOT_PLUGINS config)"
+fi
+
+# === TEST 7: Graceful Shutdown ===
+echo ""; echo "--- Test 7: Graceful Shutdown ---"
 
 echo -n "Deleting controller pod (triggers SIGTERM via k8s)..."
 POD=$(kubectl get pods -l app.kubernetes.io/component=controller -o name | head -1)

--- a/tests/e2e/test-marketplace/.github/plugin/marketplace.json
+++ b/tests/e2e/test-marketplace/.github/plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "e2e-test-marketplace",
+  "owner": {
+    "name": "E2E Tests",
+    "email": "e2e@test.local"
+  },
+  "metadata": {
+    "description": "Self-contained test marketplace for E2E plugin verification",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "e2e-greeter",
+      "description": "Minimal test plugin that adds a greeting skill",
+      "version": "1.0.0",
+      "source": "./plugins/e2e-greeter"
+    }
+  ]
+}

--- a/tests/e2e/test-marketplace/plugins/e2e-greeter/plugin.json
+++ b/tests/e2e/test-marketplace/plugins/e2e-greeter/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "e2e-greeter",
+  "description": "Minimal test plugin for E2E verification",
+  "version": "1.0.0",
+  "author": {
+    "name": "E2E Tests",
+    "email": "e2e@test.local"
+  },
+  "skills": ["skills/"]
+}

--- a/tests/e2e/test-marketplace/plugins/e2e-greeter/skills/greet/SKILL.md
+++ b/tests/e2e/test-marketplace/plugins/e2e-greeter/skills/greet/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: greet
+description: E2E test skill that confirms plugin loading works.
+---
+
+When the user asks for a greeting, respond with "Hello from e2e-greeter plugin!"

--- a/tests/test_aca_executor.py
+++ b/tests/test_aca_executor.py
@@ -93,6 +93,7 @@ class TestDispatchPayload:
             "repo_blob_key",
             "system_prompt",
             "user_prompt",
+            "plugins",
         }
         assert keys == expected_keys
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -204,3 +204,66 @@ class TestPrintConfigErrors:
         assert "No LLM authentication configured" in err
         assert "GITHUB_TOKEN" in err
         assert "COPILOT_PROVIDER_TYPE" in err
+
+
+# -- Plugin config tests --
+
+
+def test_plugin_defaults_empty() -> None:
+    """Plugin fields default to empty lists."""
+    settings = make_settings()
+    assert settings.copilot_plugins == []
+    assert settings.copilot_plugin_marketplaces == []
+
+
+def test_plugins_from_comma_separated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """COPILOT_PLUGINS accepts comma-separated values."""
+    monkeypatch.setenv("GITLAB_URL", GITLAB_URL)
+    monkeypatch.setenv("GITLAB_TOKEN", GITLAB_TOKEN)
+    monkeypatch.setenv("GITLAB_WEBHOOK_SECRET", WEBHOOK_SECRET)
+    monkeypatch.setenv("GITHUB_TOKEN", GITHUB_TOKEN)
+    monkeypatch.setenv("AZURE_STORAGE_CONNECTION_STRING", AZURITE_CONNECTION_STRING)
+    monkeypatch.setenv("COPILOT_PLUGINS", "plugin-a, plugin-b")
+    settings = Settings()
+    assert settings.copilot_plugins == ["plugin-a", "plugin-b"]
+
+
+def test_plugins_from_json_array(monkeypatch: pytest.MonkeyPatch) -> None:
+    """COPILOT_PLUGINS accepts JSON array format."""
+    monkeypatch.setenv("GITLAB_URL", GITLAB_URL)
+    monkeypatch.setenv("GITLAB_TOKEN", GITLAB_TOKEN)
+    monkeypatch.setenv("GITLAB_WEBHOOK_SECRET", WEBHOOK_SECRET)
+    monkeypatch.setenv("GITHUB_TOKEN", GITHUB_TOKEN)
+    monkeypatch.setenv("AZURE_STORAGE_CONNECTION_STRING", AZURITE_CONNECTION_STRING)
+    monkeypatch.setenv("COPILOT_PLUGINS", '["plugin-a","plugin-b"]')
+    settings = Settings()
+    assert settings.copilot_plugins == ["plugin-a", "plugin-b"]
+
+
+def test_empty_plugins_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty COPILOT_PLUGINS env var yields empty list."""
+    monkeypatch.setenv("GITLAB_URL", GITLAB_URL)
+    monkeypatch.setenv("GITLAB_TOKEN", GITLAB_TOKEN)
+    monkeypatch.setenv("GITLAB_WEBHOOK_SECRET", WEBHOOK_SECRET)
+    monkeypatch.setenv("GITHUB_TOKEN", GITHUB_TOKEN)
+    monkeypatch.setenv("AZURE_STORAGE_CONNECTION_STRING", AZURITE_CONNECTION_STRING)
+    monkeypatch.setenv("COPILOT_PLUGINS", "")
+    settings = Settings()
+    assert settings.copilot_plugins == []
+
+
+def test_marketplaces_from_comma_separated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """COPILOT_PLUGIN_MARKETPLACES accepts comma-separated values."""
+    monkeypatch.setenv("GITLAB_URL", GITLAB_URL)
+    monkeypatch.setenv("GITLAB_TOKEN", GITLAB_TOKEN)
+    monkeypatch.setenv("GITLAB_WEBHOOK_SECRET", WEBHOOK_SECRET)
+    monkeypatch.setenv("GITHUB_TOKEN", GITHUB_TOKEN)
+    monkeypatch.setenv("AZURE_STORAGE_CONNECTION_STRING", AZURITE_CONNECTION_STRING)
+    monkeypatch.setenv(
+        "COPILOT_PLUGIN_MARKETPLACES", "https://mp1.example.com,https://mp2.example.com"
+    )
+    settings = Settings()
+    assert settings.copilot_plugin_marketplaces == [
+        "https://mp1.example.com",
+        "https://mp2.example.com",
+    ]

--- a/tests/test_copilot_session.py
+++ b/tests/test_copilot_session.py
@@ -12,6 +12,9 @@ from gitlab_copilot_agent.copilot_session import build_sdk_env, run_copilot_sess
 from gitlab_copilot_agent.repo_config import AgentConfig, RepoConfig
 from tests.conftest import make_settings
 
+PLUGIN_A = "copilot-plugin-a"
+PLUGIN_B = "copilot-plugin-b"
+
 
 def _make_event(event_type: str, content: str = "") -> SimpleNamespace:
     """Create a mock SDK event."""
@@ -141,3 +144,113 @@ def test_build_sdk_env_includes_only_allowed_vars(monkeypatch: pytest.MonkeyPatc
     assert "GITLAB_TOKEN" not in env
     assert "GITLAB_WEBHOOK_SECRET" not in env
     assert "JIRA_API_TOKEN" not in env
+
+
+def test_merge_plugins_deduplicates() -> None:
+    from gitlab_copilot_agent.copilot_session import _merge_plugins
+
+    result = _merge_plugins(["a", "b"], ["b", "c"])
+    assert result == ["a", "b", "c"]
+
+
+def test_merge_plugins_empty_inputs() -> None:
+    from gitlab_copilot_agent.copilot_session import _merge_plugins
+
+    assert _merge_plugins([], None) == []
+    assert _merge_plugins([], []) == []
+
+
+def test_merge_plugins_service_only() -> None:
+    from gitlab_copilot_agent.copilot_session import _merge_plugins
+
+    assert _merge_plugins(["a", "b"], None) == ["a", "b"]
+
+
+def test_merge_plugins_repo_only() -> None:
+    from gitlab_copilot_agent.copilot_session import _merge_plugins
+
+    assert _merge_plugins([], ["x", "y"]) == ["x", "y"]
+
+
+@patch("gitlab_copilot_agent.copilot_session.discover_repo_config")
+@patch("gitlab_copilot_agent.copilot_session.CopilotClient")
+async def test_session_creates_isolated_home(
+    mock_client_class: MagicMock,
+    mock_discover: MagicMock,
+    _run: Any,
+) -> None:
+    """Each session gets a fresh temp HOME that is cleaned up."""
+    mock_discover.return_value = RepoConfig()
+    _setup_mock_session(
+        mock_client_class,
+        [_make_event("assistant.message", "done"), _make_event("session.idle")],
+    )
+
+    await _run()
+
+    # Verify the SDK env got a custom HOME (not the process HOME)
+    client_opts = mock_client_class.call_args[0][0]
+    sdk_home = client_opts["env"]["HOME"]
+    assert "copilot-session-" in sdk_home
+    # Temp dir should be cleaned up after session
+    assert not Path(sdk_home).exists()
+
+
+@patch("gitlab_copilot_agent.plugin_manager.setup_plugins", new_callable=AsyncMock)
+@patch("gitlab_copilot_agent.copilot_session.discover_repo_config")
+@patch("gitlab_copilot_agent.copilot_session.CopilotClient")
+async def test_session_installs_plugins(
+    mock_client_class: MagicMock,
+    mock_discover: MagicMock,
+    mock_setup: AsyncMock,
+    tmp_path: Path,
+) -> None:
+    """Plugins are installed into the session HOME."""
+    mock_discover.return_value = RepoConfig()
+    _setup_mock_session(
+        mock_client_class,
+        [_make_event("assistant.message", "done"), _make_event("session.idle")],
+    )
+
+    settings = make_settings(
+        copilot_plugins=["svc-plugin"],
+        copilot_plugin_marketplaces=["https://mp.example.com"],
+    )
+    await run_copilot_session(
+        settings=settings,
+        repo_path=str(tmp_path),
+        system_prompt="System",
+        user_prompt="User",
+        plugins=["repo-plugin"],
+    )
+
+    mock_setup.assert_awaited_once()
+    call_args = mock_setup.call_args
+    home_dir = call_args[0][0]
+    plugins = call_args[0][1]
+    marketplaces = call_args[0][2]
+    assert "copilot-session-" in home_dir
+    assert "svc-plugin" in plugins
+    assert "repo-plugin" in plugins
+    assert marketplaces == ["https://mp.example.com"]
+
+
+@patch("gitlab_copilot_agent.copilot_session.discover_repo_config")
+@patch("gitlab_copilot_agent.copilot_session.CopilotClient")
+async def test_session_no_plugins_skips_setup(
+    mock_client_class: MagicMock,
+    mock_discover: MagicMock,
+    _run: Any,
+) -> None:
+    """No plugins configured means setup_plugins is not called."""
+    mock_discover.return_value = RepoConfig()
+    _setup_mock_session(
+        mock_client_class,
+        [_make_event("assistant.message", "done"), _make_event("session.idle")],
+    )
+
+    with patch(
+        "gitlab_copilot_agent.plugin_manager.setup_plugins", new_callable=AsyncMock
+    ) as mock_setup:
+        await _run()
+        mock_setup.assert_not_awaited()

--- a/tests/test_mapping_models.py
+++ b/tests/test_mapping_models.py
@@ -25,6 +25,8 @@ DEFAULT_BRANCH = "main"
 DEVELOP_BRANCH = "develop"
 DEFAULT_CRED = "default"
 PLATFORM_CRED = "platform_team"
+PLUGIN_A = "copilot-plugin-a"
+PLUGIN_B = "copilot-plugin-b"
 
 
 # ---------------------------------------------------------------------------
@@ -203,3 +205,61 @@ class TestRendering:
         json_str = rendered.model_dump_json()
         reloaded = RenderedMap.model_validate_json(json_str)
         assert reloaded == rendered
+
+
+class TestPlugins:
+    def test_defaults_plugins_empty(self) -> None:
+        d = Defaults()
+        assert d.plugins == []
+
+    def test_defaults_with_plugins(self) -> None:
+        d = Defaults(plugins=[PLUGIN_A, PLUGIN_B])
+        assert d.plugins == [PLUGIN_A, PLUGIN_B]
+
+    def test_binding_plugins_none_by_default(self) -> None:
+        b = Binding(**_minimal_binding())
+        assert b.plugins is None
+
+    def test_binding_with_plugins(self) -> None:
+        b = Binding(**_minimal_binding(plugins=[PLUGIN_A]))
+        assert b.plugins == [PLUGIN_A]
+
+    def test_render_uses_default_plugins(self) -> None:
+        data = _minimal_mapping(defaults={"plugins": [PLUGIN_A]})
+        m = MappingFile(**data)
+        rendered = m.render()
+        assert rendered.mappings[JIRA_KEY_PROJ].plugins == [PLUGIN_A]
+
+    def test_render_binding_overrides_default_plugins(self) -> None:
+        data = _minimal_mapping(
+            defaults={"plugins": [PLUGIN_A]},
+            bindings=[_minimal_binding(plugins=[PLUGIN_B])],
+        )
+        m = MappingFile(**data)
+        rendered = m.render()
+        assert rendered.mappings[JIRA_KEY_PROJ].plugins == [PLUGIN_B]
+
+    def test_render_binding_empty_plugins_overrides_defaults(self) -> None:
+        """Explicitly setting empty list on binding clears default plugins."""
+        data = _minimal_mapping(
+            defaults={"plugins": [PLUGIN_A]},
+            bindings=[_minimal_binding(plugins=[])],
+        )
+        m = MappingFile(**data)
+        rendered = m.render()
+        assert rendered.mappings[JIRA_KEY_PROJ].plugins == []
+
+    def test_render_binding_none_inherits_defaults(self) -> None:
+        """When binding.plugins is None, defaults apply."""
+        data = _minimal_mapping(defaults={"plugins": [PLUGIN_A, PLUGIN_B]})
+        m = MappingFile(**data)
+        rendered = m.render()
+        assert rendered.mappings[JIRA_KEY_PROJ].plugins == [PLUGIN_A, PLUGIN_B]
+
+    def test_rendered_json_round_trip_with_plugins(self) -> None:
+        data = _minimal_mapping(defaults={"plugins": [PLUGIN_A]})
+        m = MappingFile(**data)
+        rendered = m.render()
+        json_str = rendered.model_dump_json()
+        reloaded = RenderedMap.model_validate_json(json_str)
+        assert reloaded.mappings[JIRA_KEY_PROJ].plugins == [PLUGIN_A]

--- a/tests/test_plugin_isolation.py
+++ b/tests/test_plugin_isolation.py
@@ -1,0 +1,242 @@
+"""Integration tests for plugin session isolation.
+
+Verifies that per-session HOME isolation prevents plugin state from
+leaking between repos/sessions. Uses mocked subprocess calls — does
+not require a real Copilot CLI or public marketplaces.
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gitlab_copilot_agent.copilot_session import _merge_plugins, run_copilot_session
+from gitlab_copilot_agent.repo_config import RepoConfig
+from tests.conftest import make_settings
+
+# Deterministic fixture plugin specs (no external dependencies)
+SVC_PLUGIN = "svc-analytics"
+REPO_A_PLUGIN = "repo-a-linter"
+REPO_B_PLUGIN = "repo-b-formatter"
+MARKETPLACE = "https://marketplace.example.com"
+
+_SESSION_MOD = "gitlab_copilot_agent.copilot_session"
+_PLUGIN_MOD = "gitlab_copilot_agent.plugin_manager"
+
+
+def _make_event(event_type: str, content: str = "") -> object:
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        type=SimpleNamespace(value=event_type),
+        data=SimpleNamespace(content=content),
+    )
+
+
+def _setup_mock_client(mock_client_class: MagicMock) -> None:
+    """Wire up a mock CopilotClient that emits idle on send."""
+    from collections.abc import Callable
+    from typing import Any
+
+    mock_client = AsyncMock()
+    mock_client_class.return_value = mock_client
+    mock_session = AsyncMock()
+    mock_session.on = MagicMock()
+    mock_client.create_session.return_value = mock_session
+
+    captured: dict[str, Callable[..., Any] | None] = {"handler": None}
+
+    def capture_on(handler: Callable[..., Any]) -> None:
+        captured["handler"] = handler
+
+    mock_session.on.side_effect = capture_on
+
+    async def fake_send(msg: object) -> None:
+        assert captured["handler"] is not None
+        captured["handler"](_make_event("assistant.message", "done"))
+        captured["handler"](_make_event("session.idle"))
+
+    mock_session.send.side_effect = fake_send
+
+
+class TestPluginMergeAndDedupe:
+    """Merge and dedupe behavior for service + repo plugins."""
+
+    def test_service_and_repo_merged(self) -> None:
+        result = _merge_plugins([SVC_PLUGIN], [REPO_A_PLUGIN])
+        assert result == [SVC_PLUGIN, REPO_A_PLUGIN]
+
+    def test_duplicates_removed(self) -> None:
+        result = _merge_plugins([SVC_PLUGIN, REPO_A_PLUGIN], [REPO_A_PLUGIN, REPO_B_PLUGIN])
+        assert result == [SVC_PLUGIN, REPO_A_PLUGIN, REPO_B_PLUGIN]
+
+    def test_service_order_preserved(self) -> None:
+        result = _merge_plugins(["c", "a", "b"], ["d", "a"])
+        assert result == ["c", "a", "b", "d"]
+
+    def test_repo_none_uses_service_only(self) -> None:
+        assert _merge_plugins([SVC_PLUGIN], None) == [SVC_PLUGIN]
+
+    def test_both_empty(self) -> None:
+        assert _merge_plugins([], []) == []
+
+
+class TestSessionHomeIsolation:
+    """Each session gets its own HOME; no state leaks between sessions."""
+
+    @patch(f"{_PLUGIN_MOD}.setup_plugins", new_callable=AsyncMock)
+    @patch(f"{_SESSION_MOD}.discover_repo_config")
+    @patch(f"{_SESSION_MOD}.CopilotClient")
+    async def test_two_sessions_get_different_homes(
+        self,
+        mock_client_class: MagicMock,
+        mock_discover: MagicMock,
+        mock_setup: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        """Repo A and repo B sessions must use distinct HOME directories."""
+        mock_discover.return_value = RepoConfig()
+        homes: list[str] = []
+
+        async def capture_home(home_dir: str, *_args: object, **_kw: object) -> None:
+            homes.append(home_dir)
+
+        mock_setup.side_effect = capture_home
+
+        settings = make_settings(copilot_plugins=[SVC_PLUGIN])
+
+        for repo_plugins in [[REPO_A_PLUGIN], [REPO_B_PLUGIN]]:
+            _setup_mock_client(mock_client_class)
+            await run_copilot_session(
+                settings=settings,
+                repo_path=str(tmp_path),
+                system_prompt="test",
+                user_prompt="test",
+                plugins=repo_plugins,
+            )
+
+        assert len(homes) == 2
+        assert homes[0] != homes[1]
+        # Both should be cleaned up
+        assert not Path(homes[0]).exists()
+        assert not Path(homes[1]).exists()
+
+    @patch(f"{_PLUGIN_MOD}.setup_plugins", new_callable=AsyncMock)
+    @patch(f"{_SESSION_MOD}.discover_repo_config")
+    @patch(f"{_SESSION_MOD}.CopilotClient")
+    async def test_repo_a_plugins_not_visible_to_repo_b(
+        self,
+        mock_client_class: MagicMock,
+        mock_discover: MagicMock,
+        mock_setup: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        """Plugin install calls for repo A must not include repo B specs."""
+        mock_discover.return_value = RepoConfig()
+        install_calls: list[tuple[str, list[str]]] = []
+
+        async def capture_install(
+            home_dir: str, plugins: list[str], *_args: object, **_kw: object
+        ) -> None:
+            install_calls.append((home_dir, list(plugins)))
+
+        mock_setup.side_effect = capture_install
+
+        settings = make_settings(copilot_plugins=[SVC_PLUGIN])
+
+        # Session for repo A
+        _setup_mock_client(mock_client_class)
+        await run_copilot_session(
+            settings=settings,
+            repo_path=str(tmp_path),
+            system_prompt="test",
+            user_prompt="test",
+            plugins=[REPO_A_PLUGIN],
+        )
+
+        # Session for repo B
+        _setup_mock_client(mock_client_class)
+        await run_copilot_session(
+            settings=settings,
+            repo_path=str(tmp_path),
+            system_prompt="test",
+            user_prompt="test",
+            plugins=[REPO_B_PLUGIN],
+        )
+
+        assert len(install_calls) == 2
+        repo_a_plugins = install_calls[0][1]
+        repo_b_plugins = install_calls[1][1]
+        # Repo A sees service + repo A only
+        assert SVC_PLUGIN in repo_a_plugins
+        assert REPO_A_PLUGIN in repo_a_plugins
+        assert REPO_B_PLUGIN not in repo_a_plugins
+        # Repo B sees service + repo B only
+        assert SVC_PLUGIN in repo_b_plugins
+        assert REPO_B_PLUGIN in repo_b_plugins
+        assert REPO_A_PLUGIN not in repo_b_plugins
+
+    @patch(f"{_PLUGIN_MOD}.setup_plugins", new_callable=AsyncMock)
+    @patch(f"{_SESSION_MOD}.discover_repo_config")
+    @patch(f"{_SESSION_MOD}.CopilotClient")
+    async def test_service_plugins_apply_to_all_sessions(
+        self,
+        mock_client_class: MagicMock,
+        mock_discover: MagicMock,
+        mock_setup: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        """Service-level plugins appear in every session."""
+        mock_discover.return_value = RepoConfig()
+        install_calls: list[list[str]] = []
+
+        async def capture_install(
+            home_dir: str, plugins: list[str], *_args: object, **_kw: object
+        ) -> None:
+            install_calls.append(list(plugins))
+
+        mock_setup.side_effect = capture_install
+
+        settings = make_settings(copilot_plugins=[SVC_PLUGIN])
+
+        for repo_plugins in [[REPO_A_PLUGIN], [REPO_B_PLUGIN], []]:
+            _setup_mock_client(mock_client_class)
+            await run_copilot_session(
+                settings=settings,
+                repo_path=str(tmp_path),
+                system_prompt="test",
+                user_prompt="test",
+                plugins=repo_plugins or None,
+            )
+
+        assert len(install_calls) == 3
+        for call_plugins in install_calls:
+            assert SVC_PLUGIN in call_plugins
+
+    @patch(f"{_SESSION_MOD}.discover_repo_config")
+    @patch(f"{_SESSION_MOD}.CopilotClient")
+    async def test_home_cleaned_up_on_session_error(
+        self,
+        mock_client_class: MagicMock,
+        mock_discover: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Temp HOME is removed even when the session raises."""
+        mock_discover.return_value = RepoConfig()
+        mock_client = AsyncMock()
+        mock_client_class.return_value = mock_client
+        mock_client.start.side_effect = RuntimeError("startup failed")
+
+        with pytest.raises(RuntimeError, match="startup failed"):
+            await run_copilot_session(
+                settings=make_settings(),
+                repo_path=str(tmp_path),
+                system_prompt="test",
+                user_prompt="test",
+            )
+
+        # All copilot-session- dirs should be cleaned up
+        import tempfile
+
+        remaining = list(Path(tempfile.gettempdir()).glob("copilot-session-*"))
+        assert len(remaining) == 0

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,0 +1,121 @@
+"""Tests for Copilot CLI plugin manager — installation and isolation."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gitlab_copilot_agent.plugin_manager import (
+    _sanitize_url,
+    add_marketplace,
+    install_plugin,
+    setup_plugins,
+)
+
+PLUGIN_A = "copilot-plugin-a"
+PLUGIN_B = "copilot-plugin-b"
+MARKETPLACE_URL = "https://marketplace.example.com"
+FAKE_HOME = "/home/copilot-session-test"
+FAKE_CLI = "/usr/local/bin/copilot"
+
+_MODULE = "gitlab_copilot_agent.plugin_manager"
+
+
+def _mock_process(returncode: int = 0, stderr: bytes = b"") -> AsyncMock:
+    proc = AsyncMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(b"", stderr))
+    proc.kill = MagicMock()
+    proc.wait = AsyncMock()
+    return proc
+
+
+class TestAddMarketplace:
+    @patch(f"{_MODULE}.get_real_cli_path", return_value=FAKE_CLI)
+    @patch("asyncio.create_subprocess_exec")
+    async def test_success(self, mock_exec: AsyncMock, _cli: MagicMock) -> None:
+        mock_exec.return_value = _mock_process()
+        await add_marketplace(FAKE_HOME, MARKETPLACE_URL)
+        mock_exec.assert_awaited_once()
+        args = mock_exec.call_args[0]
+        assert args == (FAKE_CLI, "plugin", "marketplace", "add", MARKETPLACE_URL)
+        env = mock_exec.call_args[1]["env"]
+        assert env["HOME"] == FAKE_HOME
+
+    @patch(f"{_MODULE}.get_real_cli_path", return_value=FAKE_CLI)
+    @patch("asyncio.create_subprocess_exec")
+    async def test_failure_raises(self, mock_exec: AsyncMock, _cli: MagicMock) -> None:
+        mock_exec.return_value = _mock_process(returncode=1, stderr=b"not found")
+        with pytest.raises(RuntimeError, match="Plugin command failed"):
+            await add_marketplace(FAKE_HOME, MARKETPLACE_URL)
+
+
+class TestInstallPlugin:
+    @patch(f"{_MODULE}.get_real_cli_path", return_value=FAKE_CLI)
+    @patch("asyncio.create_subprocess_exec")
+    async def test_success(self, mock_exec: AsyncMock, _cli: MagicMock) -> None:
+        mock_exec.return_value = _mock_process()
+        await install_plugin(FAKE_HOME, PLUGIN_A)
+        args = mock_exec.call_args[0]
+        assert args == (FAKE_CLI, "plugin", "install", PLUGIN_A)
+
+    @patch(f"{_MODULE}.get_real_cli_path", return_value=FAKE_CLI)
+    @patch("asyncio.create_subprocess_exec")
+    async def test_failure_raises(self, mock_exec: AsyncMock, _cli: MagicMock) -> None:
+        mock_exec.return_value = _mock_process(returncode=1, stderr=b"install failed")
+        with pytest.raises(RuntimeError, match="Plugin command failed"):
+            await install_plugin(FAKE_HOME, PLUGIN_A)
+
+    @patch(f"{_MODULE}.get_real_cli_path", return_value=FAKE_CLI)
+    @patch("asyncio.create_subprocess_exec")
+    async def test_timeout_kills_process(self, mock_exec: AsyncMock, _cli: MagicMock) -> None:
+        proc = _mock_process()
+        proc.communicate = AsyncMock(side_effect=TimeoutError)
+        mock_exec.return_value = proc
+        with pytest.raises(RuntimeError, match="timed out"):
+            await install_plugin(FAKE_HOME, PLUGIN_A)
+        proc.kill.assert_called_once()
+        proc.wait.assert_awaited_once()
+
+
+class TestSetupPlugins:
+    @patch(f"{_MODULE}.install_plugin", new_callable=AsyncMock)
+    @patch(f"{_MODULE}.add_marketplace", new_callable=AsyncMock)
+    async def test_no_plugins_no_calls(self, mock_mp: AsyncMock, mock_inst: AsyncMock) -> None:
+        await setup_plugins(FAKE_HOME, [], None)
+        mock_mp.assert_not_awaited()
+        mock_inst.assert_not_awaited()
+
+    @patch(f"{_MODULE}.install_plugin", new_callable=AsyncMock)
+    @patch(f"{_MODULE}.add_marketplace", new_callable=AsyncMock)
+    async def test_installs_plugins_and_marketplaces(
+        self, mock_mp: AsyncMock, mock_inst: AsyncMock
+    ) -> None:
+        await setup_plugins(FAKE_HOME, [PLUGIN_A, PLUGIN_B], [MARKETPLACE_URL])
+        mock_mp.assert_awaited_once_with(FAKE_HOME, MARKETPLACE_URL)
+        assert mock_inst.await_count == 2
+        mock_inst.assert_any_await(FAKE_HOME, PLUGIN_A)
+        mock_inst.assert_any_await(FAKE_HOME, PLUGIN_B)
+
+    @patch(f"{_MODULE}.install_plugin", new_callable=AsyncMock)
+    @patch(f"{_MODULE}.add_marketplace", new_callable=AsyncMock)
+    async def test_deduplicates_plugins(self, mock_mp: AsyncMock, mock_inst: AsyncMock) -> None:
+        await setup_plugins(FAKE_HOME, [PLUGIN_A, PLUGIN_A, PLUGIN_B], None)
+        assert mock_inst.await_count == 2
+
+    @patch(f"{_MODULE}.install_plugin", new_callable=AsyncMock)
+    @patch(f"{_MODULE}.add_marketplace", new_callable=AsyncMock)
+    async def test_plugins_only(self, mock_mp: AsyncMock, mock_inst: AsyncMock) -> None:
+        await setup_plugins(FAKE_HOME, [PLUGIN_A], None)
+        mock_mp.assert_not_awaited()
+        mock_inst.assert_awaited_once_with(FAKE_HOME, PLUGIN_A)
+
+
+class TestSanitizeUrl:
+    def test_strips_credentials(self) -> None:
+        assert _sanitize_url("https://user:pass@host.com/path") == "https://host.com/path"
+
+    def test_strips_query_params(self) -> None:
+        assert _sanitize_url("https://host.com/path?token=secret") == "https://host.com/path"
+
+    def test_plain_url_unchanged(self) -> None:
+        assert _sanitize_url(MARKETPLACE_URL) == MARKETPLACE_URL

--- a/tests/test_project_registry.py
+++ b/tests/test_project_registry.py
@@ -76,7 +76,8 @@ class TestLookup:
 
     def test_repr_hides_token(self) -> None:
         r = repr(_proj())
-        assert DEFAULT_TOKEN not in r and "***" in r
+        assert DEFAULT_TOKEN not in r
+        assert "token" not in r
 
 
 def _binding(repo: str = REPO_A, branch: str = "main", cred: str = "default") -> RenderedBinding:

--- a/tests/test_task_executor.py
+++ b/tests/test_task_executor.py
@@ -68,6 +68,7 @@ class TestLocalTaskExecutor:
             system_prompt=SYSTEM_PROMPT,
             user_prompt=USER_PROMPT,
             task_type="review",
+            plugins=None,
         )
 
     async def test_requires_repo_path(self) -> None:
@@ -75,3 +76,21 @@ class TestLocalTaskExecutor:
         task = _make_task(repo_path=None)
         with pytest.raises(ValueError, match="repo_path"):
             await executor.execute(task)
+
+
+class TestTaskParamsPlugins:
+    def test_plugins_default_empty(self) -> None:
+        task = _make_task()
+        assert task.plugins == []
+
+    def test_plugins_set(self) -> None:
+        task = _make_task(plugins=["plugin-a", "plugin-b"])
+        assert task.plugins == ["plugin-a", "plugin-b"]
+
+    @patch("gitlab_copilot_agent.copilot_session.run_copilot_session", new_callable=AsyncMock)
+    async def test_local_executor_passes_plugins(self, mock_session: AsyncMock) -> None:
+        mock_session.return_value = "ok"
+        executor = LocalTaskExecutor()
+        task = _make_task(plugins=["plugin-a"])
+        await executor.execute(task)
+        assert mock_session.call_args[1]["plugins"] == ["plugin-a"]

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -9,6 +9,7 @@ from gitlab_copilot_agent.task_runner import (
     ENV_TASK_ID,
     ENV_TASK_PAYLOAD,
     ENV_TASK_TYPE,
+    QueueTaskPayload,
     _build_coding_result,
     _coding_response_validator,
     _dequeue_task,
@@ -20,6 +21,7 @@ from gitlab_copilot_agent.task_runner import (
 
 TASK_ID = "task-001"
 PAYLOAD = json.dumps({"prompt": "Review this"})
+PLUGIN_SPEC = "copilot-plugin-a"
 _M = "gitlab_copilot_agent.task_runner"
 
 
@@ -52,23 +54,28 @@ class TestHelpers:
 
 
 REPO_BLOB_KEY = "repos/task-001.tar.gz"
-QUEUE_PARAMS = {
-    "task_type": "review",
-    "task_id": TASK_ID,
-    "repo_blob_key": REPO_BLOB_KEY,
-    "user_prompt": "Review this",
-}
+QUEUE_PAYLOAD = QueueTaskPayload(
+    task_type="review",
+    task_id=TASK_ID,
+    repo_blob_key=REPO_BLOB_KEY,
+    system_prompt="",
+    user_prompt="Review this",
+)
 
 
 def _make_queue_result(
-    params: dict[str, str] | None = None,
-) -> tuple[dict[str, str], MagicMock, MagicMock]:
-    """Build a (params, queue_msg, task_queue) tuple for _dequeue_task mocks."""
+    payload: QueueTaskPayload | None = None,
+) -> tuple[QueueTaskPayload, MagicMock, MagicMock]:
+    """Build a (payload, queue_msg, task_queue) tuple for _dequeue_task mocks."""
     from gitlab_copilot_agent.concurrency import QueueMessage
 
-    p = params or QUEUE_PARAMS
+    p = payload or QUEUE_PAYLOAD
     msg = QueueMessage(
-        message_id="m1", receipt="r1", task_id=p["task_id"], payload=json.dumps(p), dequeue_count=1
+        message_id="m1",
+        receipt="r1",
+        task_id=p.task_id,
+        payload=p.model_dump_json(),
+        dequeue_count=1,
     )
     queue = MagicMock()
     queue.complete = AsyncMock()
@@ -104,9 +111,9 @@ class TestRunTask:
 
     async def test_missing_blob_key_returns_error(self, task_env: None) -> None:
         """Review/coding tasks without repo_blob_key return error and close queue."""
-        params = {**QUEUE_PARAMS, "repo_blob_key": None}
-        _, msg, queue = _make_queue_result(params)
-        qr = (params, msg, queue)
+        payload = QUEUE_PAYLOAD.model_copy(update={"repo_blob_key": None})
+        _, msg, queue = _make_queue_result(payload)
+        qr = (payload, msg, queue)
         with patch(f"{_M}._dequeue_task", AsyncMock(return_value=qr)):
             assert await run_task() == 1
         queue.aclose.assert_awaited_once()
@@ -118,9 +125,9 @@ class TestRunTask:
 
     async def test_invalid_blob_key_prefix_returns_error(self, task_env: None) -> None:
         """Blob keys must start with 'repos/' prefix; queue is closed."""
-        params = {**QUEUE_PARAMS, "repo_blob_key": "evil/path.tar.gz"}
-        _, msg, queue = _make_queue_result(params)
-        qr = (params, msg, queue)
+        payload = QUEUE_PAYLOAD.model_copy(update={"repo_blob_key": "evil/path.tar.gz"})
+        _, msg, queue = _make_queue_result(payload)
+        qr = (payload, msg, queue)
         with patch(f"{_M}._dequeue_task", AsyncMock(return_value=qr)):
             assert await run_task() == 1
         queue.aclose.assert_awaited_once()
@@ -129,8 +136,8 @@ class TestRunTask:
         coding_json = json.dumps(
             {"result_type": "coding", "summary": "x", "patch": "p", "base_sha": "abc"}
         )
-        params = {**QUEUE_PARAMS, "task_type": "coding"}
-        qr = _make_queue_result(params)
+        payload = QUEUE_PAYLOAD.model_copy(update={"task_type": "coding"})
+        qr = _make_queue_result(payload)
         with (
             patch(f"{_M}._dequeue_task", AsyncMock(return_value=qr)),
             patch(f"{_M}.extract_repo_tarball", AsyncMock(return_value=Path("/tmp/r"))),
@@ -344,17 +351,18 @@ class TestDequeueTask:
     async def test_returns_params_and_queue_on_success(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Returns parsed params, message, and queue on successful dequeue."""
+        """Returns parsed payload, message, and queue on successful dequeue."""
         monkeypatch.setenv("GITHUB_TOKEN", "g")
         monkeypatch.setenv("AZURE_STORAGE_CONNECTION_STRING", "conn")
 
         from gitlab_copilot_agent.concurrency import QueueMessage
 
+        payload_data = {"task_type": "review", "task_id": "task-1", "user_prompt": "Review this"}
         fake_msg = QueueMessage(
             message_id="m1",
             receipt="r1",
             task_id="task-1",
-            payload=json.dumps({"task_type": "review", "task_id": "task-1"}),
+            payload=json.dumps(payload_data),
             dequeue_count=1,
         )
         mock_queue = MagicMock()
@@ -362,7 +370,38 @@ class TestDequeueTask:
         with patch(f"{_STATE_MOD}.create_task_queue", return_value=mock_queue):
             result = await _dequeue_task()
         assert result is not None
-        params, msg, queue = result
-        assert params == {"task_type": "review", "task_id": "task-1"}
+        payload, msg, queue = result
+        assert isinstance(payload, QueueTaskPayload)
+        assert payload.task_type == "review"
+        assert payload.task_id == "task-1"
         assert msg.message_id == "m1"
         assert queue is mock_queue
+
+
+class TestPluginThreading:
+    async def test_plugins_passed_from_queue_to_session(self, task_env: None) -> None:
+        """Plugins from queue payload are passed to run_copilot_session."""
+        payload = QUEUE_PAYLOAD.model_copy(update={"plugins": [PLUGIN_SPEC]})
+        qr = _make_queue_result(payload)
+        with (
+            patch(f"{_M}._dequeue_task", AsyncMock(return_value=qr)),
+            patch(f"{_M}.extract_repo_tarball", AsyncMock(return_value=Path("/tmp/r"))),
+            patch(f"{_M}.run_copilot_session", AsyncMock(return_value="done")) as ms,
+            patch(f"{_M}._store_result", AsyncMock()),
+            patch(f"{_M}.shutil.rmtree"),
+        ):
+            assert await run_task() == 0
+            assert ms.call_args[1]["plugins"] == [PLUGIN_SPEC]
+
+    async def test_no_plugins_in_payload(self, task_env: None) -> None:
+        """Missing plugins field in queue payload passes None to session."""
+        qr = _make_queue_result()
+        with (
+            patch(f"{_M}._dequeue_task", AsyncMock(return_value=qr)),
+            patch(f"{_M}.extract_repo_tarball", AsyncMock(return_value=Path("/tmp/r"))),
+            patch(f"{_M}.run_copilot_session", AsyncMock(return_value="done")) as ms,
+            patch(f"{_M}._store_result", AsyncMock()),
+            patch(f"{_M}.shutil.rmtree"),
+        ):
+            assert await run_task() == 0
+            assert ms.call_args[1]["plugins"] is None

--- a/uv.lock
+++ b/uv.lock
@@ -513,7 +513,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.135.1"
+version = "0.135.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -522,9 +522,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd", size = 394962, upload-time = "2026-03-01T18:18:29.369Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/73/5903c4b13beae98618d64eb9870c3fac4f605523dd0312ca5c80dadbd5b9/fastapi-0.135.2.tar.gz", hash = "sha256:88a832095359755527b7f63bb4c6bc9edb8329a026189eed83d6c1afcf419d56", size = 395833, upload-time = "2026-03-23T14:12:41.697Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/72/42e900510195b23a56bde950d26a51f8b723846bfcaa0286e90287f0422b/fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e", size = 116999, upload-time = "2026-03-01T18:18:30.831Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/ea/18f6d0457f9efb2fc6fa594857f92810cadb03024975726db6546b3d6fcf/fastapi-0.135.2-py3-none-any.whl", hash = "sha256:0af0447d541867e8db2a6a25c23a8c4bd80e2394ac5529bd87501bbb9e240ca5", size = 117407, upload-time = "2026-03-23T14:12:43.284Z" },
 ]
 
 [[package]]
@@ -693,7 +693,7 @@ requires-dist = [
     { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.17.0" },
     { name = "azure-storage-blob", marker = "extra == 'azure'", specifier = ">=12.24.0" },
     { name = "azure-storage-queue", marker = "extra == 'azure'", specifier = ">=12.12.0" },
-    { name = "fastapi", specifier = "==0.135.1" },
+    { name = "fastapi", specifier = "==0.135.2" },
     { name = "github-copilot-sdk", specifier = "==0.1.32" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "httpx", marker = "extra == 'dev'", specifier = "==0.28.1" },
@@ -713,9 +713,9 @@ requires-dist = [
     { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "python-gitlab", specifier = "==8.1.0" },
     { name = "pyyaml", specifier = "==6.0.3" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.6" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.8" },
     { name = "structlog", specifier = "==25.5.0" },
-    { name = "uvicorn", extras = ["standard"], specifier = "==0.41.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = "==0.42.0" },
 ]
 provides-extras = ["kubernetes", "azure", "dev"]
 
@@ -1736,27 +1736,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.6"
+version = "0.15.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/df/f8629c19c5318601d3121e230f74cbee7a3732339c52b21daa2b82ef9c7d/ruff-0.15.6.tar.gz", hash = "sha256:8394c7bb153a4e3811a4ecdacd4a8e6a4fa8097028119160dffecdcdf9b56ae4", size = 4597916, upload-time = "2026-03-12T23:05:47.51Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/b0/73cf7550861e2b4824950b8b52eebdcc5adc792a00c514406556c5b80817/ruff-0.15.8.tar.gz", hash = "sha256:995f11f63597ee362130d1d5a327a87cb6f3f5eae3094c620bcc632329a4d26e", size = 4610921, upload-time = "2026-03-26T18:39:38.675Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/2f/4e03a7e5ce99b517e98d3b4951f411de2b0fa8348d39cf446671adcce9a2/ruff-0.15.6-py3-none-linux_armv6l.whl", hash = "sha256:7c98c3b16407b2cf3d0f2b80c80187384bc92c6774d85fefa913ecd941256fff", size = 10508953, upload-time = "2026-03-12T23:05:17.246Z" },
-    { url = "https://files.pythonhosted.org/packages/70/60/55bcdc3e9f80bcf39edf0cd272da6fa511a3d94d5a0dd9e0adf76ceebdb4/ruff-0.15.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ee7dcfaad8b282a284df4aa6ddc2741b3f4a18b0555d626805555a820ea181c3", size = 10942257, upload-time = "2026-03-12T23:05:23.076Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/f9/005c29bd1726c0f492bfa215e95154cf480574140cb5f867c797c18c790b/ruff-0.15.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3bd9967851a25f038fc8b9ae88a7fbd1b609f30349231dffaa37b6804923c4bb", size = 10322683, upload-time = "2026-03-12T23:05:33.738Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/74/2f861f5fd7cbb2146bddb5501450300ce41562da36d21868c69b7a828169/ruff-0.15.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:13f4594b04e42cd24a41da653886b04d2ff87adbf57497ed4f728b0e8a4866f8", size = 10660986, upload-time = "2026-03-12T23:05:53.245Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/a1/309f2364a424eccb763cdafc49df843c282609f47fe53aa83f38272389e0/ruff-0.15.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e2ed8aea2f3fe57886d3f00ea5b8aae5bf68d5e195f487f037a955ff9fbaac9e", size = 10332177, upload-time = "2026-03-12T23:05:56.145Z" },
-    { url = "https://files.pythonhosted.org/packages/30/41/7ebf1d32658b4bab20f8ac80972fb19cd4e2c6b78552be263a680edc55ac/ruff-0.15.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70789d3e7830b848b548aae96766431c0dc01a6c78c13381f423bf7076c66d15", size = 11170783, upload-time = "2026-03-12T23:06:01.742Z" },
-    { url = "https://files.pythonhosted.org/packages/76/be/6d488f6adca047df82cd62c304638bcb00821c36bd4881cfca221561fdfc/ruff-0.15.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:542aaf1de3154cea088ced5a819ce872611256ffe2498e750bbae5247a8114e9", size = 12044201, upload-time = "2026-03-12T23:05:28.697Z" },
-    { url = "https://files.pythonhosted.org/packages/71/68/e6f125df4af7e6d0b498f8d373274794bc5156b324e8ab4bf5c1b4fc0ec7/ruff-0.15.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1c22e6f02c16cfac3888aa636e9eba857254d15bbacc9906c9689fdecb1953ab", size = 11421561, upload-time = "2026-03-12T23:05:31.236Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/9f/f85ef5fd01a52e0b472b26dc1b4bd228b8f6f0435975442ffa4741278703/ruff-0.15.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98893c4c0aadc8e448cfa315bd0cc343a5323d740fe5f28ef8a3f9e21b381f7e", size = 11310928, upload-time = "2026-03-12T23:05:45.288Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/26/b75f8c421f5654304b89471ed384ae8c7f42b4dff58fa6ce1626d7f2b59a/ruff-0.15.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:70d263770d234912374493e8cc1e7385c5d49376e41dfa51c5c3453169dc581c", size = 11235186, upload-time = "2026-03-12T23:05:50.677Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/d4/d5a6d065962ff7a68a86c9b4f5500f7d101a0792078de636526c0edd40da/ruff-0.15.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:55a1ad63c5a6e54b1f21b7514dfadc0c7fb40093fa22e95143cf3f64ebdcd512", size = 10635231, upload-time = "2026-03-12T23:05:37.044Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/56/7c3acf3d50910375349016cf33de24be021532042afbed87942858992491/ruff-0.15.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8dc473ba093c5ec238bb1e7429ee676dca24643c471e11fbaa8a857925b061c0", size = 10340357, upload-time = "2026-03-12T23:06:04.748Z" },
-    { url = "https://files.pythonhosted.org/packages/06/54/6faa39e9c1033ff6a3b6e76b5df536931cd30caf64988e112bbf91ef5ce5/ruff-0.15.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:85b042377c2a5561131767974617006f99f7e13c63c111b998f29fc1e58a4cfb", size = 10860583, upload-time = "2026-03-12T23:05:58.978Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/1e/509a201b843b4dfb0b32acdedf68d951d3377988cae43949ba4c4133a96a/ruff-0.15.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:cef49e30bc5a86a6a92098a7fbf6e467a234d90b63305d6f3ec01225a9d092e0", size = 11410976, upload-time = "2026-03-12T23:05:39.955Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/25/3fc9114abf979a41673ce877c08016f8e660ad6cf508c3957f537d2e9fa9/ruff-0.15.6-py3-none-win32.whl", hash = "sha256:bbf67d39832404812a2d23020dda68fee7f18ce15654e96fb1d3ad21a5fe436c", size = 10616872, upload-time = "2026-03-12T23:05:42.451Z" },
-    { url = "https://files.pythonhosted.org/packages/89/7a/09ece68445ceac348df06e08bf75db72d0e8427765b96c9c0ffabc1be1d9/ruff-0.15.6-py3-none-win_amd64.whl", hash = "sha256:aee25bc84c2f1007ecb5037dff75cef00414fdf17c23f07dc13e577883dca406", size = 11787271, upload-time = "2026-03-12T23:05:20.168Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/d0/578c47dd68152ddddddf31cd7fc67dc30b7cdf639a86275fda821b0d9d98/ruff-0.15.6-py3-none-win_arm64.whl", hash = "sha256:c34de3dd0b0ba203be50ae70f5910b17188556630e2178fd7d79fc030eb0d837", size = 11060497, upload-time = "2026-03-12T23:05:25.968Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/92/c445b0cd6da6e7ae51e954939cb69f97e008dbe750cfca89b8cedc081be7/ruff-0.15.8-py3-none-linux_armv6l.whl", hash = "sha256:cbe05adeba76d58162762d6b239c9056f1a15a55bd4b346cfd21e26cd6ad7bc7", size = 10527394, upload-time = "2026-03-26T18:39:41.566Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/92/f1c662784d149ad1414cae450b082cf736430c12ca78367f20f5ed569d65/ruff-0.15.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d3e3d0b6ba8dca1b7ef9ab80a28e840a20070c4b62e56d675c24f366ef330570", size = 10905693, upload-time = "2026-03-26T18:39:30.364Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f2/7a631a8af6d88bcef997eb1bf87cc3da158294c57044aafd3e17030613de/ruff-0.15.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6ee3ae5c65a42f273f126686353f2e08ff29927b7b7e203b711514370d500de3", size = 10323044, upload-time = "2026-03-26T18:39:33.37Z" },
+    { url = "https://files.pythonhosted.org/packages/67/18/1bf38e20914a05e72ef3b9569b1d5c70a7ef26cd188d69e9ca8ef588d5bf/ruff-0.15.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fdce027ada77baa448077ccc6ebb2fa9c3c62fd110d8659d601cf2f475858d94", size = 10629135, upload-time = "2026-03-26T18:39:44.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/e9/138c150ff9af60556121623d41aba18b7b57d95ac032e177b6a53789d279/ruff-0.15.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12e617fc01a95e5821648a6df341d80456bd627bfab8a829f7cfc26a14a4b4a3", size = 10348041, upload-time = "2026-03-26T18:39:52.178Z" },
+    { url = "https://files.pythonhosted.org/packages/02/f1/5bfb9298d9c323f842c5ddeb85f1f10ef51516ac7a34ba446c9347d898df/ruff-0.15.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:432701303b26416d22ba696c39f2c6f12499b89093b61360abc34bcc9bf07762", size = 11121987, upload-time = "2026-03-26T18:39:55.195Z" },
+    { url = "https://files.pythonhosted.org/packages/10/11/6da2e538704e753c04e8d86b1fc55712fdbdcc266af1a1ece7a51fff0d10/ruff-0.15.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d910ae974b7a06a33a057cb87d2a10792a3b2b3b35e33d2699fdf63ec8f6b17a", size = 11951057, upload-time = "2026-03-26T18:39:19.18Z" },
+    { url = "https://files.pythonhosted.org/packages/83/f0/c9208c5fd5101bf87002fed774ff25a96eea313d305f1e5d5744698dc314/ruff-0.15.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2033f963c43949d51e6fdccd3946633c6b37c484f5f98c3035f49c27395a8ab8", size = 11464613, upload-time = "2026-03-26T18:40:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/22/d7f2fabdba4fae9f3b570e5605d5eb4500dcb7b770d3217dca4428484b17/ruff-0.15.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f29b989a55572fb885b77464cf24af05500806ab4edf9a0fd8977f9759d85b1", size = 11257557, upload-time = "2026-03-26T18:39:57.972Z" },
+    { url = "https://files.pythonhosted.org/packages/71/8c/382a9620038cf6906446b23ce8632ab8c0811b8f9d3e764f58bedd0c9a6f/ruff-0.15.8-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:ac51d486bf457cdc985a412fb1801b2dfd1bd8838372fc55de64b1510eff4bec", size = 11169440, upload-time = "2026-03-26T18:39:22.205Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/0d/0994c802a7eaaf99380085e4e40c845f8e32a562e20a38ec06174b52ef24/ruff-0.15.8-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c9861eb959edab053c10ad62c278835ee69ca527b6dcd72b47d5c1e5648964f6", size = 10605963, upload-time = "2026-03-26T18:39:46.682Z" },
+    { url = "https://files.pythonhosted.org/packages/19/aa/d624b86f5b0aad7cef6bbf9cd47a6a02dfdc4f72c92a337d724e39c9d14b/ruff-0.15.8-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8d9a5b8ea13f26ae90838afc33f91b547e61b794865374f114f349e9036835fb", size = 10357484, upload-time = "2026-03-26T18:39:49.176Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c3/e0b7835d23001f7d999f3895c6b569927c4d39912286897f625736e1fd04/ruff-0.15.8-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c2a33a529fb3cbc23a7124b5c6ff121e4d6228029cba374777bd7649cc8598b8", size = 10830426, upload-time = "2026-03-26T18:40:03.702Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/51/ab20b322f637b369383adc341d761eaaa0f0203d6b9a7421cd6e783d81b9/ruff-0.15.8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:75e5cd06b1cf3f47a3996cfc999226b19aa92e7cce682dcd62f80d7035f98f49", size = 11345125, upload-time = "2026-03-26T18:39:27.799Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e6/90b2b33419f59d0f2c4c8a48a4b74b460709a557e8e0064cf33ad894f983/ruff-0.15.8-py3-none-win32.whl", hash = "sha256:bc1f0a51254ba21767bfa9a8b5013ca8149dcf38092e6a9eb704d876de94dc34", size = 10571959, upload-time = "2026-03-26T18:39:36.117Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/a2/ef467cb77099062317154c63f234b8a7baf7cb690b99af760c5b68b9ee7f/ruff-0.15.8-py3-none-win_amd64.whl", hash = "sha256:04f79eff02a72db209d47d665ba7ebcad609d8918a134f86cb13dd132159fc89", size = 11743893, upload-time = "2026-03-26T18:39:25.01Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e2/77be4fff062fa78d9b2a4dea85d14785dac5f1d0c1fb58ed52331f0ebe28/ruff-0.15.8-py3-none-win_arm64.whl", hash = "sha256:cf891fa8e3bb430c0e7fac93851a5978fc99c8fa2c053b57b118972866f8e5f2", size = 11048175, upload-time = "2026-03-26T18:40:01.06Z" },
 ]
 
 [[package]]
@@ -1822,15 +1822,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.41.0"
+version = "0.42.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/ad/4a96c425be6fb67e0621e62d86c402b4a17ab2be7f7c055d9bd2f638b9e2/uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775", size = 85393, upload-time = "2026-03-16T06:19:50.077Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/89/f8827ccff89c1586027a105e5630ff6139a64da2515e24dafe860bd9ae4d/uvicorn-0.42.0-py3-none-any.whl", hash = "sha256:96c30f5c7abe6f74ae8900a70e92b85ad6613b745d4879eb9b16ccad15645359", size = 68830, upload-time = "2026-03-16T06:19:48.325Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What

Add isolated runtime Copilot CLI plugin support. Plugins are configurable at service-level (env vars) and per-repo (mapping schema), with per-session HOME isolation to prevent plugin state leakage between repos.

Closes #313

## How

**Config** — `copilot_plugins` and `copilot_plugin_marketplaces` on Settings and TaskRunnerSettings, accepting comma-separated or JSON array env vars via `_parse_comma_list` validator.

**Mapping** — `plugins: list[str]` on Defaults, Binding, RenderedBinding, and ResolvedProject. Binding overrides defaults when explicitly set.

**Plugin manager** — New `plugin_manager.py` with `_run_cli()` helper (subprocess exec with timeout + kill-on-timeout), `add_marketplace()`, `install_plugin()`, `setup_plugins()`. Minimal env (HOME + PATH only) prevents secret leakage. URL sanitization strips credentials before logging.

**Session isolation** — Each `run_copilot_session()` creates a `tempfile.mkdtemp()` HOME, installs plugins there, overrides `sdk_env["HOME"]`, and cleans up in `finally`. Plugin errors are reported through the task result flow.

**Dispatch** — `plugins` threaded through TaskParams → queue payload → task_runner → session.

**Helm** — `copilotPlugins` and `copilotPluginMarketplaces` in values.yaml, conditional entries in configmap.yaml, scaledjob uses entrypoint.

## Testing

- 520 tests pass, 91.73% coverage
- `test_plugin_manager.py` — 12 tests: subprocess mocking, timeout kill, dedupe, URL sanitization
- `test_plugin_isolation.py` — 9 integration tests: merge/dedupe, two-session isolation, cross-session verification, cleanup on error
- Plugin config, mapping, session, executor, and task_runner test updates

## OWASP Self-Review

- [x] Broken Access Control — N/A (no auth changes)
- [x] Cryptographic Failures — N/A (no crypto changes)
- [x] Injection — subprocess uses exec (not shell), args passed as separate parameters
- [x] Insecure Design — per-session HOME isolation prevents cross-repo state leakage
- [x] Security Misconfiguration — plugin install env scrubbed to HOME+PATH only (no pod secrets)
- [x] Vulnerable and Outdated Components — no new dependencies
- [x] Identification and Authentication Failures — N/A
- [x] Software and Data Integrity Failures — N/A
- [x] Security Logging and Monitoring — URLs sanitized before logging (credentials/query params stripped)
- [x] SSRF — marketplace URLs are operator-configured (not user-supplied); LOW risk documented
- [x] Container Security — subprocess env isolation, read-only filesystem compatible

### Findings addressed
- **HIGH (fixed)**: Subprocess timeout now kills orphaned process and reaps it (`_run_cli`)
- **MEDIUM (fixed)**: Plugin install moved entirely to Python session path — entrypoint no longer does redundant install that bypassed error reporting
- **MEDIUM (fixed)**: Marketplace URLs sanitized before logging via `_sanitize_url()`
- **LOW (documented)**: Marketplace URLs are SSRF vectors but operator-only configured, not user-supplied

## Code Review

Cross-vendor review by GPT-5.4 (code authored by Claude Opus 4.6). All HIGH/CRITICAL findings addressed.