### PR TITLE
fix(terraform): order AMPLS private endpoint dependencies

### DIFF
--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -128,4 +128,13 @@ resource "azurerm_private_endpoint" "ampls" {
   }
 
   tags = var.tags
+
+  depends_on = [
+    azurerm_monitor_private_link_scoped_service.law,
+    azurerm_monitor_private_link_scoped_service.ai,
+    azurerm_private_dns_zone_virtual_network_link.monitor,
+    azurerm_private_dns_zone_virtual_network_link.oms,
+    azurerm_private_dns_zone_virtual_network_link.ods,
+    azurerm_private_dns_zone_virtual_network_link.agentsvc,
+  ]
 }


### PR DESCRIPTION
## What
Add explicit dependencies for the AMPLS private endpoint so Terraform waits for the Azure Monitor scoped services and DNS VNet links before creating the endpoint.

## Why
Staging deployment failed during Terraform apply while creating the Azure Monitor Private Link Scope private endpoint. This change makes the AMPLS endpoint creation order deterministic for the staging rollout.

Closes #315

## How to Test
terraform -chdir=infra init -backend=false
terraform -chdir=infra validate
Rerun the CD Staging workflow or run a manual staging deploy
