### PR TITLE
feat(review): rich discussion context extraction (#321)

### DIFF
--- a/docs/wiki/configuration-reference.md
+++ b/docs/wiki/configuration-reference.md
@@ -93,7 +93,8 @@ At least one of these must be set:
 - **Type**: `str | None`
 - **Required**: ❌ No
 - **Default**: `None`
-- **Description**: Agent's GitLab username for loop prevention (skips self-authored `/copilot` notes)
+- **Deprecated**: ⚠️ Agent identity is now auto-discovered via `GET /user` using the existing `GITLAB_TOKEN`. The `CredentialRegistry` lazily resolves and caches the agent's `AgentIdentity` (immutable `user_id` + `username`) per credential on first use. No new env vars are needed.
+- **Description**: Previously used for loop prevention (skips self-authored `/copilot` notes). Retained for backward compatibility but no longer required.
 - **Example**: `"copilot-agent"`
 
 ### `CLONE_DIR`

--- a/docs/wiki/data-models.md
+++ b/docs/wiki/data-models.md
@@ -191,6 +191,65 @@ All models use `extra="ignore"` to allow additional API fields.
 
 ---
 
+## Discussion Models (`discussion_models.py`)
+
+Models for MR discussion history, shared by review and discussion flows. All models use `frozen=True` (immutable).
+
+### `DiscussionNote`
+**Purpose**: A single note within a discussion thread.
+
+**Config**: `frozen=True` (immutable)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `note_id` | `int` | — | GitLab note ID |
+| `author_id` | `int` | — | Author's GitLab user ID |
+| `author_username` | `str` | — | Author's GitLab username (for display) |
+| `body` | `str` | — | Note body text |
+| `created_at` | `str` | — | ISO 8601 timestamp |
+| `is_system` | `bool` | — | True for system-generated notes |
+| `resolved` | `bool \| None` | `None` | Resolution status (None if not resolvable) |
+| `resolvable` | `bool` | `False` | Whether the note can be resolved |
+| `position` | `dict[str, object] \| None` | `None` | Diff position: new_path, old_path, new_line, old_line |
+
+---
+
+### `Discussion`
+**Purpose**: A threaded discussion on a merge request.
+
+**Config**: `frozen=True` (immutable)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `discussion_id` | `str` | — | GitLab discussion ID |
+| `notes` | `list[DiscussionNote]` | — | Notes in thread order |
+| `is_resolved` | `bool` | `False` | Whether the discussion is resolved |
+| `is_inline` | `bool` | `False` | True for DiffNote (inline), False for overview |
+
+---
+
+### `AgentIdentity`
+**Purpose**: The agent's GitLab identity, discovered via `GET /user`.
+
+**Config**: `frozen=True` (immutable)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `user_id` | `int` | Immutable GitLab user ID |
+| `username` | `str` | GitLab username (mutable, for display/@mention) |
+
+---
+
+### `DiscussionHistory`
+**Purpose**: Full discussion context for an MR, including agent identity.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `discussions` | `list[Discussion]` | `[]` | All discussions on the MR |
+| `agent` | `AgentIdentity` | — | Agent identity for self-detection |
+
+---
+
 ## Jira Models (`jira_models.py`)
 
 All models use `extra="ignore"` to allow additional API fields.
@@ -521,6 +580,13 @@ graph TB
         RCFG --> AC[AgentConfig]
     end
     
+    subgraph "Discussion Context"
+        DH[DiscussionHistory]
+        DH --> DISC[Discussion]
+        DISC --> DN[DiscussionNote]
+        DH --> AI[AgentIdentity]
+    end
+    
     subgraph "Project Mapping"
         MS[MappingSource] -->|render| RM[RenderedMap]
         RM --> RB[RenderedBinding]
@@ -534,6 +600,8 @@ graph TB
     TP -.->|copilot_session.py| RCFG
     TP -.->|executor| PR
     PR -.->|comment_poster.py| MRD
+    CR -.->|resolve_identity| AI
+    DH -.->|orchestrator.py| TP
 ```
 
 ---
@@ -549,6 +617,7 @@ graph TB
 | Review (`comment_parser.py`) | ❌ No | ❌ Forbidden | ✅ Yes |
 | Task Exec (`task_executor.py`) | ❌ No | ❌ Forbidden | ✅ Yes |
 | Repo Config (`repo_config.py`) | ❌ No | ❌ Forbidden | ✅ Yes |
+| Discussion (`discussion_models.py`) | ❌ No | ❌ Forbidden | ✅ Yes |
 | Project Mapping (`project_mapping.py`) | ✅ Yes | ❌ Forbidden | ❌ No |
 
 **Strict Mode**: Rejects unknown fields and enforces exact type matching.  

--- a/docs/wiki/module-reference.md
+++ b/docs/wiki/module-reference.md
@@ -520,6 +520,25 @@ All use `extra="ignore"` config.
 
 ---
 
+### `discussion_models.py`
+**Purpose**: Pydantic models for MR discussion history, shared by review and discussion flows.
+
+**Key Models**:
+- `DiscussionNote`: note_id, author_id, author_username, body, created_at, is_system, resolved, resolvable, position
+- `Discussion`: discussion_id, notes, is_resolved, is_inline
+- `AgentIdentity`: user_id, username (discovered via `GET /user`)
+- `DiscussionHistory`: discussions, agent
+
+All use `frozen=True` config.
+
+**Dependencies**: `pydantic`
+
+**Internal Imports**: None
+
+**Depended On By**: `orchestrator.py`, `credential_registry.py`
+
+---
+
 ### `project_mapping.py` *(legacy)*
 **Purpose**: Original Jira→GitLab mapping. Superseded by `mapping_models.py` + `project_registry.py` for the Jira polling path.
 
@@ -713,6 +732,7 @@ All use `extra="ignore"` config.
 | `repo_config.py` | Utils | 184 | Repo config discovery |
 | `models.py` | Data | 79 | Webhook models |
 | `jira_models.py` | Data | 87 | Jira API models |
+| `discussion_models.py` | Data | 71 | MR discussion history models |
 | `project_mapping.py` | Data | 34 | Jira→GitLab mapping |
 | `config.py` | Data | 137 | Settings |
 | `concurrency.py` | State | 208 | In-memory locks/dedup |

--- a/docs/wiki/request-flows.md
+++ b/docs/wiki/request-flows.md
@@ -14,6 +14,7 @@ sequenceDiagram
     participant WH as webhook.py
     participant ORCH as orchestrator.py
     participant GLCL as gitlab_client.py
+    participant CREG as credential_registry.py
     participant EXEC as TaskExecutor
     participant COP as copilot_session.py
     participant SDK as Copilot SDK
@@ -41,6 +42,15 @@ sequenceDiagram
     ORCH->>GLCL: clone_repo(git_http_url, source_branch, token)
     GLCL->>GLCL: git_operations.git_clone()
     GLCL-->>ORCH: repo_path: Path
+    
+    ORCH->>GLCL: list_mr_discussions(project_id, mr_iid)
+    GLCL-->>ORCH: list[Discussion]
+    
+    ORCH->>CREG: resolve_identity(credential_ref, gitlab_url)
+    Note over CREG: GET /user (cached per credential)
+    CREG-->>ORCH: AgentIdentity (user_id, username)
+    
+    ORCH->>ORCH: Build DiscussionHistory(discussions, agent)
     
     ORCH->>EXEC: execute(TaskParams: review)
     alt LocalTaskExecutor

--- a/docs/wiki/security-model.md
+++ b/docs/wiki/security-model.md
@@ -109,6 +109,9 @@ graph TB
 - Store in Kubernetes Secret
 - Audit GitLab API logs for suspicious activity
 
+**Per-Credential Identity Caching**:
+Each GitLab token maps to a different user. The `CredentialRegistry` lazily discovers and caches the agent's identity by calling `GET /user` on first use per credential. The returned `AgentIdentity` (immutable `user_id` + display `username`) is stored in-memory for the lifetime of the process. Identity is used for self-comment detection during review — matching on the immutable `user_id` rather than the mutable `username` prevents bypass via username changes.
+
 ---
 
 ### 3. GitHub Token (Service → Copilot API)

--- a/src/gitlab_copilot_agent/config.py
+++ b/src/gitlab_copilot_agent/config.py
@@ -1,5 +1,6 @@
 """Application configuration via environment variables."""
 
+import warnings
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -228,6 +229,18 @@ class Settings(BaseSettings):
                 project_map_json=self.jira_project_map,
             )
         return None
+
+    @model_validator(mode="after")
+    def _warn_deprecated_fields(self) -> "Settings":
+        if self.agent_gitlab_username is not None:
+            warnings.warn(
+                "agent_gitlab_username is deprecated. "
+                "Agent identity is now auto-discovered via GET /user. "
+                "Remove AGENT_GITLAB_USERNAME from your configuration.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return self
 
     @model_validator(mode="after")
     def _check_auth(self) -> "Settings":

--- a/src/gitlab_copilot_agent/credential_registry.py
+++ b/src/gitlab_copilot_agent/credential_registry.py
@@ -4,15 +4,22 @@ Reads ``GITLAB_TOKEN`` (the default) and ``GITLAB_TOKEN__<ALIAS>`` env vars
 at construction time.  A binding's ``credential_ref`` is resolved to the
 matching token via :meth:`resolve`.
 
+Also provides lazy identity caching: each credential can be resolved to the
+GitLab user it authenticates as via :meth:`resolve_identity`.
+
 No raw secrets are ever logged.
 """
 
 from __future__ import annotations
 
+import asyncio
 import os
 import re
 
+import gitlab
 import structlog
+
+from gitlab_copilot_agent.discussion_models import AgentIdentity
 
 log = structlog.get_logger()
 
@@ -26,6 +33,7 @@ class CredentialRegistry:
         self._tokens: dict[str, str] = {"default": default_token}
         for alias, token in (named_tokens or {}).items():
             self._tokens[alias.lower()] = token
+        self._identities: dict[str, AgentIdentity] = {}
 
     @classmethod
     def from_env(cls) -> CredentialRegistry:
@@ -64,6 +72,46 @@ class CredentialRegistry:
             )
             raise KeyError(msg) from None
 
+    async def resolve_identity(self, credential_ref: str, gitlab_url: str) -> AgentIdentity:
+        """Return the :class:`AgentIdentity` for *credential_ref*, with caching.
+
+        On the first call for a given *credential_ref* this authenticates
+        against the GitLab API; subsequent calls return the cached result.
+        """
+        ref = credential_ref.lower()
+        cached = self._identities.get(ref)
+        if cached is not None:
+            return cached
+
+        token = self.resolve(credential_ref)
+        identity = await _fetch_identity(gitlab_url, token)
+        self._identities[ref] = identity
+        log.info(
+            "agent_identity_resolved",
+            credential_ref=ref,
+            user_id=identity.user_id,
+            username=identity.username,
+        )
+        return identity
+
     def aliases(self) -> set[str]:
         """Return all registered credential aliases."""
         return set(self._tokens)
+
+
+async def _fetch_identity(gitlab_url: str, token: str) -> AgentIdentity:
+    """Authenticate against GitLab and return the caller's identity.
+
+    Uses :func:`asyncio.to_thread` because python-gitlab is synchronous.
+    """
+
+    def _sync_auth() -> AgentIdentity:
+        gl = gitlab.Gitlab(gitlab_url, private_token=token)
+        gl.auth()
+        user = gl.user
+        if user is None:  # pragma: no cover – defensive
+            msg = "gl.auth() succeeded but gl.user is None"
+            raise RuntimeError(msg)
+        return AgentIdentity(user_id=user.id, username=user.username)
+
+    return await asyncio.to_thread(_sync_auth)

--- a/src/gitlab_copilot_agent/credential_registry.py
+++ b/src/gitlab_copilot_agent/credential_registry.py
@@ -34,6 +34,7 @@ class CredentialRegistry:
         for alias, token in (named_tokens or {}).items():
             self._tokens[alias.lower()] = token
         self._identities: dict[str, AgentIdentity] = {}
+        self._identity_lock = asyncio.Lock()
 
     @classmethod
     def from_env(cls) -> CredentialRegistry:
@@ -77,22 +78,31 @@ class CredentialRegistry:
 
         On the first call for a given *credential_ref* this authenticates
         against the GitLab API; subsequent calls return the cached result.
+
+        Uses an asyncio lock to prevent thundering-herd duplicate API calls
+        when multiple coroutines resolve the same credential concurrently.
         """
         ref = credential_ref.lower()
         cached = self._identities.get(ref)
         if cached is not None:
             return cached
 
-        token = self.resolve(credential_ref)
-        identity = await _fetch_identity(gitlab_url, token)
-        self._identities[ref] = identity
-        log.info(
-            "agent_identity_resolved",
-            credential_ref=ref,
-            user_id=identity.user_id,
-            username=identity.username,
-        )
-        return identity
+        async with self._identity_lock:
+            # Double-check after acquiring the lock
+            cached = self._identities.get(ref)
+            if cached is not None:
+                return cached
+
+            token = self.resolve(credential_ref)
+            identity = await _fetch_identity(gitlab_url, token)
+            self._identities[ref] = identity
+            log.info(
+                "agent_identity_resolved",
+                credential_ref=ref,
+                user_id=identity.user_id,
+                username=identity.username,
+            )
+            return identity
 
     def aliases(self) -> set[str]:
         """Return all registered credential aliases."""

--- a/src/gitlab_copilot_agent/discussion_models.py
+++ b/src/gitlab_copilot_agent/discussion_models.py
@@ -1,0 +1,70 @@
+"""Pydantic models for MR discussion history.
+
+Used by both the review pipeline (dedup, resolution, incremental review)
+and the discussion handler (Q&A, coding via @mention).  Models map
+closely to the GitLab Discussions API response structure.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class DiscussionNote(BaseModel):
+    """A single note within a discussion thread."""
+
+    model_config = ConfigDict(frozen=True)
+
+    note_id: int = Field(description="GitLab note ID")
+    author_id: int = Field(description="Author's GitLab user ID")
+    author_username: str = Field(description="Author's GitLab username (for display)")
+    body: str = Field(description="Note body text")
+    created_at: str = Field(description="ISO 8601 timestamp")
+    is_system: bool = Field(description="True for system-generated notes")
+    resolved: bool | None = Field(
+        default=None, description="Resolution status (None if not resolvable)"
+    )
+    resolvable: bool = Field(default=False, description="Whether the note can be resolved")
+    position: dict[str, object] | None = Field(
+        default=None,
+        description="Diff position: new_path, old_path, new_line, old_line",
+    )
+
+
+class Discussion(BaseModel):
+    """A threaded discussion on a merge request."""
+
+    model_config = ConfigDict(frozen=True)
+
+    discussion_id: str = Field(description="GitLab discussion ID")
+    notes: list[DiscussionNote] = Field(description="Notes in thread order")
+    is_resolved: bool = Field(default=False, description="Whether the discussion is resolved")
+    is_inline: bool = Field(
+        default=False, description="True for DiffNote (inline), False for overview"
+    )
+
+
+class AgentIdentity(BaseModel):
+    """The agent's GitLab identity, discovered via GET /user."""
+
+    model_config = ConfigDict(frozen=True)
+
+    user_id: int = Field(description="Immutable GitLab user ID")
+    username: str = Field(description="GitLab username (mutable, for display/@mention)")
+
+
+class DiscussionHistory(BaseModel):
+    """Full discussion context for an MR, including agent identity."""
+
+    discussions: list[Discussion] = Field(
+        default_factory=lambda: [], description="All discussions"
+    )
+    agent: AgentIdentity = Field(description="Agent identity for self-detection")
+
+
+# Resolve forward references for Pydantic v2 + `from __future__ import annotations`.
+# Without this, pytest-cov instrumentation can break class identity checks.
+DiscussionNote.model_rebuild()
+Discussion.model_rebuild()
+AgentIdentity.model_rebuild()
+DiscussionHistory.model_rebuild()

--- a/src/gitlab_copilot_agent/gitlab_client.py
+++ b/src/gitlab_copilot_agent/gitlab_client.py
@@ -10,6 +10,8 @@ import gitlab
 import structlog
 from pydantic import BaseModel, ConfigDict, Field
 
+from gitlab_copilot_agent.discussion_models import AgentIdentity, Discussion, DiscussionNote
+
 log = structlog.get_logger()
 
 
@@ -96,6 +98,8 @@ class GitLabClientProtocol(Protocol):
         self, project_id: int, mr_iid: int, created_after: str | None = None
     ) -> list[NoteListItem]: ...
     async def resolve_project(self, id_or_path: str | int) -> int: ...
+    async def list_mr_discussions(self, project_id: int, mr_iid: int) -> list[Discussion]: ...
+    async def get_current_user(self) -> AgentIdentity: ...
 
 
 class GitLabClient:
@@ -216,3 +220,87 @@ class GitLabClient:
             return project.id  # pyright: ignore[reportReturnType]
 
         return await asyncio.to_thread(_resolve)
+
+    async def list_mr_discussions(self, project_id: int, mr_iid: int) -> list[Discussion]:
+        """Fetch all discussions on an MR with thread structure."""
+
+        def _fetch() -> list[Discussion]:
+            project = self._gl.projects.get(project_id)
+            mr = project.mergerequests.get(mr_iid)
+            raw_discussions = mr.discussions.list(get_all=True)
+
+            discussions: list[Discussion] = []
+            for raw_disc in raw_discussions:
+                attrs = raw_disc.attributes
+                notes: list[DiscussionNote] = []
+                is_inline = False
+
+                for raw_note in attrs.get("notes", []):
+                    if raw_note.get("system", False):
+                        continue  # Skip system notes
+
+                    note_type = raw_note.get("type")
+                    if note_type == "DiffNote":
+                        is_inline = True
+
+                    position: dict[str, object] | None = None
+                    raw_pos = raw_note.get("position")
+                    if raw_pos and isinstance(raw_pos, dict):
+                        position = {
+                            "new_path": raw_pos.get("new_path"),  # pyright: ignore[reportUnknownMemberType]
+                            "old_path": raw_pos.get("old_path"),  # pyright: ignore[reportUnknownMemberType]
+                            "new_line": raw_pos.get("new_line"),  # pyright: ignore[reportUnknownMemberType]
+                            "old_line": raw_pos.get("old_line"),  # pyright: ignore[reportUnknownMemberType]
+                        }
+
+                    author = raw_note.get("author", {})
+                    notes.append(
+                        DiscussionNote(
+                            note_id=raw_note["id"],
+                            author_id=author.get("id", 0),
+                            author_username=author.get("username", ""),
+                            body=raw_note.get("body", ""),
+                            created_at=raw_note.get("created_at", ""),
+                            is_system=False,  # already filtered above
+                            resolved=raw_note.get("resolved"),
+                            resolvable=raw_note.get("resolvable", False),
+                            position=position,
+                        )
+                    )
+
+                if not notes:
+                    continue  # All notes were system notes
+
+                # Check resolution at discussion level
+                raw_notes = attrs.get("notes", [])
+                first_note: dict[str, object] = (
+                    raw_notes[0] if raw_notes else {}  # pyright: ignore[reportUnknownMemberType]
+                )
+                is_resolved = bool(first_note.get("resolved", False))
+
+                discussions.append(
+                    Discussion(
+                        discussion_id=attrs["id"],
+                        notes=notes,
+                        is_resolved=is_resolved,
+                        is_inline=is_inline,
+                    )
+                )
+
+            return discussions
+
+        return await asyncio.to_thread(_fetch)
+
+    async def get_current_user(self) -> AgentIdentity:
+        """Discover the identity of the authenticated user."""
+
+        def _fetch() -> AgentIdentity:
+            self._gl.auth()
+            user = self._gl.user
+            assert user is not None, "GitLab auth() did not populate user"
+            return AgentIdentity(
+                user_id=user.id,  # pyright: ignore[reportArgumentType]
+                username=user.username,  # pyright: ignore[reportArgumentType]
+            )
+
+        return await asyncio.to_thread(_fetch)

--- a/src/gitlab_copilot_agent/main.py
+++ b/src/gitlab_copilot_agent/main.py
@@ -157,6 +157,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     app.state.dedup_store = dedup_store
     app.state.review_tracker = ReviewedMRTracker()
 
+    # Credential registry — always available for identity resolution
+    creds = CredentialRegistry.from_env()
+    app.state.credential_registry = creds
+
     poller: JiraPoller | None = None
     gl_poller: GitLabPoller | None = None
     jira_client: JiraClient | None = None
@@ -180,7 +184,6 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 and settings.jira.in_review_status != "In Review"
             ):
                 binding.in_review_status = settings.jira.in_review_status
-        creds = CredentialRegistry.from_env()
         try:
             project_registry = await ProjectRegistry.from_rendered_map(
                 rendered, creds, settings.gitlab_url

--- a/src/gitlab_copilot_agent/orchestrator.py
+++ b/src/gitlab_copilot_agent/orchestrator.py
@@ -1,4 +1,7 @@
-"""Orchestrator — wires webhook → clone → review → post."""
+"""Orchestrator — wires webhook → clone → review → post.
+
+Fetches MR discussion history and agent identity for context-aware reviews.
+"""
 
 from __future__ import annotations
 
@@ -11,6 +14,7 @@ import structlog
 
 from gitlab_copilot_agent.comment_parser import parse_review
 from gitlab_copilot_agent.comment_poster import post_review
+from gitlab_copilot_agent.discussion_models import DiscussionHistory
 from gitlab_copilot_agent.gitlab_client import GitLabClient
 from gitlab_copilot_agent.metrics import reviews_duration, reviews_total
 from gitlab_copilot_agent.review_engine import ReviewRequest, run_review
@@ -19,6 +23,7 @@ from gitlab_copilot_agent.telemetry import get_tracer
 
 if TYPE_CHECKING:
     from gitlab_copilot_agent.config import Settings
+    from gitlab_copilot_agent.credential_registry import CredentialRegistry
     from gitlab_copilot_agent.models import MergeRequestWebhookPayload
     from gitlab_copilot_agent.task_executor import TaskExecutor
 
@@ -31,6 +36,7 @@ async def handle_review(
     payload: MergeRequestWebhookPayload,
     executor: TaskExecutor,
     project_token: str | None = None,
+    credential_registry: CredentialRegistry | None = None,
 ) -> None:
     """Full review pipeline: clone → review → parse → post comments."""
     mr = payload.object_attributes
@@ -58,6 +64,29 @@ async def handle_review(
 
             mr_details = await gl_client.get_mr_details(project.id, mr.iid)
 
+            # Fetch discussion history for context
+            discussions = await gl_client.list_mr_discussions(project.id, mr.iid)
+
+            # Resolve agent identity (cached per credential)
+            discussion_history: DiscussionHistory | None = None
+            if credential_registry is not None:
+                try:
+                    agent_identity = await credential_registry.resolve_identity(
+                        "default", settings.gitlab_url
+                    )
+                    discussion_history = DiscussionHistory(
+                        discussions=discussions, agent=agent_identity
+                    )
+                    bound_log.info(
+                        "discussion_history_loaded",
+                        discussion_count=len(discussions),
+                        agent_user_id=agent_identity.user_id,
+                    )
+                except Exception:
+                    bound_log.warning("discussion_history_failed", exc_info=True)
+            else:
+                bound_log.debug("discussion_history_skipped", reason="no_credential_registry")
+
             # Build diff text from MR changes so the LLM reviews only the diff
             diff_text = "\n".join(
                 f"--- a/{c.old_path}\n+++ b/{c.new_path}\n{c.diff}" for c in mr_details.changes
@@ -77,6 +106,7 @@ async def handle_review(
                 project.git_http_url,
                 review_req,
                 diff_text=diff_text,
+                discussion_history=discussion_history,
             )
             parsed = parse_review(raw_result.summary)
 

--- a/src/gitlab_copilot_agent/orchestrator.py
+++ b/src/gitlab_copilot_agent/orchestrator.py
@@ -64,13 +64,12 @@ async def handle_review(
 
             mr_details = await gl_client.get_mr_details(project.id, mr.iid)
 
-            # Fetch discussion history for context
-            discussions = await gl_client.list_mr_discussions(project.id, mr.iid)
-
-            # Resolve agent identity (cached per credential)
+            # Fetch discussion history for context (requires credential_registry
+            # to resolve agent identity — skip entirely without it)
             discussion_history: DiscussionHistory | None = None
             if credential_registry is not None:
                 try:
+                    discussions = await gl_client.list_mr_discussions(project.id, mr.iid)
                     agent_identity = await credential_registry.resolve_identity(
                         "default", settings.gitlab_url
                     )

--- a/src/gitlab_copilot_agent/review_engine.py
+++ b/src/gitlab_copilot_agent/review_engine.py
@@ -1,11 +1,18 @@
 """Copilot review engine — runs an agent review session on an MR."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import structlog
 from pydantic import BaseModel, ConfigDict, Field
 
 from gitlab_copilot_agent.config import Settings
 from gitlab_copilot_agent.prompt_defaults import DEFAULT_REVIEW_PROMPT, get_prompt
 from gitlab_copilot_agent.task_executor import TaskExecutor, TaskParams, TaskResult
+
+if TYPE_CHECKING:
+    from gitlab_copilot_agent.discussion_models import DiscussionHistory
 
 log = structlog.get_logger()
 
@@ -26,7 +33,11 @@ class ReviewRequest(BaseModel):
     target_branch: str = Field(description="Target branch name")
 
 
-def build_review_prompt(req: ReviewRequest, diff_text: str | None = None) -> str:
+def build_review_prompt(
+    req: ReviewRequest,
+    diff_text: str | None = None,
+    discussion_history: DiscussionHistory | None = None,
+) -> str:
     """Build the user prompt — includes the diff directly when available."""
     prompt = (
         f"## Merge Request\n"
@@ -60,6 +71,7 @@ async def run_review(
     repo_url: str,
     review_request: ReviewRequest,
     diff_text: str | None = None,
+    discussion_history: DiscussionHistory | None = None,
 ) -> TaskResult:
     """Run a Copilot agent review and return the structured result."""
     task = TaskParams(
@@ -68,7 +80,7 @@ async def run_review(
         repo_url=repo_url,
         branch=review_request.source_branch,
         system_prompt=get_prompt(settings, "review"),
-        user_prompt=build_review_prompt(review_request, diff_text),
+        user_prompt=build_review_prompt(review_request, diff_text, discussion_history),
         settings=settings,
         repo_path=repo_path,
     )

--- a/src/gitlab_copilot_agent/webhook.py
+++ b/src/gitlab_copilot_agent/webhook.py
@@ -1,6 +1,9 @@
 """Webhook endpoint for GitLab MR events."""
 
+from __future__ import annotations
+
 import hmac
+from typing import TYPE_CHECKING
 
 import structlog
 from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, Request
@@ -11,6 +14,9 @@ from gitlab_copilot_agent.models import MergeRequestWebhookPayload, NoteWebhookP
 from gitlab_copilot_agent.mr_comment_handler import handle_copilot_comment, parse_copilot_command
 from gitlab_copilot_agent.orchestrator import handle_review
 from gitlab_copilot_agent.project_registry import ProjectRegistry
+
+if TYPE_CHECKING:
+    from gitlab_copilot_agent.credential_registry import CredentialRegistry
 
 log = structlog.get_logger()
 
@@ -56,10 +62,19 @@ async def _process_review(request: Request, payload: MergeRequestWebhookPayload)
     project_id = payload.project.id
     head_sha = mr.last_commit.id
     project_token = _resolve_project_token(project_id, registry, settings.gitlab_token)
+    credential_registry: CredentialRegistry | None = getattr(
+        request.app.state, "credential_registry", None
+    )
     bound = log.bind(project_id=project_id, mr_iid=mr.iid, head_sha=head_sha)
     bound.info("background_review_starting")
     try:
-        await handle_review(settings, payload, executor, project_token=project_token)
+        await handle_review(
+            settings,
+            payload,
+            executor,
+            project_token=project_token,
+            credential_registry=credential_registry,
+        )
         review_tracker.mark(project_id, mr.iid, head_sha)
         bound.info("background_review_completed")
     except Exception:
@@ -144,11 +159,27 @@ async def webhook(
             return {"status": "ignored", "reason": "not an MR note"}
         if not parse_copilot_command(note_payload.object_attributes.note):
             return {"status": "ignored", "reason": "not a /copilot command"}
+
+        # Self-comment detection: prefer immutable user_id over mutable username
+        credential_registry: CredentialRegistry | None = getattr(
+            request.app.state, "credential_registry", None
+        )
+        if credential_registry is not None:
+            try:
+                agent_identity = await credential_registry.resolve_identity(
+                    "default", settings.gitlab_url
+                )
+                if note_payload.user.id == agent_identity.user_id:
+                    return {"status": "ignored", "reason": "self-comment"}
+            except Exception:
+                await log.awarning("identity_resolution_failed_for_self_check", exc_info=True)
+        # Fallback to legacy username comparison (deprecated)
         if (
             settings.agent_gitlab_username
             and note_payload.user.username == settings.agent_gitlab_username
         ):
             return {"status": "ignored", "reason": "self-comment"}
+
         background_tasks.add_task(_process_copilot_comment, request, note_payload)
         return {"status": "queued"}
 

--- a/tests/e2e/mock_gitlab.py
+++ b/tests/e2e/mock_gitlab.py
@@ -93,8 +93,35 @@ async def get_mr_changes(project_id: int, mr_iid: int) -> dict:
 
 @app.get("/api/v4/projects/{project_id}/merge_requests/{mr_iid}/discussions")
 async def list_mr_discussions(project_id: int, mr_iid: int) -> list[dict]:
-    """Return empty discussion list (Feature 1, #321)."""
-    return []
+    """Return mock discussion threads for the MR (#321).
+
+    Returns any discussions previously posted via POST /discussions,
+    formatted as GitLab API discussion objects with thread structure.
+    """
+    result: list[dict] = []
+    for i, disc in enumerate(discussions):
+        if disc.get("_type") == "note":
+            continue
+        result.append(
+            {
+                "id": f"disc-{i}",
+                "individual_note": False,
+                "notes": [
+                    {
+                        "id": 1000 + i,
+                        "type": "DiffNote" if disc.get("position") else "DiscussionNote",
+                        "body": disc.get("body", ""),
+                        "author": {"id": 9999, "username": "mock-review-bot"},
+                        "created_at": "2024-01-15T10:30:00Z",
+                        "system": False,
+                        "resolvable": True,
+                        "resolved": False,
+                        "position": disc.get("position"),
+                    }
+                ],
+            }
+        )
+    return result
 
 
 @app.get("/api/v4/user")

--- a/tests/e2e/mock_gitlab.py
+++ b/tests/e2e/mock_gitlab.py
@@ -27,6 +27,7 @@ pushes: list[dict] = []
 # GitLab poller state — controlled by test script via /mock endpoints
 _open_mrs: list[dict] = []
 _mr_notes: dict[int, list[dict]] = {}  # mr_iid → notes list
+_seeded_discussions: list[dict] = []  # pre-seeded via POST /mock/discussions
 
 # Bare git repo created at startup
 _bare_repo: Path | None = None
@@ -95,10 +96,11 @@ async def get_mr_changes(project_id: int, mr_iid: int) -> dict:
 async def list_mr_discussions(project_id: int, mr_iid: int) -> list[dict]:
     """Return mock discussion threads for the MR (#321).
 
-    Returns any discussions previously posted via POST /discussions,
-    formatted as GitLab API discussion objects with thread structure.
+    Returns pre-seeded discussions (via POST /mock/discussions) plus any
+    discussions previously posted via POST /discussions, formatted as
+    GitLab API discussion objects with thread structure.
     """
-    result: list[dict] = []
+    result: list[dict] = list(_seeded_discussions)
     for i, disc in enumerate(discussions):
         if disc.get("_type") == "note":
             continue
@@ -252,6 +254,21 @@ async def clear_open_mrs() -> dict:
 @app.delete("/mock/notes")
 async def clear_notes() -> dict:
     _mr_notes.clear()
+    return {"cleared": True}
+
+
+@app.post("/mock/discussions")
+async def seed_discussions(request: Request) -> dict:
+    """Pre-seed discussions returned by GET /discussions (#321)."""
+    body = await request.json()
+    _seeded_discussions.extend(body if isinstance(body, list) else [body])
+    return {"seeded": len(_seeded_discussions)}
+
+
+@app.delete("/mock/discussions")
+async def clear_seeded_discussions() -> dict:
+    """Clear pre-seeded discussions."""
+    _seeded_discussions.clear()
     return {"cleared": True}
 
 

--- a/tests/e2e/mock_gitlab.py
+++ b/tests/e2e/mock_gitlab.py
@@ -91,6 +91,18 @@ async def get_mr_changes(project_id: int, mr_iid: int) -> dict:
     return mr
 
 
+@app.get("/api/v4/projects/{project_id}/merge_requests/{mr_iid}/discussions")
+async def list_mr_discussions(project_id: int, mr_iid: int) -> list[dict]:
+    """Return empty discussion list (Feature 1, #321)."""
+    return []
+
+
+@app.get("/api/v4/user")
+async def get_current_user() -> dict:
+    """Return agent identity (Feature 1, #321)."""
+    return {"id": 9999, "username": "mock-review-bot", "name": "Mock Review Bot"}
+
+
 @app.post("/api/v4/projects/{project_id}/merge_requests/{mr_iid}/discussions")
 async def create_discussion(project_id: int, mr_iid: int, request: Request) -> dict:
     body = await request.json()

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -283,6 +283,8 @@ fi
 
 # === TEST 8: Discussion History Capture (#321) ===
 echo ""; echo "--- Test 8: Discussion History Capture ---"
+# Agent pod was restarted by Test 7 — wait for it to be healthy again
+wait_for_health "$AGENT_URL/health" "agent (post-restart)" 40 || exit 1
 # Pre-seed a discussion thread so the agent processes non-empty history
 curl -sf -X DELETE "$MOCK_GITLAB_URL/discussions" > /dev/null
 curl -sf -X DELETE "$MOCK_GITLAB_URL/mock/discussions" > /dev/null

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # E2E test: deploy agent to k3d, run all test flows against mock services.
 # Tests: 1. Webhook MR review, 2. Jira polling, 3. /copilot command,
-#        4. GitLab polling, 5. Hot-reload config, 6. Plugin install, 7. Graceful shutdown.
+#        4. GitLab polling, 5. Hot-reload config, 6. Plugin install,
+#        7. Graceful shutdown, 8. Discussion history capture.
 # Usage: ./tests/e2e/run.sh [agent-url] [mock-gitlab-url] [mock-jira-url]
 set -euo pipefail
 
@@ -279,6 +280,65 @@ else
         echo " ⚠️ (could not verify shutdown logs — pod replaced)"
     fi
 fi
+
+# === TEST 8: Discussion History Capture (#321) ===
+echo ""; echo "--- Test 8: Discussion History Capture ---"
+# Pre-seed a discussion thread so the agent processes non-empty history
+curl -sf -X DELETE "$MOCK_GITLAB_URL/discussions" > /dev/null
+curl -sf -X DELETE "$MOCK_GITLAB_URL/mock/discussions" > /dev/null
+curl -sf -X POST "$MOCK_GITLAB_URL/mock/discussions" \
+    -H "Content-Type: application/json" \
+    -d '[{
+        "id": "seed-disc-001",
+        "individual_note": false,
+        "notes": [{
+            "id": 9001,
+            "type": "DiffNote",
+            "body": "Consider adding error handling here.",
+            "author": {"id": 9999, "username": "mock-review-bot"},
+            "created_at": "2024-01-15T10:00:00Z",
+            "system": false,
+            "resolvable": true,
+            "resolved": false,
+            "position": {"new_path": "app.py", "old_path": "app.py", "new_line": 1, "old_line": null}
+        }, {
+            "id": 9002,
+            "type": "DiffNote",
+            "body": "Will fix, thanks!",
+            "author": {"id": 42, "username": "developer"},
+            "created_at": "2024-01-15T11:00:00Z",
+            "system": false,
+            "resolvable": false,
+            "resolved": false,
+            "position": null
+        }]
+    }]' > /dev/null
+
+echo -n "Sending webhook (MR with prior discussions)..."
+send_webhook '{
+    "object_kind": "merge_request",
+    "user": {"id": 1, "username": "e2e-test"},
+    "project": {"id": 999, "path_with_namespace": "test/e2e-repo",
+                "git_http_url": "http://host.k3d.internal:9999/repo.git"},
+    "object_attributes": {"iid": 321, "title": "Discussion history test MR", "description": "Test with prior feedback",
+        "action": "open", "source_branch": "main", "target_branch": "main",
+        "last_commit": {"id": "disc321", "message": "test discussions"}, "url": "http://mock/mr/321", "oldrev": null}
+}'
+
+poll_until "$MOCK_GITLAB_URL/discussions" \
+    "import sys,json; d=json.load(sys.stdin); print(len(d) if d else 0)" \
+    "Waiting for review with discussion context" || { kubectl logs -l app.kubernetes.io/name=gitlab-copilot-agent --tail=50 2>/dev/null || true; exit 1; }
+
+echo -n "Verifying review completed with non-empty discussion history..."
+REVIEW_POSTED=$(curl -sf "$MOCK_GITLAB_URL/discussions" | python3 -c "
+import sys, json
+ds = json.load(sys.stdin)
+has_review = any('position' in str(d) for d in ds)
+print('yes' if has_review else 'no')")
+[ "$REVIEW_POSTED" = "yes" ] && echo " ✅" || { echo " ❌"; exit 1; }
+
+# Clean up seeded discussions
+curl -sf -X DELETE "$MOCK_GITLAB_URL/mock/discussions" > /dev/null
 
 echo ""; echo "=== ALL E2E TESTS PASSED ==="
 exit 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -267,3 +267,21 @@ def test_marketplaces_from_comma_separated(monkeypatch: pytest.MonkeyPatch) -> N
         "https://mp1.example.com",
         "https://mp2.example.com",
     ]
+
+
+# -- Deprecation warning tests --
+
+
+def test_agent_gitlab_username_emits_deprecation_warning() -> None:
+    """Setting agent_gitlab_username should emit a DeprecationWarning."""
+    with pytest.warns(DeprecationWarning, match="agent_gitlab_username is deprecated"):
+        make_settings(agent_gitlab_username="bot")
+
+
+def test_no_deprecation_warning_without_agent_username() -> None:
+    """No DeprecationWarning when agent_gitlab_username is not set."""
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        make_settings()  # should not raise

--- a/tests/test_credential_registry.py
+++ b/tests/test_credential_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -176,3 +177,27 @@ class TestResolveIdentity:
         assert first == expected
         assert second is first
         mock_fetch.assert_awaited_once()
+
+    async def test_concurrent_calls_only_fetch_once(self) -> None:
+        """Multiple concurrent resolve_identity calls for the same ref
+        result in only one API call (lock prevents thundering herd)."""
+        reg = CredentialRegistry(default_token=DEFAULT_TOKEN)
+        expected = _make_identity()
+
+        call_count = 0
+
+        async def _slow_fetch(gitlab_url: str, token: str) -> AgentIdentity:
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.05)
+            return expected
+
+        with patch(_FETCH_PATH, side_effect=_slow_fetch):
+            results = await asyncio.gather(
+                reg.resolve_identity("default", GITLAB_URL),
+                reg.resolve_identity("default", GITLAB_URL),
+                reg.resolve_identity("default", GITLAB_URL),
+            )
+
+        assert all(r == expected for r in results)
+        assert call_count == 1

--- a/tests/test_credential_registry.py
+++ b/tests/test_credential_registry.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 from gitlab_copilot_agent.credential_registry import CredentialRegistry
+from gitlab_copilot_agent.discussion_models import AgentIdentity
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -13,6 +16,12 @@ from gitlab_copilot_agent.credential_registry import CredentialRegistry
 DEFAULT_TOKEN = "glpat-default-token"
 PLATFORM_TOKEN = "glpat-platform-token"
 OPS_TOKEN = "glpat-ops-token"
+
+GITLAB_URL = "https://gitlab.example.com"
+AGENT_USER_ID = 100
+AGENT_USERNAME = "agent-bot"
+OPS_USER_ID = 200
+OPS_USERNAME = "ops-bot"
 
 
 # ---------------------------------------------------------------------------
@@ -92,3 +101,78 @@ class TestFromEnv:
         monkeypatch.setenv("GITLAB_TOKEN__EMPTY", "")
         reg = CredentialRegistry.from_env()
         assert reg.aliases() == {"default"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_identity(user_id: int = AGENT_USER_ID, username: str = AGENT_USERNAME) -> AgentIdentity:
+    return AgentIdentity(user_id=user_id, username=username)
+
+
+# ---------------------------------------------------------------------------
+# resolve_identity
+# ---------------------------------------------------------------------------
+
+_FETCH_PATH = "gitlab_copilot_agent.credential_registry._fetch_identity"
+
+
+class TestResolveIdentity:
+    async def test_returns_identity_on_first_call(self) -> None:
+        reg = CredentialRegistry(default_token=DEFAULT_TOKEN)
+        expected = _make_identity()
+        with patch(_FETCH_PATH, new_callable=AsyncMock, return_value=expected) as mock_fetch:
+            result = await reg.resolve_identity("default", GITLAB_URL)
+
+        assert result == expected
+        mock_fetch.assert_awaited_once_with(GITLAB_URL, DEFAULT_TOKEN)
+
+    async def test_returns_cached_on_second_call(self) -> None:
+        reg = CredentialRegistry(default_token=DEFAULT_TOKEN)
+        expected = _make_identity()
+        with patch(_FETCH_PATH, new_callable=AsyncMock, return_value=expected) as mock_fetch:
+            first = await reg.resolve_identity("default", GITLAB_URL)
+            second = await reg.resolve_identity("default", GITLAB_URL)
+
+        assert first == expected
+        assert second is first
+        mock_fetch.assert_awaited_once()
+
+    async def test_caches_per_credential_ref(self) -> None:
+        reg = CredentialRegistry(
+            default_token=DEFAULT_TOKEN,
+            named_tokens={"ops": OPS_TOKEN},
+        )
+        default_id = _make_identity()
+        ops_id = _make_identity(user_id=OPS_USER_ID, username=OPS_USERNAME)
+
+        async def _fake_fetch(_url: str, token: str) -> AgentIdentity:
+            if token == DEFAULT_TOKEN:
+                return default_id
+            return ops_id
+
+        with patch(_FETCH_PATH, new_callable=AsyncMock, side_effect=_fake_fetch) as mock_fetch:
+            result_default = await reg.resolve_identity("default", GITLAB_URL)
+            result_ops = await reg.resolve_identity("ops", GITLAB_URL)
+
+        assert result_default == default_id
+        assert result_ops == ops_id
+        assert mock_fetch.await_count == 2
+
+    async def test_raises_on_unknown_credential_ref(self) -> None:
+        reg = CredentialRegistry(default_token=DEFAULT_TOKEN)
+        with pytest.raises(KeyError, match="Unknown credential_ref 'missing'"):
+            await reg.resolve_identity("missing", GITLAB_URL)
+
+    async def test_cache_is_case_insensitive(self) -> None:
+        reg = CredentialRegistry(default_token=DEFAULT_TOKEN)
+        expected = _make_identity()
+        with patch(_FETCH_PATH, new_callable=AsyncMock, return_value=expected) as mock_fetch:
+            first = await reg.resolve_identity("DEFAULT", GITLAB_URL)
+            second = await reg.resolve_identity("default", GITLAB_URL)
+
+        assert first == expected
+        assert second is first
+        mock_fetch.assert_awaited_once()

--- a/tests/test_discussion_models.py
+++ b/tests/test_discussion_models.py
@@ -1,0 +1,127 @@
+"""Unit tests for discussion_models."""
+
+from gitlab_copilot_agent.discussion_models import (
+    AgentIdentity,
+    Discussion,
+    DiscussionHistory,
+    DiscussionNote,
+)
+
+# -- Test constants --
+AGENT_USER_ID = 100
+AGENT_USERNAME = "review-bot"
+HUMAN_USER_ID = 42
+HUMAN_USERNAME = "developer"
+DISCUSSION_ID = "abc123def"
+NOTE_ID = 501
+CREATED_AT = "2024-01-15T10:30:00Z"
+NOTE_BODY = "Consider adding a null check here."
+DIFF_POSITION = {
+    "new_path": "src/app.py",
+    "old_path": "src/app.py",
+    "new_line": 42,
+    "old_line": None,
+}
+
+
+def _make_note(**overrides: object) -> DiscussionNote:
+    """Factory for DiscussionNote with sensible defaults."""
+    defaults: dict[str, object] = {
+        "note_id": NOTE_ID,
+        "author_id": AGENT_USER_ID,
+        "author_username": AGENT_USERNAME,
+        "body": NOTE_BODY,
+        "created_at": CREATED_AT,
+        "is_system": False,
+        "resolved": None,
+        "resolvable": True,
+        "position": None,
+    }
+    return DiscussionNote(**(defaults | overrides))
+
+
+def _make_discussion(**overrides: object) -> Discussion:
+    """Factory for Discussion with sensible defaults."""
+    defaults: dict[str, object] = {
+        "discussion_id": DISCUSSION_ID,
+        "notes": [_make_note()],
+        "is_resolved": False,
+        "is_inline": False,
+    }
+    return Discussion(**(defaults | overrides))
+
+
+class TestDiscussionNote:
+    def test_construction(self) -> None:
+        note = _make_note()
+        assert note.note_id == NOTE_ID
+        assert note.author_id == AGENT_USER_ID
+        assert note.body == NOTE_BODY
+        assert note.is_system is False
+
+    def test_with_position(self) -> None:
+        note = _make_note(position=DIFF_POSITION)
+        assert note.position is not None
+        assert note.position["new_path"] == "src/app.py"
+        assert note.position["new_line"] == 42
+
+    def test_system_note(self) -> None:
+        note = _make_note(is_system=True, body="assigned to @dev")
+        assert note.is_system is True
+
+    def test_resolved_states(self) -> None:
+        unresolvable = _make_note(resolvable=False, resolved=None)
+        assert unresolvable.resolved is None
+
+        resolved = _make_note(resolvable=True, resolved=True)
+        assert resolved.resolved is True
+
+        unresolved = _make_note(resolvable=True, resolved=False)
+        assert unresolved.resolved is False
+
+
+class TestDiscussion:
+    def test_overview_discussion(self) -> None:
+        disc = _make_discussion(is_inline=False)
+        assert disc.is_inline is False
+        assert disc.discussion_id == DISCUSSION_ID
+
+    def test_inline_discussion(self) -> None:
+        note = _make_note(position=DIFF_POSITION)
+        disc = _make_discussion(is_inline=True, notes=[note])
+        assert disc.is_inline is True
+
+    def test_resolved_discussion(self) -> None:
+        disc = _make_discussion(is_resolved=True)
+        assert disc.is_resolved is True
+
+    def test_multiple_notes_in_thread(self) -> None:
+        notes = [
+            _make_note(note_id=1, author_id=AGENT_USER_ID, body="Issue found"),
+            _make_note(note_id=2, author_id=HUMAN_USER_ID, body="Fixed"),
+        ]
+        disc = _make_discussion(notes=notes)
+        assert len(disc.notes) == 2
+        assert disc.notes[0].author_id == AGENT_USER_ID
+        assert disc.notes[1].author_id == HUMAN_USER_ID
+
+
+class TestAgentIdentity:
+    def test_construction(self) -> None:
+        identity = AgentIdentity(user_id=AGENT_USER_ID, username=AGENT_USERNAME)
+        assert identity.user_id == AGENT_USER_ID
+        assert identity.username == AGENT_USERNAME
+
+
+class TestDiscussionHistory:
+    def test_empty_history(self) -> None:
+        identity = AgentIdentity(user_id=AGENT_USER_ID, username=AGENT_USERNAME)
+        history = DiscussionHistory(discussions=[], agent=identity)
+        assert len(history.discussions) == 0
+
+    def test_with_discussions(self) -> None:
+        identity = AgentIdentity(user_id=AGENT_USER_ID, username=AGENT_USERNAME)
+        discussions = [_make_discussion(), _make_discussion(discussion_id="other")]
+        history = DiscussionHistory(discussions=discussions, agent=identity)
+        assert len(history.discussions) == 2
+        assert history.agent.user_id == AGENT_USER_ID

--- a/tests/test_gitlab_client.py
+++ b/tests/test_gitlab_client.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from gitlab_copilot_agent.discussion_models import AgentIdentity
 from gitlab_copilot_agent.gitlab_client import (
     GitLabClient,
     MRAuthor,
@@ -31,6 +32,10 @@ ISO_TIMESTAMP = "2024-01-01T00:00:00Z"
 SECRET_TOKEN = "glpat-secret-token-value"
 AUTHOR_ATTRS = {"id": 1, "username": "testuser"}
 MR_WEB_URL = f"{GITLAB_URL}/{PROJECT_PATH}/-/merge_requests/{MR_IID}"
+DISCUSSION_ID = "abc123discussion"
+DIFF_NOTE_PATH = "src/utils.py"
+BOT_USER_ID = 99
+BOT_USERNAME = "review-bot"
 
 
 @pytest.fixture
@@ -190,3 +195,158 @@ async def test_clone_repo_sanitizes_token_in_error(tmp_path: Path) -> None:
     with pytest.raises(RuntimeError, match="git clone failed") as exc_info:
         await client.clone_repo("https://gitlab.com/nonexistent/repo.git", "main", SECRET_TOKEN)
     assert SECRET_TOKEN not in str(exc_info.value)
+
+
+# -- list_mr_discussions tests --
+
+
+def _make_raw_note(
+    *,
+    note_id: int = NOTE_ID,
+    body: str = NOTE_BODY,
+    system: bool = False,
+    note_type: str | None = None,
+    resolved: bool | None = None,
+    resolvable: bool = False,
+    position: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """Factory for raw discussion note dicts as returned by python-gitlab."""
+    note: dict[str, object] = {
+        "id": note_id,
+        "body": body,
+        "author": AUTHOR_ATTRS,
+        "system": system,
+        "created_at": ISO_TIMESTAMP,
+        "resolvable": resolvable,
+    }
+    if note_type is not None:
+        note["type"] = note_type
+    if resolved is not None:
+        note["resolved"] = resolved
+    if position is not None:
+        note["position"] = position
+    return note
+
+
+def _make_discussion_mock(discussion_id: str, notes: list[dict[str, object]]) -> MagicMock:
+    """Factory for a raw discussion object with .attributes."""
+    disc = MagicMock()
+    disc.attributes = {"id": discussion_id, "notes": notes}
+    return disc
+
+
+async def test_list_mr_discussions_mixed_types(mock_gl: MagicMock) -> None:
+    """DiffNote sets is_inline=True; DiscussionNote keeps is_inline=False."""
+    diff_note = _make_raw_note(
+        note_id=10,
+        body="inline comment",
+        note_type="DiffNote",
+        position={
+            "new_path": DIFF_NOTE_PATH,
+            "old_path": DIFF_NOTE_PATH,
+            "new_line": 5,
+            "old_line": None,
+        },
+    )
+    regular_note = _make_raw_note(note_id=20, body="general comment", note_type="DiscussionNote")
+
+    disc_inline = _make_discussion_mock("d1", [diff_note])
+    disc_general = _make_discussion_mock("d2", [regular_note])
+
+    mr_mock = mock_gl.projects.get.return_value.mergerequests.get.return_value
+    mr_mock.discussions.list.return_value = [disc_inline, disc_general]
+
+    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
+    result = await client.list_mr_discussions(PROJECT_ID, MR_IID)
+
+    assert len(result) == 2
+    assert result[0].is_inline is True
+    assert result[0].notes[0].note_id == 10
+    assert result[1].is_inline is False
+    assert result[1].notes[0].note_id == 20
+
+
+async def test_list_mr_discussions_system_notes_filtered(mock_gl: MagicMock) -> None:
+    """System notes are excluded from the returned discussion."""
+    system_note = _make_raw_note(note_id=30, body="system event", system=True)
+    user_note = _make_raw_note(note_id=31, body="user reply")
+
+    disc = _make_discussion_mock("d3", [system_note, user_note])
+    mr_mock = mock_gl.projects.get.return_value.mergerequests.get.return_value
+    mr_mock.discussions.list.return_value = [disc]
+
+    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
+    result = await client.list_mr_discussions(PROJECT_ID, MR_IID)
+
+    assert len(result) == 1
+    assert len(result[0].notes) == 1
+    assert result[0].notes[0].note_id == 31
+
+
+async def test_list_mr_discussions_all_system_notes_skipped(mock_gl: MagicMock) -> None:
+    """Discussions where ALL notes are system notes are dropped entirely."""
+    system_only = _make_raw_note(note_id=40, body="system", system=True)
+    disc = _make_discussion_mock("d4", [system_only])
+
+    mr_mock = mock_gl.projects.get.return_value.mergerequests.get.return_value
+    mr_mock.discussions.list.return_value = [disc]
+
+    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
+    result = await client.list_mr_discussions(PROJECT_ID, MR_IID)
+
+    assert result == []
+
+
+async def test_list_mr_discussions_position_extraction(mock_gl: MagicMock) -> None:
+    """DiffNote position fields are correctly extracted."""
+    position = {
+        "new_path": DIFF_NOTE_PATH,
+        "old_path": "src/old_utils.py",
+        "new_line": 42,
+        "old_line": 10,
+    }
+    diff_note = _make_raw_note(note_id=50, note_type="DiffNote", position=position)
+    disc = _make_discussion_mock("d5", [diff_note])
+
+    mr_mock = mock_gl.projects.get.return_value.mergerequests.get.return_value
+    mr_mock.discussions.list.return_value = [disc]
+
+    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
+    result = await client.list_mr_discussions(PROJECT_ID, MR_IID)
+
+    note = result[0].notes[0]
+    assert note.position is not None
+    assert note.position["new_path"] == DIFF_NOTE_PATH
+    assert note.position["old_path"] == "src/old_utils.py"
+    assert note.position["new_line"] == 42
+    assert note.position["old_line"] == 10
+
+
+async def test_list_mr_discussions_empty(mock_gl: MagicMock) -> None:
+    """Empty discussions list returns empty result."""
+    mr_mock = mock_gl.projects.get.return_value.mergerequests.get.return_value
+    mr_mock.discussions.list.return_value = []
+
+    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
+    result = await client.list_mr_discussions(PROJECT_ID, MR_IID)
+
+    assert result == []
+    mr_mock.discussions.list.assert_called_once_with(get_all=True)
+
+
+# -- get_current_user tests --
+
+
+async def test_get_current_user(mock_gl: MagicMock) -> None:
+    """Returns AgentIdentity with user_id and username from authenticated user."""
+    mock_gl.user = MagicMock()
+    mock_gl.user.id = BOT_USER_ID
+    mock_gl.user.username = BOT_USERNAME
+
+    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
+    identity = await client.get_current_user()
+
+    mock_gl.auth.assert_called_once()
+    assert isinstance(identity, AgentIdentity)
+    assert identity.user_id == BOT_USER_ID
+    assert identity.username == BOT_USERNAME

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from httpx import AsyncClient
 
+from gitlab_copilot_agent.discussion_models import AgentIdentity, DiscussionHistory
 from gitlab_copilot_agent.gitlab_client import MRDetails
 from gitlab_copilot_agent.models import (
     MergeRequestWebhookPayload,
@@ -19,6 +20,7 @@ from tests.conftest import (
     DIFF_REFS,
     FAKE_REVIEW_OUTPUT,
     GITLAB_TOKEN,
+    GITLAB_URL,
     HEADERS,
     MR_IID,
     MR_PAYLOAD,
@@ -43,6 +45,7 @@ def _setup_mocks(
             changes=[],
         )
     )
+    mock_gl_instance.list_mr_discussions = AsyncMock(return_value=[])
     mock_run_review.return_value = ReviewResult(summary=FAKE_REVIEW_OUTPUT)
     return mock_gl_instance  # type: ignore[no-any-return]
 
@@ -122,3 +125,110 @@ async def test_orchestrator_cleans_up_on_error(
         await handle_review(make_settings(), payload, AsyncMock())
 
     mock_gl_instance.cleanup.assert_awaited_once()
+
+
+# -- Shared test data for credential_registry tests --
+
+_AGENT_IDENTITY = AgentIdentity(user_id=99, username="copilot-bot")
+
+
+def _make_payload() -> MergeRequestWebhookPayload:
+    return MergeRequestWebhookPayload(
+        object_kind="merge_request",
+        user=WebhookUser(id=1, username="jdoe"),
+        project=WebhookProject(
+            id=PROJECT_ID,
+            path_with_namespace="group/my-project",
+            git_http_url="https://gitlab.com/group/my-project.git",
+        ),
+        object_attributes=MRObjectAttributes(
+            iid=MR_IID,
+            title="Add feature",
+            description="Implements X",
+            action="open",
+            source_branch="feature/x",
+            target_branch="main",
+            last_commit=MRLastCommit(id="abc123", message="feat: add X"),
+            url="https://gitlab.com/group/my-project/-/merge_requests/7",
+        ),
+    )
+
+
+@patch("gitlab_copilot_agent.orchestrator.post_review", new_callable=AsyncMock)
+@patch("gitlab_copilot_agent.orchestrator.run_review", new_callable=AsyncMock)
+@patch("gitlab_copilot_agent.orchestrator.GitLabClient")
+@patch("gitlab_copilot_agent.orchestrator.gitlab.Gitlab")
+async def test_discussion_history_passed_with_credential_registry(
+    mock_gl_class: MagicMock,
+    mock_client_class: MagicMock,
+    mock_run_review: AsyncMock,
+    mock_post_review: AsyncMock,
+) -> None:
+    """When credential_registry is provided, discussion_history is forwarded to run_review."""
+    mock_gl_instance = _setup_mocks(mock_client_class, mock_run_review)
+
+    mock_registry = AsyncMock()
+    mock_registry.resolve_identity = AsyncMock(return_value=_AGENT_IDENTITY)
+
+    await handle_review(
+        make_settings(),
+        _make_payload(),
+        AsyncMock(),
+        credential_registry=mock_registry,
+    )
+
+    mock_gl_instance.list_mr_discussions.assert_awaited_once_with(PROJECT_ID, MR_IID)
+    mock_registry.resolve_identity.assert_awaited_once_with("default", GITLAB_URL)
+
+    review_kwargs = mock_run_review.call_args[1]
+    history = review_kwargs["discussion_history"]
+    assert isinstance(history, DiscussionHistory)
+    assert history.agent == _AGENT_IDENTITY
+    assert history.discussions == []
+
+
+@patch("gitlab_copilot_agent.orchestrator.post_review", new_callable=AsyncMock)
+@patch("gitlab_copilot_agent.orchestrator.run_review", new_callable=AsyncMock)
+@patch("gitlab_copilot_agent.orchestrator.GitLabClient")
+@patch("gitlab_copilot_agent.orchestrator.gitlab.Gitlab")
+async def test_discussion_history_none_without_credential_registry(
+    mock_gl_class: MagicMock,
+    mock_client_class: MagicMock,
+    mock_run_review: AsyncMock,
+    mock_post_review: AsyncMock,
+) -> None:
+    """Without credential_registry, discussion_history is None."""
+    _setup_mocks(mock_client_class, mock_run_review)
+
+    await handle_review(make_settings(), _make_payload(), AsyncMock())
+
+    review_kwargs = mock_run_review.call_args[1]
+    assert review_kwargs["discussion_history"] is None
+
+
+@patch("gitlab_copilot_agent.orchestrator.post_review", new_callable=AsyncMock)
+@patch("gitlab_copilot_agent.orchestrator.run_review", new_callable=AsyncMock)
+@patch("gitlab_copilot_agent.orchestrator.GitLabClient")
+@patch("gitlab_copilot_agent.orchestrator.gitlab.Gitlab")
+async def test_discussion_history_failure_is_non_fatal(
+    mock_gl_class: MagicMock,
+    mock_client_class: MagicMock,
+    mock_run_review: AsyncMock,
+    mock_post_review: AsyncMock,
+) -> None:
+    """Identity resolution failure logs warning but review still completes."""
+    _setup_mocks(mock_client_class, mock_run_review)
+
+    mock_registry = AsyncMock()
+    mock_registry.resolve_identity = AsyncMock(side_effect=RuntimeError("API down"))
+
+    await handle_review(
+        make_settings(),
+        _make_payload(),
+        AsyncMock(),
+        credential_registry=mock_registry,
+    )
+
+    # Review still ran, but without discussion_history
+    review_kwargs = mock_run_review.call_args[1]
+    assert review_kwargs["discussion_history"] is None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,7 +5,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from httpx import AsyncClient
 
-from gitlab_copilot_agent.discussion_models import AgentIdentity, DiscussionHistory
+from gitlab_copilot_agent.discussion_models import (
+    AgentIdentity,
+    Discussion,
+    DiscussionHistory,
+    DiscussionNote,
+)
 from gitlab_copilot_agent.gitlab_client import MRDetails
 from gitlab_copilot_agent.models import (
     MergeRequestWebhookPayload,
@@ -131,6 +136,43 @@ async def test_orchestrator_cleans_up_on_error(
 
 _AGENT_IDENTITY = AgentIdentity(user_id=99, username="copilot-bot")
 
+_SAMPLE_DISCUSSIONS = [
+    Discussion(
+        discussion_id="disc-001",
+        notes=[
+            DiscussionNote(
+                note_id=501,
+                author_id=_AGENT_IDENTITY.user_id,
+                author_username=_AGENT_IDENTITY.username,
+                body="Consider adding a null check here.",
+                created_at="2024-01-15T10:30:00Z",
+                is_system=False,
+                resolved=False,
+                resolvable=True,
+                position={
+                    "new_path": "src/app.py",
+                    "old_path": "src/app.py",
+                    "new_line": 42,
+                    "old_line": None,
+                },
+            ),
+            DiscussionNote(
+                note_id=502,
+                author_id=1,
+                author_username="developer",
+                body="Good catch, will fix.",
+                created_at="2024-01-15T11:00:00Z",
+                is_system=False,
+                resolved=None,
+                resolvable=False,
+                position=None,
+            ),
+        ],
+        is_resolved=False,
+        is_inline=True,
+    ),
+]
+
 
 def _make_payload() -> MergeRequestWebhookPayload:
     return MergeRequestWebhookPayload(
@@ -232,3 +274,55 @@ async def test_discussion_history_failure_is_non_fatal(
     # Review still ran, but without discussion_history
     review_kwargs = mock_run_review.call_args[1]
     assert review_kwargs["discussion_history"] is None
+
+
+@patch("gitlab_copilot_agent.orchestrator.post_review", new_callable=AsyncMock)
+@patch("gitlab_copilot_agent.orchestrator.run_review", new_callable=AsyncMock)
+@patch("gitlab_copilot_agent.orchestrator.GitLabClient")
+@patch("gitlab_copilot_agent.orchestrator.gitlab.Gitlab")
+async def test_discussion_threads_flow_through_pipeline(
+    mock_gl_class: MagicMock,
+    mock_client_class: MagicMock,
+    mock_run_review: AsyncMock,
+    mock_post_review: AsyncMock,
+) -> None:
+    """Actual discussion data (threads, authors, positions) is preserved through the pipeline."""
+    mock_gl_instance = _setup_mocks(mock_client_class, mock_run_review)
+    mock_gl_instance.list_mr_discussions = AsyncMock(return_value=_SAMPLE_DISCUSSIONS)
+
+    mock_registry = AsyncMock()
+    mock_registry.resolve_identity = AsyncMock(return_value=_AGENT_IDENTITY)
+
+    await handle_review(
+        make_settings(),
+        _make_payload(),
+        AsyncMock(),
+        credential_registry=mock_registry,
+    )
+
+    review_kwargs = mock_run_review.call_args[1]
+    history = review_kwargs["discussion_history"]
+    assert isinstance(history, DiscussionHistory)
+
+    # Verify discussion structure is preserved
+    assert len(history.discussions) == 1
+    disc = history.discussions[0]
+    assert disc.discussion_id == "disc-001"
+    assert disc.is_inline is True
+    assert disc.is_resolved is False
+
+    # Verify thread hierarchy — root note + reply
+    assert len(disc.notes) == 2
+    root = disc.notes[0]
+    assert root.author_id == _AGENT_IDENTITY.user_id
+    assert root.body == "Consider adding a null check here."
+    assert root.position is not None
+    assert root.position["new_line"] == 42
+
+    reply = disc.notes[1]
+    assert reply.author_id == 1
+    assert reply.author_username == "developer"
+
+    # Verify agent can distinguish own comments
+    assert root.author_id == history.agent.user_id
+    assert reply.author_id != history.agent.user_id

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -154,6 +154,7 @@ async def test_review_pipeline_records_success_metrics(
     mock_gl.get_mr_details = AsyncMock(
         return_value=MRDetails(title="t", description=None, diff_refs=DIFF_REFS, changes=[])
     )
+    mock_gl.list_mr_discussions = AsyncMock(return_value=[])
     mock_run_review.return_value = ReviewResult(summary=FAKE_REVIEW_OUTPUT)
 
     mock_total = MagicMock()
@@ -213,6 +214,7 @@ async def test_review_task_execution_failure_posts_comment_without_raising(
     mock_gl.get_mr_details = AsyncMock(
         return_value=MRDetails(title="t", description=None, diff_refs=DIFF_REFS, changes=[])
     )
+    mock_gl.list_mr_discussions = AsyncMock(return_value=[])
     mock_gl.post_mr_comment = AsyncMock()
     mock_run_review.side_effect = TaskExecutionError("Task failed: runner error")
 

--- a/tests/test_review_engine.py
+++ b/tests/test_review_engine.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock
 
+from gitlab_copilot_agent.discussion_models import AgentIdentity, DiscussionHistory
 from gitlab_copilot_agent.prompt_defaults import get_prompt
 from gitlab_copilot_agent.review_engine import (
     ReviewRequest,
@@ -51,3 +52,41 @@ async def test_run_review_delegates_to_executor() -> None:
     assert task.system_prompt == get_prompt(settings, "review")
     assert "Add feature X" in task.user_prompt
     assert "git diff main...feature/x" in task.user_prompt
+
+
+def test_build_review_prompt_accepts_discussion_history() -> None:
+    """discussion_history param is accepted without affecting output (Feature 2 will render it)."""
+    req = _make_request()
+    history = DiscussionHistory(
+        discussions=[],
+        agent=AgentIdentity(user_id=1, username="bot"),
+    )
+    prompt_with = build_review_prompt(req, discussion_history=history)
+    prompt_without = build_review_prompt(req)
+    # Until Feature 2, discussion_history does not change the prompt
+    assert prompt_with == prompt_without
+
+
+async def test_run_review_forwards_discussion_history() -> None:
+    """run_review passes discussion_history through to build_review_prompt."""
+    mock_executor = AsyncMock()
+    mock_executor.execute.return_value = "Review result"
+
+    settings = make_settings()
+    req = _make_request()
+    history = DiscussionHistory(
+        discussions=[],
+        agent=AgentIdentity(user_id=1, username="bot"),
+    )
+    result = await run_review(
+        mock_executor,
+        settings,
+        "/tmp/repo",
+        EXAMPLE_CLONE_URL,
+        req,
+        discussion_history=history,
+    )
+
+    assert result == "Review result"
+    # Verify executor was called (prompt content tested separately)
+    mock_executor.execute.assert_awaited_once()

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,11 +1,12 @@
 """Tests for the webhook endpoint."""
 
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import AsyncClient
 
+from gitlab_copilot_agent.discussion_models import AgentIdentity
 from gitlab_copilot_agent.main import app
 from gitlab_copilot_agent.project_registry import ProjectRegistry, ResolvedProject
 from tests.conftest import (
@@ -305,3 +306,127 @@ async def test_webhook_review_works_without_registry(client: AsyncClient) -> Non
     mock_handle.assert_awaited_once()
     _, kwargs = mock_handle.call_args
     assert kwargs["project_token"] == GITLAB_TOKEN
+
+
+async def test_webhook_review_passes_credential_registry(client: AsyncClient) -> None:
+    """MR review forwards credential_registry from app.state."""
+    mock_registry = MagicMock()
+    app.state.credential_registry = mock_registry
+    mock_handle = AsyncMock()
+    try:
+        with patch("gitlab_copilot_agent.webhook.handle_review", mock_handle):
+            resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
+            assert resp.json() == {"status": "queued"}
+            await asyncio.sleep(0.1)
+
+        mock_handle.assert_awaited_once()
+        _, kwargs = mock_handle.call_args
+        assert kwargs["credential_registry"] is mock_registry
+    finally:
+        del app.state.credential_registry
+
+
+# -- Self-comment detection tests --
+
+AGENT_USER_ID = 100
+AGENT_USERNAME = "copilot-bot"
+NOTE_AUTHOR_USER_ID = 1
+
+
+def _make_credential_registry_mock(
+    user_id: int = AGENT_USER_ID,
+    username: str = AGENT_USERNAME,
+    *,
+    raise_on_resolve: bool = False,
+) -> MagicMock:
+    """Build a mock CredentialRegistry with resolve_identity behaviour."""
+    mock = MagicMock()
+    if raise_on_resolve:
+        mock.resolve_identity = AsyncMock(side_effect=RuntimeError("network error"))
+    else:
+        mock.resolve_identity = AsyncMock(
+            return_value=AgentIdentity(user_id=user_id, username=username)
+        )
+    return mock
+
+
+def _note_body_with_user(
+    user_id: int = NOTE_AUTHOR_USER_ID,
+    username: str = "reviewer",
+    note: str = "/copilot fix the bug",
+) -> dict[str, object]:
+    """Build a note webhook body with a specific user id and username."""
+    return {
+        "object_kind": "note",
+        "user": {"id": user_id, "username": username},
+        "project": {
+            "id": PROJECT_ID,
+            "path_with_namespace": "g/p",
+            "git_http_url": "https://x.git",
+        },
+        "object_attributes": {"note": note, "noteable_type": "MergeRequest"},
+        "merge_request": {
+            "iid": MR_IID,
+            "title": "Fix",
+            "source_branch": "feat",
+            "target_branch": "main",
+        },
+    }
+
+
+async def test_self_comment_detected_via_user_id(client: AsyncClient) -> None:
+    """Note from the agent (matched by user_id) is ignored."""
+    app.state.credential_registry = _make_credential_registry_mock(user_id=AGENT_USER_ID)
+    try:
+        body = _note_body_with_user(user_id=AGENT_USER_ID, username="someone-else")
+        resp = await client.post("/webhook", json=body, headers=HEADERS)
+        assert resp.json() == {"status": "ignored", "reason": "self-comment"}
+    finally:
+        del app.state.credential_registry
+
+
+async def test_self_comment_fallback_to_username(client: AsyncClient) -> None:
+    """Without credential_registry, username comparison still works."""
+    app.state.settings = make_settings(agent_gitlab_username=AGENT_USERNAME)
+    body = _note_body_with_user(user_id=NOTE_AUTHOR_USER_ID, username=AGENT_USERNAME)
+    resp = await client.post("/webhook", json=body, headers=HEADERS)
+    assert resp.json() == {"status": "ignored", "reason": "self-comment"}
+
+
+async def test_no_self_comment_when_ids_differ(client: AsyncClient) -> None:
+    """Note from a different user proceeds to queue."""
+    app.state.credential_registry = _make_credential_registry_mock(user_id=AGENT_USER_ID)
+    try:
+        with patch("gitlab_copilot_agent.webhook.handle_copilot_comment"):
+            body = _note_body_with_user(user_id=NOTE_AUTHOR_USER_ID)
+            resp = await client.post("/webhook", json=body, headers=HEADERS)
+            assert resp.json() == {"status": "queued"}
+    finally:
+        del app.state.credential_registry
+
+
+async def test_identity_resolution_failure_falls_through(client: AsyncClient) -> None:
+    """When resolve_identity raises, self-check falls through to username."""
+    app.state.credential_registry = _make_credential_registry_mock(raise_on_resolve=True)
+    app.state.settings = make_settings(agent_gitlab_username=AGENT_USERNAME)
+    try:
+        body = _note_body_with_user(user_id=NOTE_AUTHOR_USER_ID, username=AGENT_USERNAME)
+        resp = await client.post("/webhook", json=body, headers=HEADERS)
+        # Falls through to username check which matches → self-comment
+        assert resp.json() == {"status": "ignored", "reason": "self-comment"}
+    finally:
+        del app.state.credential_registry
+
+
+async def test_identity_resolution_failure_proceeds_when_no_username_match(
+    client: AsyncClient,
+) -> None:
+    """When resolve_identity raises and username doesn't match, note is queued."""
+    app.state.credential_registry = _make_credential_registry_mock(raise_on_resolve=True)
+    try:
+        with patch("gitlab_copilot_agent.webhook.handle_copilot_comment"):
+            body = _note_body_with_user(user_id=NOTE_AUTHOR_USER_ID, username="reviewer")
+            resp = await client.post("/webhook", json=body, headers=HEADERS)
+            assert resp.json() == {"status": "queued"}
+    finally:
+        del app.state.credential_registry


### PR DESCRIPTION
## What

Feature 1 of #321 — foundation for discussion history awareness. Adds structured discussion context extraction, agent identity discovery, and pipeline wiring.

## Why

The MR review agent currently treats each webhook event in isolation. This PR introduces the data models and infrastructure needed for all downstream features: dedup (F2), auto-resolve (F3), question answering (F4), incremental review (F5), etc.

## Changes

### New files
- `discussion_models.py` — Pydantic models: `DiscussionNote`, `Discussion`, `AgentIdentity`, `DiscussionHistory`
- `test_discussion_models.py` — 11 unit tests

### Modified files
- `credential_registry.py` — lazy `AgentIdentity` cache per credential via `GET /user`
- `gitlab_client.py` — `list_mr_discussions()`, `get_current_user()` methods
- `orchestrator.py` — wires discussion fetch + identity into review pipeline (non-fatal on failure)
- `review_engine.py` — accepts `discussion_history` parameter (rendered in Feature 2)
- `webhook.py` — self-comment detection via immutable `user_id` with username fallback
- `config.py` — deprecation warning for `agent_gitlab_username`

### Documentation
- `docs/wiki/data-models.md` — new model documentation
- `docs/wiki/module-reference.md` — `discussion_models.py` entry
- `docs/wiki/request-flows.md` — updated review flow diagram
- `docs/wiki/configuration-reference.md` — `AGENT_GITLAB_USERNAME` deprecated
- `docs/wiki/security-model.md` — per-credential identity caching

### Tests (666 lines, excluded from PR limit)
- 11 model tests, 5 credential registry tests, 6 client tests
- 3 integration tests (pipeline wiring), 2 review engine tests
- 7 webhook tests (self-comment via user_id), 2 config tests
- 2 metrics test fixes (mock `list_mr_discussions`)

## OWASP Self-Review
- [x] Broken Access Control — N/A (no new endpoints)
- [x] Cryptographic Failures — tokens handled via existing secure patterns, never logged
- [x] Injection — python-gitlab parameterized methods throughout
- [x] Insecure Design — immutable `user_id` replaces mutable `username` for identity
- [x] Security Misconfiguration — deprecation warning guides away from fragile config
- [x] Vulnerable Components — no new dependencies
- [x] Authentication — uses existing GITLAB_TOKEN for GET /user
- [x] Data Integrity — frozen Pydantic models prevent mutation
- [x] Logging — only non-sensitive data logged (user_id, username)
- [x] SSRF — gitlab_url from service config, not user input
- [x] Container — no changes

## Code size
- 296 lines code (slightly over 200 — all tightly coupled foundation models + client + identity cache)
- 666 lines tests + 104 lines docs (excluded from limit)

Closes: Part of #321