### PR TITLE
feat(review): render prior feedback in review prompt to prevent duplicates (#321)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ build/
 .env.k3d
 .env.aca
 demo.env
+.copilot-tracking/
 
 # Terraform (S2: state must never be committed)
 .terraform/

--- a/docs/wiki/module-reference.md
+++ b/docs/wiki/module-reference.md
@@ -92,14 +92,17 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 **Purpose**: MR review orchestration — clone, review, parse, post comments.
 
 **Key Functions**:
-- `handle_review(settings: Settings, payload: MergeRequestWebhookPayload, executor: TaskExecutor) -> None`: Full review pipeline with OTEL span and metrics
+- `handle_review(settings: Settings, payload: MergeRequestWebhookPayload, executor: TaskExecutor, project_token: str | None = None, credential_registry: CredentialRegistry | None = None) -> None`: Full review pipeline with OTEL span and metrics
   - Clones repo
-  - Calls `run_review()` via executor
-  - Parses structured review
-  - Fetches MR details and posts comments
+  - Fetches MR details (title, description, diff_refs, changes)
+  - If `credential_registry` provided: fetches discussions via `list_mr_discussions()`, resolves agent identity via `resolve_identity()`, builds `DiscussionHistory`
+  - Builds diff text from MR changes
+  - Calls `run_review()` with diff text and discussion history
+  - Parses structured review via `parse_review()`
+  - Posts comments via `post_review()`
   - Emits `reviews_total` and `reviews_duration` metrics
 
-**Internal Imports**: `config`, `models`, `task_executor`, `gitlab_client`, `review_engine`, `comment_parser`, `comment_poster`, `metrics`, `telemetry`
+**Internal Imports**: `config`, `models`, `task_executor`, `gitlab_client`, `review_engine`, `comment_parser`, `comment_poster`, `metrics`, `telemetry`, `discussion_models`, `credential_registry`
 
 **Depended On By**: `webhook.py`, `gitlab_poller.py`
 
@@ -173,15 +176,21 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 
 **Key Constants**:
 - `REVIEW_SYSTEM_PROMPT: str`: Review system prompt (re-exported from `prompt_defaults.DEFAULT_REVIEW_PROMPT`)
+- `MAX_DIFF_CHARS: int`: Maximum characters of diff to include in the prompt before truncation
+- `_SEVERITY_PREFIX_RE: re.Pattern`: Compiled regex to strip severity prefixes (e.g., `**[WARNING]**`) from comments
+- `_SUGGESTION_BLOCK_RE: re.Pattern`: Compiled regex to strip suggestion code blocks from comments
+- `_PRIOR_FEEDBACK_RULES: str`: Prompt rules instructing the LLM not to duplicate prior feedback
 
 **Key Models**:
 - `ReviewRequest`: MR metadata (title, description, source/target branches)
 
 **Key Functions**:
-- `build_review_prompt(req: ReviewRequest) -> str`: Build user prompt instructing agent to run `git diff`
-- `run_review(executor: TaskExecutor, settings: Settings, repo_path: str, repo_url: str, review_request: ReviewRequest) -> str`: Execute review task and return raw response
+- `build_review_prompt(req: ReviewRequest, diff_text: str | None = None, discussion_history: DiscussionHistory | None = None) -> str`: Build user prompt; includes diff inline when available and injects prior unresolved feedback
+- `run_review(executor: TaskExecutor, settings: Settings, repo_path: str, repo_url: str, review_request: ReviewRequest, diff_text: str | None = None, discussion_history: DiscussionHistory | None = None) -> TaskResult`: Execute review task and return structured result
+- `_format_prior_feedback(history: DiscussionHistory) -> str`: Render the agent's unresolved inline comments as a prompt section (grouped by file, sorted by line)
+- `_strip_comment_formatting(body: str) -> str`: Remove agent-added severity prefix and suggestion blocks from a comment
 
-**Internal Imports**: `config`, `prompt_defaults`, `task_executor`
+**Internal Imports**: `config`, `prompt_defaults`, `task_executor`, `discussion_models` (TYPE_CHECKING)
 
 **Depended On By**: `orchestrator.py`
 
@@ -738,7 +747,7 @@ All use `frozen=True` config.
 | `discussion_orchestrator.py` | Processing | 191 | Unified @mention/thread interaction handler |
 | `discussion_engine.py` | Processing | 147 | Discussion prompt construction & response parsing |
 | `coding_orchestrator.py` | Processing | 142 | Jira task implementation |
-| `review_engine.py` | Processing | 91 | Review prompt construction |
+| `review_engine.py` | Processing | 160 | Review prompt construction |
 | `coding_engine.py` | Processing | 109 | Coding prompt construction |
 | `prompt_defaults.py` | Processing | 164 | System prompt defaults & resolution |
 | `task_executor.py` | Execution | 53 | TaskExecutor protocol |
@@ -763,4 +772,4 @@ All use `frozen=True` config.
 | `process_sandbox.py` | Utils | 20 | CLI path resolution |
 | `plugin_manager.py` | Utils | 88 | Plugin installation |
 
-**Total: 33 modules, ~3,856 lines of code**
+**Total: 33 modules, ~3,925 lines of code**

--- a/docs/wiki/request-flows.md
+++ b/docs/wiki/request-flows.md
@@ -52,6 +52,8 @@ sequenceDiagram
     
     ORCH->>ORCH: Build DiscussionHistory(discussions, agent)
     
+    Note over ORCH: build_review_prompt() renders<br/>prior feedback into prompt
+    
     ORCH->>EXEC: execute(TaskParams: review)
     alt LocalTaskExecutor
         EXEC->>COP: run_copilot_session(repo_path, prompts)

--- a/src/gitlab_copilot_agent/review_engine.py
+++ b/src/gitlab_copilot_agent/review_engine.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+from collections import defaultdict
 from typing import TYPE_CHECKING
 
 import structlog
@@ -20,6 +22,18 @@ log = structlog.get_logger()
 # truncated and the LLM is told to run git diff for the full picture.
 MAX_DIFF_CHARS = 120_000
 
+_SEVERITY_PREFIX_RE = re.compile(r"^\*\*\[(?:ERROR|WARNING|INFO)\]\*\*\s*")
+_SUGGESTION_BLOCK_RE = re.compile(r"\n\n```suggestion.*?```", re.DOTALL)
+# ↑ Formats coupled with comment_poster.py:89-93 — update in lockstep.
+
+_PRIOR_FEEDBACK_RULES = """\
+Rules:
+- Do NOT generate any comment that covers the same issue as any item \
+in Agent's Prior Feedback, even if line numbers have shifted.
+- If the code has changed but the underlying issue remains, the prior \
+feedback still applies — do not re-comment.\
+"""
+
 REVIEW_SYSTEM_PROMPT = DEFAULT_REVIEW_PROMPT
 
 
@@ -31,6 +45,65 @@ class ReviewRequest(BaseModel):
     description: str | None = Field(description="MR description")
     source_branch: str = Field(description="Source branch name")
     target_branch: str = Field(description="Target branch name")
+
+
+def _strip_comment_formatting(body: str) -> str:
+    """Remove agent-added severity prefix and suggestion blocks from a comment."""
+    body = _SEVERITY_PREFIX_RE.sub("", body)
+    body = _SUGGESTION_BLOCK_RE.sub("", body)
+    return body.strip()
+
+
+def _format_prior_feedback(history: DiscussionHistory) -> str:
+    """Render the agent's unresolved inline comments as a prompt section.
+
+    Returns the complete section (header + grouped comments + rules) or an
+    empty string when no qualifying comments exist.
+    """
+    comments_by_file: dict[str, list[tuple[int | None, str]]] = defaultdict(list)
+
+    for disc in history.discussions:
+        if disc.is_resolved or not disc.is_inline:
+            continue
+        if not disc.notes:
+            continue
+        first_note = disc.notes[0]
+        if first_note.author_id != history.agent.user_id:
+            continue
+
+        position = first_note.position or {}
+        raw_path = position.get("new_path")
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            continue
+        file_path = raw_path
+
+        raw_line = position.get("new_line")
+        line_num: int | None = None
+        if isinstance(raw_line, int):
+            line_num = raw_line
+        elif isinstance(raw_line, str):
+            try:
+                line_num = int(raw_line)
+            except ValueError:
+                line_num = None
+        body = _strip_comment_formatting(first_note.body)
+        comments_by_file[file_path].append((line_num, body))
+
+    if not comments_by_file:
+        return ""
+
+    lines = ["## Agent's Prior Feedback (Unresolved)\n"]
+    for file_path in sorted(comments_by_file):
+        lines.append(f"### {file_path}")
+        for line_num, body in sorted(
+            comments_by_file[file_path], key=lambda c: (c[0] is None, c[0] or 0)
+        ):
+            prefix = f"Line {line_num}" if line_num is not None else "General"
+            lines.append(f"- {prefix}: {body}")
+        lines.append("")  # blank line between files
+
+    lines.append(_PRIOR_FEEDBACK_RULES)
+    return "\n".join(lines)
 
 
 def build_review_prompt(
@@ -61,6 +134,11 @@ def build_review_prompt(
             f"Run `git diff {req.target_branch}...{req.source_branch}` to see "
             f"the changes, then read relevant files for context."
         )
+
+    if discussion_history:
+        prior_section = _format_prior_feedback(discussion_history)
+        if prior_section:
+            prompt += f"\n\n{prior_section}"
     return prompt
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,12 @@ from httpx import ASGITransport, AsyncClient
 from gitlab_copilot_agent.config import Settings
 from gitlab_copilot_agent.gitlab_client import MRChange, MRDiffRef
 from gitlab_copilot_agent.main import app
+from gitlab_copilot_agent.models import (
+    MergeRequestWebhookPayload,
+    MRObjectAttributes,
+    WebhookProject,
+    WebhookUser,
+)
 from gitlab_copilot_agent.task_executor import LocalTaskExecutor
 
 # -- Constants --
@@ -119,6 +125,17 @@ def make_mr_changes(file_path: str = "src/main.py", diff: str = SAMPLE_DIFF) -> 
             renamed_file=False,
         )
     ]
+
+
+def make_webhook_payload(**attr_overrides: Any) -> MergeRequestWebhookPayload:
+    """Create a typed MR webhook payload. Override object_attributes fields."""
+    attrs = {**MR_PAYLOAD["object_attributes"], **attr_overrides}
+    return MergeRequestWebhookPayload(
+        object_kind="merge_request",
+        user=WebhookUser(**MR_PAYLOAD["user"]),
+        project=WebhookProject(**MR_PAYLOAD["project"]),
+        object_attributes=MRObjectAttributes(**attrs),
+    )
 
 
 # -- Fixtures --

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -12,13 +12,6 @@ from gitlab_copilot_agent.discussion_models import (
     DiscussionNote,
 )
 from gitlab_copilot_agent.gitlab_client import MRDetails
-from gitlab_copilot_agent.models import (
-    MergeRequestWebhookPayload,
-    MRLastCommit,
-    MRObjectAttributes,
-    WebhookProject,
-    WebhookUser,
-)
 from gitlab_copilot_agent.orchestrator import handle_review
 from gitlab_copilot_agent.task_executor import ReviewResult
 from tests.conftest import (
@@ -30,7 +23,9 @@ from tests.conftest import (
     MR_IID,
     MR_PAYLOAD,
     PROJECT_ID,
+    make_mr_changes,
     make_settings,
+    make_webhook_payload,
 )
 
 
@@ -109,28 +104,8 @@ async def test_orchestrator_cleans_up_on_error(
     mock_gl_instance.get_mr_details = AsyncMock(side_effect=RuntimeError("SDK crashed"))
     mock_gl_instance.cleanup = AsyncMock()
 
-    payload = MergeRequestWebhookPayload(
-        object_kind="merge_request",
-        user=WebhookUser(id=1, username="jdoe"),
-        project=WebhookProject(
-            id=PROJECT_ID,
-            path_with_namespace="group/my-project",
-            git_http_url="https://gitlab.example.com/group/my-project.git",
-        ),
-        object_attributes=MRObjectAttributes(
-            iid=MR_IID,
-            title="Add feature",
-            description="Implements X",
-            action="open",
-            source_branch="feature/x",
-            target_branch="main",
-            last_commit=MRLastCommit(id="abc123", message="feat: add X"),
-            url="https://gitlab.example.com/group/my-project/-/merge_requests/7",
-        ),
-    )
-
     with pytest.raises(RuntimeError, match="SDK crashed"):
-        await handle_review(make_settings(), payload, AsyncMock())
+        await handle_review(make_settings(), make_webhook_payload(), AsyncMock())
 
     mock_gl_instance.cleanup.assert_awaited_once()
 
@@ -177,28 +152,6 @@ _SAMPLE_DISCUSSIONS = [
 ]
 
 
-def _make_payload() -> MergeRequestWebhookPayload:
-    return MergeRequestWebhookPayload(
-        object_kind="merge_request",
-        user=WebhookUser(id=1, username="jdoe"),
-        project=WebhookProject(
-            id=PROJECT_ID,
-            path_with_namespace="group/my-project",
-            git_http_url="https://gitlab.example.com/group/my-project.git",
-        ),
-        object_attributes=MRObjectAttributes(
-            iid=MR_IID,
-            title="Add feature",
-            description="Implements X",
-            action="open",
-            source_branch="feature/x",
-            target_branch="main",
-            last_commit=MRLastCommit(id="abc123", message="feat: add X"),
-            url="https://gitlab.example.com/group/my-project/-/merge_requests/7",
-        ),
-    )
-
-
 @patch("gitlab_copilot_agent.orchestrator.post_review", new_callable=AsyncMock)
 @patch("gitlab_copilot_agent.orchestrator.run_review", new_callable=AsyncMock)
 @patch("gitlab_copilot_agent.orchestrator.GitLabClient")
@@ -217,7 +170,7 @@ async def test_discussion_history_passed_with_credential_registry(
 
     await handle_review(
         make_settings(),
-        _make_payload(),
+        make_webhook_payload(),
         AsyncMock(),
         credential_registry=mock_registry,
     )
@@ -245,7 +198,7 @@ async def test_discussion_history_none_without_credential_registry(
     """Without credential_registry, discussion_history is None."""
     _setup_mocks(mock_client_class, mock_run_review)
 
-    await handle_review(make_settings(), _make_payload(), AsyncMock())
+    await handle_review(make_settings(), make_webhook_payload(), AsyncMock())
 
     review_kwargs = mock_run_review.call_args[1]
     assert review_kwargs["discussion_history"] is None
@@ -269,7 +222,7 @@ async def test_discussion_history_failure_is_non_fatal(
 
     await handle_review(
         make_settings(),
-        _make_payload(),
+        make_webhook_payload(),
         AsyncMock(),
         credential_registry=mock_registry,
     )
@@ -298,7 +251,7 @@ async def test_discussion_threads_flow_through_pipeline(
 
     await handle_review(
         make_settings(),
-        _make_payload(),
+        make_webhook_payload(),
         AsyncMock(),
         credential_registry=mock_registry,
     )
@@ -329,3 +282,53 @@ async def test_discussion_threads_flow_through_pipeline(
     # Verify agent can distinguish own comments
     assert root.author_id == history.agent.user_id
     assert reply.author_id != history.agent.user_id
+
+
+@patch("gitlab_copilot_agent.orchestrator.post_review", new_callable=AsyncMock)
+@patch("gitlab_copilot_agent.orchestrator.GitLabClient")
+@patch("gitlab_copilot_agent.orchestrator.gitlab.Gitlab")
+async def test_prior_feedback_rendered_in_prompt(
+    mock_gl_class: MagicMock,
+    mock_client_class: MagicMock,
+    mock_post_review: AsyncMock,
+) -> None:
+    """Prior agent comments flow through orchestrator into the review prompt.
+
+    Unlike other integration tests that patch run_review, this test lets
+    run_review execute with a mock executor so we can inspect the actual
+    user_prompt in TaskParams — verifying the full chain:
+    orchestrator → run_review → build_review_prompt → prior feedback in prompt.
+    """
+    mock_gl_instance = mock_client_class.return_value
+    mock_gl_instance.clone_repo = AsyncMock(return_value="/tmp/fake-repo")
+    mock_gl_instance.cleanup = AsyncMock()
+    mock_gl_instance.get_mr_details = AsyncMock(
+        return_value=MRDetails(
+            title="Add feature",
+            description="Implements X",
+            diff_refs=DIFF_REFS,
+            changes=make_mr_changes(),
+        )
+    )
+    mock_gl_instance.list_mr_discussions = AsyncMock(return_value=_SAMPLE_DISCUSSIONS)
+
+    mock_executor = AsyncMock()
+    mock_executor.execute.return_value = ReviewResult(summary=FAKE_REVIEW_OUTPUT)
+
+    mock_registry = AsyncMock()
+    mock_registry.resolve_identity = AsyncMock(return_value=_AGENT_IDENTITY)
+
+    await handle_review(
+        make_settings(),
+        make_webhook_payload(),
+        mock_executor,
+        credential_registry=mock_registry,
+    )
+
+    # Inspect the TaskParams passed to the executor
+    task_params = mock_executor.execute.call_args[0][0]
+    prompt = task_params.user_prompt
+
+    assert "## Agent's Prior Feedback (Unresolved)" in prompt
+    assert "Consider adding a null check here." in prompt
+    assert "src/app.py" in prompt

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -11,24 +11,15 @@ from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 
 from gitlab_copilot_agent import metrics as app_metrics
 from gitlab_copilot_agent.gitlab_client import MRDetails
-from gitlab_copilot_agent.models import (
-    MergeRequestWebhookPayload,
-    MRLastCommit,
-    MRObjectAttributes,
-    WebhookProject,
-    WebhookUser,
-)
 from gitlab_copilot_agent.orchestrator import handle_review
 from gitlab_copilot_agent.task_executor import ReviewResult, TaskExecutionError
 from tests.conftest import (
     DIFF_REFS,
-    EXAMPLE_CLONE_URL,
     FAKE_REVIEW_OUTPUT,
     HEADERS,
-    MR_IID,
     MR_PAYLOAD,
-    PROJECT_ID,
     make_settings,
+    make_webhook_payload,
 )
 
 
@@ -115,28 +106,6 @@ def test_copilot_session_duration_records_task_type() -> None:
 # These patch the metric instruments at the call site to verify recording.
 
 
-def _make_payload() -> MergeRequestWebhookPayload:
-    return MergeRequestWebhookPayload(
-        object_kind="merge_request",
-        user=WebhookUser(id=1, username="jdoe"),
-        project=WebhookProject(
-            id=PROJECT_ID,
-            path_with_namespace="group/project",
-            git_http_url=EXAMPLE_CLONE_URL,
-        ),
-        object_attributes=MRObjectAttributes(
-            iid=MR_IID,
-            title="Add feature",
-            description="Implements X",
-            action="open",
-            source_branch="feature/x",
-            target_branch="main",
-            last_commit=MRLastCommit(id="abc123", message="feat: add X"),
-            url=f"{EXAMPLE_CLONE_URL.replace('.git', '')}/-/merge_requests/{MR_IID}",
-        ),
-    )
-
-
 @patch("gitlab_copilot_agent.orchestrator.post_review", new_callable=AsyncMock)
 @patch("gitlab_copilot_agent.orchestrator.run_review", new_callable=AsyncMock)
 @patch("gitlab_copilot_agent.orchestrator.GitLabClient")
@@ -163,7 +132,7 @@ async def test_review_pipeline_records_success_metrics(
         patch("gitlab_copilot_agent.orchestrator.reviews_total", mock_total),
         patch("gitlab_copilot_agent.orchestrator.reviews_duration", mock_duration),
     ):
-        await handle_review(make_settings(), _make_payload(), AsyncMock())
+        await handle_review(make_settings(), make_webhook_payload(), AsyncMock())
 
     mock_total.add.assert_called_once_with(1, {"outcome": "success"})
     mock_duration.record.assert_called_once()
@@ -193,7 +162,7 @@ async def test_review_pipeline_records_error_metrics(
         patch("gitlab_copilot_agent.orchestrator.reviews_duration", mock_duration),
         pytest.raises(RuntimeError),
     ):
-        await handle_review(make_settings(), _make_payload(), AsyncMock())
+        await handle_review(make_settings(), make_webhook_payload(), AsyncMock())
 
     mock_total.add.assert_called_once_with(1, {"outcome": "error"})
     mock_duration.record.assert_called_once()
@@ -219,7 +188,7 @@ async def test_review_task_execution_failure_posts_comment_without_raising(
     mock_run_review.side_effect = TaskExecutionError("Task failed: runner error")
 
     with pytest.raises(TaskExecutionError, match="runner error"):
-        await handle_review(make_settings(), _make_payload(), AsyncMock())
+        await handle_review(make_settings(), make_webhook_payload(), AsyncMock())
 
     mock_gl.post_mr_comment.assert_awaited_once()
     comment = mock_gl.post_mr_comment.call_args[0][2]

--- a/tests/test_review_engine.py
+++ b/tests/test_review_engine.py
@@ -2,14 +2,74 @@
 
 from unittest.mock import AsyncMock
 
-from gitlab_copilot_agent.discussion_models import AgentIdentity, DiscussionHistory
+from gitlab_copilot_agent.discussion_models import (
+    AgentIdentity,
+    Discussion,
+    DiscussionHistory,
+    DiscussionNote,
+)
 from gitlab_copilot_agent.prompt_defaults import get_prompt
 from gitlab_copilot_agent.review_engine import (
     ReviewRequest,
+    _format_prior_feedback,
     build_review_prompt,
     run_review,
 )
 from tests.conftest import EXAMPLE_CLONE_URL, make_settings
+
+# -- Agent note & discussion helpers for prior-feedback tests --
+AGENT_USER_ID = 100
+AGENT_USERNAME = "copilot-bot"
+
+
+def _make_agent_note(
+    note_id: int = 1,
+    author_id: int = AGENT_USER_ID,
+    body: str = "**[WARNING]** Consider error handling",
+    resolved: bool | None = False,
+    file_path: str = "src/main.py",
+    line: int = 42,
+) -> DiscussionNote:
+    return DiscussionNote(
+        note_id=note_id,
+        author_id=author_id,
+        author_username="bot",
+        body=body,
+        created_at="2026-04-06T12:00:00Z",
+        is_system=False,
+        resolved=resolved,
+        resolvable=True,
+        position={
+            "new_path": file_path,
+            "new_line": line,
+            "old_path": file_path,
+            "old_line": None,
+        },
+    )
+
+
+def _make_discussion(
+    discussion_id: str = "disc-1",
+    notes: list[DiscussionNote] | None = None,
+    is_resolved: bool = False,
+    is_inline: bool = True,
+) -> Discussion:
+    return Discussion(
+        discussion_id=discussion_id,
+        notes=notes or [],
+        is_resolved=is_resolved,
+        is_inline=is_inline,
+    )
+
+
+def _make_history(
+    discussions: list[Discussion] | None = None,
+    agent_user_id: int = AGENT_USER_ID,
+) -> DiscussionHistory:
+    return DiscussionHistory(
+        discussions=discussions or [],
+        agent=AgentIdentity(user_id=agent_user_id, username=AGENT_USERNAME),
+    )
 
 
 def _make_request() -> ReviewRequest:
@@ -54,17 +114,19 @@ async def test_run_review_delegates_to_executor() -> None:
     assert "git diff main...feature/x" in task.user_prompt
 
 
-def test_build_review_prompt_accepts_discussion_history() -> None:
-    """discussion_history param is accepted without affecting output (Feature 2 will render it)."""
-    req = _make_request()
-    history = DiscussionHistory(
-        discussions=[],
-        agent=AgentIdentity(user_id=1, username="bot"),
+def test_build_review_prompt_includes_prior_feedback() -> None:
+    """Unresolved agent comments appear in the prompt as prior feedback."""
+    note = _make_agent_note(body="**[WARNING]** Consider error handling")
+    disc = _make_discussion(notes=[note])
+    history = _make_history(discussions=[disc])
+
+    prompt = build_review_prompt(
+        _make_request(), diff_text="some diff", discussion_history=history
     )
-    prompt_with = build_review_prompt(req, discussion_history=history)
-    prompt_without = build_review_prompt(req)
-    # Until Feature 2, discussion_history does not change the prompt
-    assert prompt_with == prompt_without
+
+    assert "## Agent's Prior Feedback (Unresolved)" in prompt
+    assert "Consider error handling" in prompt
+    assert "Review ONLY" in prompt
 
 
 async def test_run_review_forwards_discussion_history() -> None:
@@ -90,3 +152,172 @@ async def test_run_review_forwards_discussion_history() -> None:
     assert result == "Review result"
     # Verify executor was called (prompt content tested separately)
     mock_executor.execute.assert_awaited_once()
+
+
+# -- _format_prior_feedback unit tests --
+
+
+def test_format_prior_feedback_groups_by_file() -> None:
+    """Comments are grouped by file and sorted by line number."""
+    notes = [
+        _make_agent_note(note_id=1, body="Issue A", file_path="src/b.py", line=10),
+        _make_agent_note(note_id=2, body="Issue B", file_path="src/a.py", line=5),
+        _make_agent_note(note_id=3, body="Issue C", file_path="src/a.py", line=1),
+    ]
+    discussions = [_make_discussion(discussion_id=f"d{i}", notes=[n]) for i, n in enumerate(notes)]
+    history = _make_history(discussions=discussions)
+
+    result = _format_prior_feedback(history)
+
+    # File a.py appears before b.py (sorted)
+    assert result.index("src/a.py") < result.index("src/b.py")
+    # Within a.py, line 1 appears before line 5
+    assert result.index("Line 1") < result.index("Line 5")
+    assert "Issue A" in result
+    assert "Issue B" in result
+    assert "Issue C" in result
+
+
+def test_format_prior_feedback_excludes_resolved() -> None:
+    """Resolved discussions produce no output."""
+    note = _make_agent_note()
+    disc = _make_discussion(notes=[note], is_resolved=True)
+    history = _make_history(discussions=[disc])
+
+    assert _format_prior_feedback(history) == ""
+
+
+def test_format_prior_feedback_excludes_human_comments() -> None:
+    """Discussions authored by humans (non-agent) produce no output."""
+    note = _make_agent_note(author_id=999)
+    disc = _make_discussion(notes=[note])
+    history = _make_history(discussions=[disc])
+
+    assert _format_prior_feedback(history) == ""
+
+
+def test_format_prior_feedback_excludes_overview_notes() -> None:
+    """Non-inline (overview) discussions produce no output."""
+    note = _make_agent_note()
+    disc = _make_discussion(notes=[note], is_inline=False)
+    history = _make_history(discussions=[disc])
+
+    assert _format_prior_feedback(history) == ""
+
+
+def test_format_prior_feedback_strips_severity_prefix() -> None:
+    """Severity prefixes like **[WARNING]** are removed from output."""
+    note = _make_agent_note(body="**[WARNING]** Consider error handling")
+    disc = _make_discussion(notes=[note])
+    history = _make_history(discussions=[disc])
+
+    result = _format_prior_feedback(history)
+
+    assert "Consider error handling" in result
+    assert "**[WARNING]**" not in result
+
+
+def test_format_prior_feedback_strips_suggestion_blocks() -> None:
+    """Suggestion code blocks are removed from output."""
+    body = "Fix the return type\n\n```suggestion:-0+0\nreturn None\n```"
+    note = _make_agent_note(body=body)
+    disc = _make_discussion(notes=[note])
+    history = _make_history(discussions=[disc])
+
+    result = _format_prior_feedback(history)
+
+    assert "Fix the return type" in result
+    assert "```suggestion" not in result
+    assert "return None" not in result
+
+
+def test_format_prior_feedback_empty_history() -> None:
+    """Empty discussions list produces no output."""
+    history = _make_history(discussions=[])
+
+    assert _format_prior_feedback(history) == ""
+
+
+# -- build_review_prompt integration tests --
+
+
+def test_build_review_prompt_omits_prior_feedback_when_none() -> None:
+    """No prior feedback section when discussion_history is None."""
+    prompt = build_review_prompt(_make_request(), diff_text="some diff")
+
+    assert "Prior Feedback" not in prompt
+    assert "Review ONLY" in prompt
+
+
+def test_build_review_prompt_omits_prior_feedback_when_all_resolved() -> None:
+    """No prior feedback section when all discussions are resolved."""
+    note = _make_agent_note()
+    disc = _make_discussion(notes=[note], is_resolved=True)
+    history = _make_history(discussions=[disc])
+
+    prompt = build_review_prompt(
+        _make_request(), diff_text="some diff", discussion_history=history
+    )
+
+    assert "Prior Feedback" not in prompt
+    assert "Review ONLY" in prompt
+
+
+def test_build_review_prompt_includes_prior_feedback_without_diff() -> None:
+    """Prior feedback renders even when diff_text is not provided."""
+    note = _make_agent_note(body="**[WARNING]** Consider error handling")
+    disc = _make_discussion(notes=[note])
+    history = _make_history(discussions=[disc])
+
+    prompt = build_review_prompt(_make_request(), discussion_history=history)
+
+    assert "## Agent's Prior Feedback (Unresolved)" in prompt
+    assert "Consider error handling" in prompt
+    assert "git diff" in prompt
+
+
+def test_format_prior_feedback_skips_none_new_path() -> None:
+    """Notes with new_path=None are excluded (not rendered as 'None')."""
+    note = _make_agent_note()
+    # Override position to have None new_path
+    note_dict = note.model_dump()
+    note_dict["position"]["new_path"] = None
+    patched_note = DiscussionNote(**note_dict)
+    disc = _make_discussion(notes=[patched_note])
+    history = _make_history(discussions=[disc])
+
+    assert _format_prior_feedback(history) == ""
+
+
+def test_format_prior_feedback_handles_non_numeric_line() -> None:
+    """Non-numeric new_line degrades to 'General', not a crash."""
+    note = _make_agent_note()
+    note_dict = note.model_dump()
+    note_dict["position"]["new_line"] = "not-a-number"
+    patched_note = DiscussionNote(**note_dict)
+    disc = _make_discussion(notes=[patched_note])
+    history = _make_history(discussions=[disc])
+
+    result = _format_prior_feedback(history)
+
+    assert "General:" in result
+    assert "Consider error handling" in result
+
+
+def test_format_prior_feedback_skips_null_position() -> None:
+    """Notes with position=None are excluded entirely."""
+    note = DiscussionNote(
+        note_id=1,
+        author_id=AGENT_USER_ID,
+        author_username="bot",
+        body="**[WARNING]** Some issue",
+        created_at="2026-04-06T12:00:00Z",
+        is_system=False,
+        resolved=False,
+        resolvable=True,
+        position=None,
+    )
+    disc = _make_discussion(notes=[note])
+    history = _make_history(discussions=[disc])
+
+    assert _format_prior_feedback(history) == ""


### PR DESCRIPTION
## What

Implements Feature 2 of #321 — "Don't Duplicate Feedback Already Given". When the agent re-reviews an MR after new commits, its prior unresolved inline comments are injected into the review prompt so the LLM avoids posting duplicate feedback.

## How

- Added `_format_prior_feedback()` and `_strip_comment_formatting()` to `review_engine.py`
- Prior feedback is filtered to agent-authored, unresolved, inline discussions only
- Comments are grouped by file path (alphabetical) with line numbers
- Severity prefixes and suggestion blocks are stripped before injection
- `_PRIOR_FEEDBACK_RULES` instructs the LLM to skip duplicate feedback
- Prior feedback renders regardless of whether diff is inline or manual
- Section omitted entirely when no qualifying comments exist

## Also in this PR

- Updated `orchestrator.py` docs with full `handle_review()` signature and discussion-history pipeline
- Added `make_webhook_payload()` factory to `conftest.py`, DRY-refactored 3 test files
- Added cross-reference comment between review_engine regex patterns and comment_poster formatting

## Testing

- 18 unit tests + 1 integration test, `review_engine.py` at 96% coverage
- 641 tests passing, 92.53% project coverage
- Code reviewed by GPT-5.4 (cross-vendor), OWASP security review passed
