### PR TITLE
feat(resolution): add configurable auto-resolution of addressed feedback (#321)

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -67,6 +67,32 @@ jobs:
           echo "::error::Controller revision did not become healthy after 5 minutes"
           exit 1
 
+      - name: Verify deployed image versions
+        env:
+          EXPECTED_TAG: pr-${{ github.event.pull_request.number || github.run_number }}-${{ github.sha }}
+        run: |
+          echo "Expected image tag: ${EXPECTED_TAG}"
+
+          controller_image=$(az containerapp show \
+            -g rg-copilot-dev -n ca-controller \
+            --query 'properties.template.containers[0].image' -o tsv)
+          echo "Controller image: ${controller_image}"
+          if [[ "$controller_image" != *"${EXPECTED_TAG}"* ]]; then
+            echo "::error::Controller is running wrong image. Expected tag '${EXPECTED_TAG}' but got '${controller_image}'"
+            exit 1
+          fi
+          echo "✓ Controller image verified"
+
+          job_image=$(az containerapp job show \
+            -g rg-copilot-dev -n job-task-runner \
+            --query 'properties.template.containers[0].image' -o tsv)
+          echo "Task runner job image: ${job_image}"
+          if [[ "$job_image" != *"${EXPECTED_TAG}"* ]]; then
+            echo "::error::Task runner job is running wrong image. Expected tag '${EXPECTED_TAG}' but got '${job_image}'"
+            exit 1
+          fi
+          echo "✓ Task runner job image verified"
+
   integration-test:
     needs: [deploy, smoke-test]
     if: >-
@@ -82,7 +108,10 @@ jobs:
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
       - name: Record test start time
         id: test-time
-        run: echo "start=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+        run: |
+          # Use deploy completion time (smoke-test start) as lookback origin
+          # so we capture review task runner pods that finish before test timeout
+          echo "start=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Run ACA integration tests
         env:
@@ -98,7 +127,7 @@ jobs:
         run: uv run python tests/e2e/aca_integration.py
 
       - name: Azure login (for log collection)
-        if: failure()
+        if: always()
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
@@ -106,20 +135,28 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Collect ACA logs
-        if: failure()
+        if: always()
         env:
           TEST_START: ${{ steps.test-time.outputs.start }}
         run: |
           mkdir -p /tmp/aca-logs
           echo "Collecting logs since ${TEST_START}"
 
-          # Controller live logs (capped at 300 lines by Azure CLI)
+          # Controller live logs (best-effort, last 300 lines only)
           az containerapp logs show \
             -n ca-controller -g rg-copilot-dev \
             --type console --tail 300 \
             > /tmp/aca-logs/controller-live.log 2>&1 || true
 
-          # Task runner job execution logs — executions started during this test run
+          # List all task runner job executions since test start (shows review + coding pods)
+          az containerapp job execution list \
+            -g rg-copilot-dev -n job-task-runner \
+            --query "[?properties.startTime>='${TEST_START}'].{name:name, status:properties.status, startTime:properties.startTime, endTime:properties.endTime}" \
+            -o table \
+            > /tmp/aca-logs/job-executions.log 2>&1 || true
+
+          # Task runner job execution logs — all executions since deploy
+          # (review pods may complete before test timeout, so broaden the window)
           for exec_name in $(az containerapp job execution list \
             -g rg-copilot-dev -n job-task-runner \
             --query "[?properties.startTime>='${TEST_START}'].name" \
@@ -131,7 +168,10 @@ jobs:
               > "/tmp/aca-logs/job-${exec_name}.log" 2>&1 || true
           done
 
-          # Full logs from Log Analytics (not truncated, survives pod cleanup)
+          # Full logs from Log Analytics (primary source — not truncated, survives pod cleanup)
+          # Wait for LA ingestion lag (typically 2-5 min, but can be longer)
+          echo "Waiting 60s for Log Analytics ingestion..."
+          sleep 60
           LA_WORKSPACE=$(az containerapp env show \
             -g rg-copilot-dev -n cae-rg-copilot-dev \
             --query 'properties.appLogsConfiguration.logAnalyticsConfiguration.customerId' \
@@ -176,7 +216,7 @@ jobs:
           ls -la /tmp/aca-logs/
 
       - name: Upload logs
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: aca-e2e-logs

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ make k3d-deploy                 # deploy via Helm
 | `GITLAB_POLL_INTERVAL` | `30` | Polling interval in seconds |
 | `GITLAB_POLL_LOOKBACK` | `60` | Minutes to look back on startup for recent MRs |
 | `GITLAB_REVIEW_ON_PUSH` | `true` | Re-review MRs on each new commit. Set `false` to review once per MR |
+| `RESOLUTION_BEHAVIOR` | `suggest` | How to handle addressed feedback: `auto-resolve`, `suggest`, or `off` |
 | `GITLAB_PROJECTS` | `None` | Comma-separated project paths/IDs (required when polling) |
 
 ### Task Execution

--- a/docs/wiki/architecture-overview.md
+++ b/docs/wiki/architecture-overview.md
@@ -95,8 +95,8 @@ graph TB
 
 ### 2. Processing Layer
 - **`orchestrator.py`**: MR review orchestration (clone → review → parse → post)
-- **`discussion_orchestrator.py`**: Unified @mention/thread interaction handler (clone → fetch context → LLM → reply ± commit/push)
-- **`discussion_engine.py`**: Discussion prompt construction, structured response parsing (intent + reply + optional code changes)
+- **`discussion_orchestrator.py`**: Unified @mention/thread interaction handler (clone → fetch context → LLM → reply ± commit/push ± resolve feedback)
+- **`discussion_engine.py`**: Discussion prompt construction, structured response parsing (reply + optional code changes + optional resolution)
 - **`coding_orchestrator.py`**: Jira issue implementation (clone → code → apply result → branch → MR)
 - **`coding_workflow.py`**: Shared helper for applying coding results (diff passback from k8s pods)
 - **`review_engine.py`**: Review prompt construction and execution
@@ -110,13 +110,13 @@ graph TB
 - **`task_runner.py`**: K8s Job entrypoint (`python -m gitlab_copilot_agent.task_runner`)
 
 ### 4. External Service Clients
-- **`gitlab_client.py`**: GitLab REST API (MR details, comments, clone, create MR)
+- **`gitlab_client.py`**: GitLab REST API (MR details, comments, clone, create MR, resolve/reply to discussions)
 - **`jira_client.py`**: Jira REST API v3 (search, transitions, comments)
 
 ### 5. Shared Utilities
 - **`git_operations.py`**: Git CLI wrappers (clone, branch, commit, push)
-- **`comment_parser.py`**: Extract structured review from agent output
-- **`comment_poster.py`**: Post inline discussions to GitLab MR
+- **`comment_parser.py`**: Extract structured review (comments + resolutions) from agent output
+- **`comment_poster.py`**: Post inline discussions to GitLab MR, handle resolution actions for prior feedback
 - **`repo_config.py`**: Discover repo-level skills, agents, instructions
 
 ### 6. State & Concurrency

--- a/docs/wiki/configuration-reference.md
+++ b/docs/wiki/configuration-reference.md
@@ -315,6 +315,17 @@ Only used when `TASK_EXECUTOR=container_apps`.
 - **Default**: `True`
 - **Description**: When `true` (default), the agent re-reviews an MR each time a new commit is pushed. When `false`, each MR is reviewed only once regardless of subsequent commits. Useful for reducing noise when developers iterate frequently on an MR.
 
+### `RESOLUTION_BEHAVIOR`
+- **Type**: `str`
+- **Required**: ❌ No
+- **Default**: `"suggest"`
+- **Description**: Controls how the agent handles its prior feedback that has been addressed by new commits or developer replies. Three modes:
+  - `auto-resolve`: Resolves the thread via GitLab API with an acknowledgment reply (✅)
+  - `suggest`: Posts an acknowledgment reply but leaves the thread open for manual review (default)
+  - `off`: Takes no action on addressed feedback
+- **Per-project override**: Yes, via `resolution_behavior` in mapping YAML bindings
+- **Note**: Partially addressed feedback is never auto-resolved regardless of this setting
+
 ---
 
 ## Jira Integration
@@ -445,6 +456,26 @@ The global env vars `JIRA_TRIGGER_STATUS`, `JIRA_IN_PROGRESS_STATUS`, and
 `JIRA_IN_REVIEW_STATUS` act as a fallback when no YAML mapping is used. When a
 YAML mapping is present the per-binding (or per-defaults) values always take
 precedence.
+
+### Per-Project Resolution Behavior
+
+The `resolution_behavior` can be overridden per binding in the YAML mapping file:
+
+```yaml
+defaults:
+  resolution_behavior: suggest  # default for all projects
+
+bindings:
+  - jira_project: PROJ
+    repo: group/service-a
+    resolution_behavior: auto-resolve  # this team wants auto-resolution
+  - jira_project: OPS
+    repo: group/platform-tools
+    resolution_behavior: "off"  # this team manages threads manually
+```
+
+When a YAML mapping is present, the per-binding value takes precedence over the
+`RESOLUTION_BEHAVIOR` env var.
 
 ### Rendered JSON (env var value)
 
@@ -612,6 +643,8 @@ JIRA_IN_REVIEW_STATUS="In Review"
 JIRA_POLL_INTERVAL=30
 JIRA_PROJECT_MAP='{"mappings":{"PROJ":{"repo":"group/project","target_branch":"main","credential_ref":"default"}}}'
 
+RESOLUTION_BEHAVIOR=suggest
+
 OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
 SERVICE_VERSION=1.0.0
 DEPLOYMENT_ENV=production
@@ -686,6 +719,7 @@ Helm `values.yaml` maps to env vars via `configmap.yaml` and `secret.yaml`:
 | `jira.inProgressStatus` | `JIRA_IN_PROGRESS_STATUS` | ❌ |
 | `jira.inReviewStatus` | `JIRA_IN_REVIEW_STATUS` | ❌ |
 | `jira.pollInterval` | `JIRA_POLL_INTERVAL` | ❌ |
+| `controller.resolutionBehavior` | `RESOLUTION_BEHAVIOR` | ❌ |
 | `extraEnv` | (arbitrary key-value pairs) | ❌ |
 | `hostAliases` | `K8S_JOB_HOST_ALIASES` (JSON for Job pods) | ❌ |
 | `hostAliases` | Pod `/etc/hosts` entries (controller pod) | ❌ |

--- a/docs/wiki/data-models.md
+++ b/docs/wiki/data-models.md
@@ -389,13 +389,27 @@ See [configuration-reference.md](configuration-reference.md) for all fields.
 
 ---
 
-### `ParsedReview`
-**Purpose**: Structured review output with comments and a summary.
+### `Resolution`
+**Purpose**: A resolution determination for a prior feedback thread.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `comments` | `list[ReviewComment]` | List of review comments |
-| `summary` | `str` | Summary paragraph of the review |
+**Config**: `frozen=True` (immutable)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `discussion_id` | `str` | — | GitLab discussion ID of the prior feedback |
+| `status` | `str` | — | Resolution status: `resolved`, `not_addressed`, or `partial` |
+| `message` | `str` | — | Acknowledgment or explanation message |
+
+---
+
+### `ParsedReview`
+**Purpose**: Structured review output with comments, resolutions, and a summary.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `comments` | `list[ReviewComment]` | — | List of review comments |
+| `summary` | `str` | — | Summary paragraph of the review |
+| `resolutions` | `list[Resolution]` | `[]` | Resolution determinations for prior feedback threads |
 
 ---
 
@@ -617,8 +631,9 @@ graph TB
 |-------|------|---------|-------------|
 | `reply` | `str` | — | Reply text to post in the discussion thread |
 | `has_code_changes` | `bool` | `False` | True if the LLM output contained a `files_changed` JSON block |
+| `resolution` | `Resolution \| None` | `None` | Resolution determination for the triggering thread (from `comment_parser.Resolution`) |
 
-**Parsing**: If the LLM output ends with a fenced JSON block containing `files_changed` (same format as the coding prompt), the reply is the text before the block and `has_code_changes` is True. Otherwise the entire output is the reply. No structured intent classification — the handler uses `has_code_changes` to decide whether to commit/push.
+**Parsing**: If the LLM output ends with a fenced JSON block containing `files_changed` (same format as the coding prompt), the reply is the text before the block and `has_code_changes` is True. If the block contains a `resolution` key, it is parsed as a `Resolution` object. Otherwise the entire output is the reply. No structured intent classification — the handler uses `has_code_changes` to decide whether to commit/push.
 
 ---
 

--- a/docs/wiki/module-reference.md
+++ b/docs/wiki/module-reference.md
@@ -31,9 +31,9 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 **Key Functions**:
 - `webhook(request: Request, background_tasks: BackgroundTasks, x_gitlab_token: str | None) -> dict[str, str]`: POST endpoint, validates HMAC, dispatches to background handlers
 - `_validate_webhook_token(received: str | None, expected: str) -> None`: HMAC comparison using `hmac.compare_digest`
-- `_process_review(request: Request, payload: MergeRequestWebhookPayload) -> None`: Background task for MR review
+- `_process_review(request: Request, payload: MergeRequestWebhookPayload) -> None`: Background task for MR review. Resolves per-project `resolution_behavior` from project registry
 - `_is_agent_directed(payload: NoteWebhookPayload, agent_identity: AgentIdentity, request: Request) -> bool`: Check if note @mentions the agent
-- `_process_discussion(request: Request, payload: NoteWebhookPayload, agent_identity: AgentIdentity) -> None`: Background task for discussion interactions
+- `_process_discussion(request: Request, payload: NoteWebhookPayload, agent_identity: AgentIdentity) -> None`: Background task for discussion interactions. Resolves per-project `resolution_behavior` from project registry
 
 **Key Constants**:
 - `HANDLED_ACTIONS = frozenset({"open", "update"})`: MR actions that trigger review
@@ -92,7 +92,7 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 **Purpose**: MR review orchestration — clone, review, parse, post comments.
 
 **Key Functions**:
-- `handle_review(settings: Settings, payload: MergeRequestWebhookPayload, executor: TaskExecutor, project_token: str | None = None, credential_registry: CredentialRegistry | None = None) -> None`: Full review pipeline with OTEL span and metrics
+- `handle_review(settings: Settings, payload: MergeRequestWebhookPayload, executor: TaskExecutor, project_token: str | None = None, credential_registry: CredentialRegistry | None = None, resolution_behavior: str = "suggest") -> None`: Full review pipeline with OTEL span and metrics
   - Clones repo
   - Fetches MR details (title, description, diff_refs, changes)
   - If `credential_registry` provided: fetches discussions via `list_mr_discussions()`, resolves agent identity via `resolve_identity()`, builds `DiscussionHistory`
@@ -100,6 +100,7 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
   - Calls `run_review()` with diff text and discussion history
   - Parses structured review via `parse_review()`
   - Posts comments via `post_review()`
+  - Passes `resolution_behavior` to `post_review()` for prior feedback resolution
   - Emits `reviews_total` and `reviews_duration` metrics
 
 **Internal Imports**: `config`, `models`, `task_executor`, `gitlab_client`, `review_engine`, `comment_parser`, `comment_poster`, `metrics`, `telemetry`, `discussion_models`, `credential_registry`
@@ -116,7 +117,7 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 - `AGENT_AUTHOR_EMAIL = "copilot-agent@noreply.gitlab.com"`
 
 **Key Functions**:
-- `handle_discussion_interaction(settings: Settings, payload: NoteWebhookPayload, executor: TaskExecutor, agent_identity: AgentIdentity, project_token: str | None, repo_locks: DistributedLock | None) -> None`: Full discussion pipeline — clone → fetch MR details & discussions → find triggering thread → build prompt → run LLM → parse response → post reply (+ optional commit/push)
+- `handle_discussion_interaction(settings: Settings, payload: NoteWebhookPayload, executor: TaskExecutor, agent_identity: AgentIdentity, project_token: str | None = None, repo_locks: DistributedLock | None = None, resolution_behavior: str = "suggest") -> None`: Full discussion pipeline — clone → fetch MR details & discussions → find triggering thread → build prompt → run LLM → parse response → post reply (+ optional commit/push) → handle resolution per `resolution_behavior`
 - `_find_triggering_discussion(discussions: list[Discussion], note_id: int) -> Discussion | None`: Locate the discussion containing the triggering note
 
 **Internal Imports**: `discussion_engine`, `discussion_models`, `coding_workflow`, `git_operations`, `gitlab_client`, `task_executor`, `telemetry`, `concurrency`, `config`, `models`, `prompt_defaults`
@@ -134,14 +135,15 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 - `MAX_OTHER_NOTE_CHARS = 100`: Max characters per summarized note
 
 **Key Models**:
-- `DiscussionResponse`: Structured LLM response — `intent` (question, coding, resolution, mixed), `reply` (text to post), `code_changes` (optional file changes)
+- `DiscussionResponse`: Structured LLM response — `reply` (text to post), `has_code_changes` (bool), `resolution` (optional Resolution for thread resolution)
 
 **Key Functions**:
 - `build_discussion_prompt(mr_details: MRDetails, discussion_history: DiscussionHistory, triggering_discussion: Discussion) -> str`: Build user prompt with MR metadata, triggering thread, diff, and other discussion context
-- `parse_discussion_response(raw: str) -> DiscussionResponse`: Extract structured response from LLM output; falls back to question-intent reply if parsing fails
+- `parse_discussion_response(raw: str) -> DiscussionResponse`: Extract structured response from LLM output. Detects `files_changed` JSON blocks for code changes and `resolution` JSON blocks for thread resolution signals
 - `run_discussion(executor: TaskExecutor, settings: Settings, repo_path: str, repo_url: str, system_prompt: str, user_prompt: str, source_branch: str) -> TaskResult`: Execute discussion LLM session via executor
+- `_parse_resolution(data: dict[str, object]) -> Resolution | None`: Extract Resolution from parsed JSON if present
 
-**Internal Imports**: `task_executor`, `config`, `discussion_models`, `gitlab_client`
+**Internal Imports**: `task_executor`, `config`, `discussion_models`, `gitlab_client`, `comment_parser`
 
 **Depended On By**: `discussion_orchestrator.py`
 
@@ -180,6 +182,7 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 - `_SEVERITY_PREFIX_RE: re.Pattern`: Compiled regex to strip severity prefixes (e.g., `**[WARNING]**`) from comments
 - `_SUGGESTION_BLOCK_RE: re.Pattern`: Compiled regex to strip suggestion code blocks from comments
 - `_PRIOR_FEEDBACK_RULES: str`: Prompt rules instructing the LLM not to duplicate prior feedback
+- `_RESOLUTION_EVAL_INSTRUCTIONS`: Prompt instructions for LLM to evaluate whether prior feedback has been addressed
 
 **Key Models**:
 - `ReviewRequest`: MR metadata (title, description, source/target branches)
@@ -187,7 +190,7 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 **Key Functions**:
 - `build_review_prompt(req: ReviewRequest, diff_text: str | None = None, discussion_history: DiscussionHistory | None = None) -> str`: Build user prompt; includes diff inline when available and injects prior unresolved feedback
 - `run_review(executor: TaskExecutor, settings: Settings, repo_path: str, repo_url: str, review_request: ReviewRequest, diff_text: str | None = None, discussion_history: DiscussionHistory | None = None) -> TaskResult`: Execute review task and return structured result
-- `_format_prior_feedback(history: DiscussionHistory) -> str`: Render the agent's unresolved inline comments as a prompt section (grouped by file, sorted by line)
+- `_format_prior_feedback(history: DiscussionHistory) -> str`: Render agent's unresolved inline comments as a prompt section. Includes `[discussion: {id}]` tags for LLM resolution referencing
 - `_strip_comment_formatting(body: str) -> str`: Remove agent-added severity prefix and suggestion blocks from a comment
 
 **Internal Imports**: `config`, `prompt_defaults`, `task_executor`, `discussion_models` (TYPE_CHECKING)
@@ -384,6 +387,10 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
   - `list_project_mrs(project_id: int, state: str, updated_after: str | None) -> list[MRListItem]`: List MRs
   - `list_mr_notes(project_id: int, mr_iid: int, created_after: str | None) -> list[NoteListItem]`: List notes
   - `resolve_project(id_or_path: str | int) -> int`: Resolve project ID
+  - `list_mr_discussions(project_id: int, mr_iid: int) -> list[Discussion]`: List MR discussions with notes and resolution status
+  - `get_current_user() -> AgentIdentity`: Discover authenticated user identity
+  - `resolve_discussion(project_id: int, mr_iid: int, discussion_id: str) -> None`: Resolve a discussion thread (sets resolved=True)
+  - `reply_to_discussion(project_id: int, mr_iid: int, discussion_id: str, body: str) -> None`: Post a reply to an existing discussion thread
 
 **Internal Imports**: `git_operations`
 
@@ -446,24 +453,27 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 
 **Key Models**:
 - `ReviewComment`: file, line, severity, comment, suggestion, suggestion_start_offset, suggestion_end_offset
-- `ParsedReview`: comments, summary
+- `Resolution`: discussion_id, status (resolved/not_addressed/partial), message — resolution determination for prior feedback
+- `ParsedReview`: comments, summary, resolutions
 
 **Key Functions**:
-- `parse_review(raw: str) -> ParsedReview`: Extract JSON array from code fence or raw text, parse comments, extract summary
+- `parse_review(raw: str) -> ParsedReview`: Extract JSON object with `comments` and `resolutions` arrays from code fence or raw text, parse into models, extract summary
 
 **Internal Imports**: None
 
-**Depended On By**: `orchestrator.py`
+**Depended On By**: `orchestrator.py`, `discussion_engine.py`
 
 ---
 
 ### `comment_poster.py`
-**Purpose**: Post review comments to GitLab MR as inline discussions and summary.
+**Purpose**: Post review comments to GitLab MR as inline discussions and summary. Handles resolution actions for prior feedback.
 
 **Key Functions**:
-- `post_review(gitlab_client: gl.Gitlab, project_id: int, mr_iid: int, diff_refs: MRDiffRef, review: ParsedReview, changes: list[MRChange]) -> None`: Post inline + summary
+- `post_review(gitlab_client: gl.Gitlab, project_id: int, mr_iid: int, diff_refs: MRDiffRef, review: ParsedReview, changes: list[MRChange], resolution_behavior: str = "suggest") -> None`: Post inline comments + resolve/acknowledge prior feedback + summary
   - Validates comment positions against diff hunks
   - Falls back to note with file:line context if position invalid
+  - Processes resolutions via `_handle_resolutions()` before posting summary
+- `_handle_resolutions(mr: object, resolutions: list[Resolution], resolution_behavior: str) -> int`: Process resolutions per configured behavior (auto-resolve/suggest/off). Returns count of resolved threads
 - `_parse_hunk_lines(diff: str, new_path: str) -> set[tuple[str, int]]`: Extract valid (file, line) positions from unified diff
 - `_is_valid_position(file: str, line: int, valid_positions: set[tuple[str, int]]) -> bool`: Check if position valid
 

--- a/docs/wiki/request-flows.md
+++ b/docs/wiki/request-flows.md
@@ -38,7 +38,7 @@ sequenceDiagram
     
     Note over WH,POST: Background task starts
     
-    WH->>ORCH: handle_review(settings, payload, executor)
+    WH->>ORCH: handle_review(settings, payload, executor, resolution_behavior)
     ORCH->>GLCL: clone_repo(git_http_url, source_branch, token)
     GLCL->>GLCL: git_operations.git_clone()
     GLCL-->>ORCH: repo_path: Path
@@ -70,12 +70,12 @@ sequenceDiagram
     EXEC-->>ORCH: raw_review: TaskResult
     
     ORCH->>PARSE: parse_review(raw_review)
-    PARSE-->>ORCH: ParsedReview (comments, summary)
+    PARSE-->>ORCH: ParsedReview (comments, resolutions, summary)
     
     ORCH->>GLCL: get_mr_details(project_id, mr_iid)
     GLCL-->>ORCH: MRDetails (diff_refs, changes)
     
-    ORCH->>POST: post_review(gl, project_id, mr_iid, diff_refs, parsed, changes)
+    ORCH->>POST: post_review(gl, project_id, mr_iid, diff_refs, parsed, changes, resolution_behavior)
     POST->>POST: _parse_hunk_lines() for all changes
     loop For each comment
         POST->>POST: _is_valid_position()
@@ -83,6 +83,16 @@ sequenceDiagram
             POST->>GL: mr.discussions.create() (inline)
         else Invalid position
             POST->>GL: mr.notes.create() (fallback)
+        end
+    end
+    alt Has resolutions & behavior != "off"
+        loop For each resolution
+            alt auto-resolve & status=resolved
+                POST->>GL: disc.notes.create() (✅ ack)
+                POST->>GL: disc.resolved = True; disc.save()
+            else suggest & status in (resolved, partial)
+                POST->>GL: disc.notes.create() (✅/⚠️ ack)
+            end
         end
     end
     POST->>GL: mr.notes.create() (summary)
@@ -128,7 +138,7 @@ sequenceDiagram
 
     Note over WH,GIT: Background task starts
 
-    WH->>DH: handle_discussion_interaction(settings, payload, executor, agent_identity)
+    WH->>DH: handle_discussion_interaction(settings, payload, executor, agent_identity, resolution_behavior)
     alt repo_locks provided
         DH->>DH: async with repo_locks.acquire(git_http_url)
     end
@@ -149,9 +159,9 @@ sequenceDiagram
     EXEC-->>DE: result: TaskResult
     DE-->>DH: result: TaskResult
     DH->>DE: parse_discussion_response(result.summary)
-    DE-->>DH: DiscussionResponse (intent, reply, code_changes)
+    DE-->>DH: DiscussionResponse (reply, has_code_changes, resolution)
 
-    alt intent == "coding" or "mixed" with code_changes
+    alt has_code_changes
         DH->>DH: apply_coding_result(result, repo_path)
         DH->>GIT: git_commit(repo_path, message, author)
         alt has_changes
@@ -160,6 +170,11 @@ sequenceDiagram
     end
 
     DH->>GL: discussion.notes.create({"body": reply})
+    alt response.resolution & behavior != "off"
+        alt auto-resolve & status=resolved
+            DH->>GL: disc.resolved = True; disc.save()
+        end
+    end
     DH->>DH: shutil.rmtree(repo_path)
 ```
 

--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -293,6 +293,11 @@ resource "azurerm_container_app" "controller" {
         }
       }
 
+      env {
+        name  = "RESOLUTION_BEHAVIOR"
+        value = var.resolution_behavior
+      }
+
       # BYOK provider config (only set when copilot_auth='byok')
       dynamic "env" {
         for_each = var.copilot_auth == "byok" ? [1] : []

--- a/infra/dev.tfvars
+++ b/infra/dev.tfvars
@@ -9,6 +9,7 @@ jira_email            = "__JIRA_EMAIL__"
 jira_project_map      = "{\"mappings\":{\"DEV\":{\"repo\":\"peteroden/gitlab-copilot-dev\",\"target_branch\":\"main\",\"credential_ref\":\"default\"},\"E2EACA\":{\"repo\":\"peteroden/e2e-aca-test\",\"target_branch\":\"main\",\"credential_ref\":\"e2e_aca_test\"}}}"
 jira_trigger_status   = "Selected for Development"
 jira_in_review_status = "Done"
+resolution_behavior   = "suggest"
 kv_bootstrap          = true
 # kv_bootstrap_secrets: injected via TF_VAR_kv_bootstrap_secrets in deploy.yml.
 # See docs/wiki/configuration-reference.md "Adding a per-project GitLab token".

--- a/infra/staging.tfvars
+++ b/infra/staging.tfvars
@@ -9,6 +9,7 @@ jira_email            = "__JIRA_EMAIL__"
 jira_project_map      = "{\"mappings\":{\"STAGING\":{\"repo\":\"peteroden/gitlab-copilot-staging\",\"target_branch\":\"main\",\"credential_ref\":\"default\"},\"DEMO\":{\"repo\":\"peteroden/copilot-demo\",\"target_branch\":\"main\",\"credential_ref\":\"copilot_demo\"}}}"
 jira_trigger_status   = "Selected for Development"
 jira_in_review_status = "Done"
+resolution_behavior   = "suggest"
 kv_bootstrap          = true
 # kv_bootstrap_secrets: injected via TF_VAR_kv_bootstrap_secrets in deploy.yml.
 # See docs/wiki/configuration-reference.md "Adding a per-project GitLab token".

--- a/infra/variables-apps.tf
+++ b/infra/variables-apps.tf
@@ -169,6 +169,12 @@ variable "jira_in_review_status" {
   default     = "In Review"
 }
 
+variable "resolution_behavior" {
+  description = "Default behavior when agent feedback is addressed: auto-resolve, suggest, or off"
+  type        = string
+  default     = "suggest"
+}
+
 # --- Key Vault Bootstrap ---
 
 variable "kv_bootstrap" {

--- a/src/gitlab_copilot_agent/comment_parser.py
+++ b/src/gitlab_copilot_agent/comment_parser.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import json
 import re
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+ResolutionStatus = Literal["resolved", "not_addressed", "partial"]
 
 
 class ReviewComment(BaseModel):
@@ -25,35 +28,31 @@ class ReviewComment(BaseModel):
     )
 
 
+class Resolution(BaseModel):
+    """A resolution determination for a prior feedback thread."""
+
+    model_config = ConfigDict(frozen=True)
+    discussion_id: str = Field(description="GitLab discussion ID of the prior feedback")
+    status: ResolutionStatus = Field(
+        description="Resolution status: resolved, not_addressed, or partial"
+    )
+    message: str = Field(description="Acknowledgment or explanation message")
+
+
 class ParsedReview(BaseModel):
-    """Structured review output with comments and a summary."""
+    """Structured review output with comments, resolutions, and a summary."""
 
     comments: list[ReviewComment] = Field(description="List of review comments")
     summary: str = Field(description="Summary paragraph of the review")
+    resolutions: list[Resolution] = Field(  # pyright: ignore[reportUnknownVariableType]
+        default_factory=list, description="Resolution determinations for prior feedback"
+    )
 
 
-def parse_review(raw: str) -> ParsedReview:
-    """Extract structured comments and summary from agent output.
-
-    Expects a JSON array (optionally in a code fence) followed by a summary.
-    Falls back to treating the entire output as a summary if parsing fails.
-    """
-    json_match = re.search(r"```json\s*\n(\[.*?\])\s*\n```", raw, re.DOTALL)
-    if not json_match:
-        json_match = re.search(r"(\[.*?\])", raw, re.DOTALL)
-    if not json_match:
-        return ParsedReview(comments=[], summary=raw.strip())
-
-    try:
-        parsed: object = json.loads(json_match.group(1))
-    except json.JSONDecodeError:
-        return ParsedReview(comments=[], summary=raw.strip())
-
-    if not isinstance(parsed, list):
-        return ParsedReview(comments=[], summary=raw.strip())
-
+def _build_parsed_review(data: dict[str, object], summary: str) -> ParsedReview:
+    """Build a ParsedReview from a parsed JSON dict and summary text."""
     comments: list[ReviewComment] = []
-    for item in parsed:  # pyright: ignore[reportUnknownVariableType]
+    for item in data.get("comments", []):  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType, reportGeneralTypeIssues]
         if not isinstance(item, dict):
             continue
         try:
@@ -61,6 +60,48 @@ def parse_review(raw: str) -> ParsedReview:
         except (KeyError, ValueError, ValidationError):
             continue
 
-    summary = raw[json_match.end() :].strip()
-    summary = re.sub(r"^```\s*", "", summary).strip() or "Review complete."
-    return ParsedReview(comments=comments, summary=summary)
+    resolutions: list[Resolution] = []
+    for item in data.get("resolutions", []):  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType, reportGeneralTypeIssues]
+        if not isinstance(item, dict):
+            continue
+        try:
+            resolutions.append(Resolution.model_validate(item))
+        except (KeyError, ValueError, ValidationError):
+            continue
+
+    return ParsedReview(comments=comments, summary=summary, resolutions=resolutions)
+
+
+def parse_review(raw: str) -> ParsedReview:
+    """Extract structured comments, resolutions, and summary from agent output.
+
+    Expects a JSON object with "comments" and "resolutions" arrays
+    (optionally in a code fence) followed by a summary.
+    Falls back to treating the entire output as a summary if parsing fails.
+    """
+    # Try code-fenced JSON object first
+    json_match = re.search(r"```json\s*\n(\{.*?\})\s*\n```", raw, re.DOTALL)
+    if json_match:
+        try:
+            parsed: object = json.loads(json_match.group(1))
+        except json.JSONDecodeError:
+            return ParsedReview(comments=[], summary=raw.strip())
+        if not isinstance(parsed, dict):
+            return ParsedReview(comments=[], summary=raw.strip())
+        summary = raw[json_match.end() :].strip()
+        summary = re.sub(r"^```\s*", "", summary).strip() or "Review complete."
+        return _build_parsed_review(parsed, summary)  # pyright: ignore[reportUnknownArgumentType]
+
+    # Try bare JSON object using raw_decode (handles braces in trailing text)
+    stripped = raw.strip()
+    idx = stripped.find("{")
+    if idx == -1:
+        return ParsedReview(comments=[], summary=stripped or "Review complete.")
+    try:
+        parsed, end_idx = json.JSONDecoder().raw_decode(stripped, idx)
+    except json.JSONDecodeError:
+        return ParsedReview(comments=[], summary=stripped)
+    if not isinstance(parsed, dict):
+        return ParsedReview(comments=[], summary=stripped)
+    summary = stripped[end_idx:].strip() or "Review complete."
+    return _build_parsed_review(parsed, summary)  # pyright: ignore[reportUnknownArgumentType]

--- a/src/gitlab_copilot_agent/comment_poster.py
+++ b/src/gitlab_copilot_agent/comment_poster.py
@@ -3,17 +3,19 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 import re
 from typing import TYPE_CHECKING
+
+import structlog
 
 if TYPE_CHECKING:
     import gitlab as gl
 
-    from gitlab_copilot_agent.comment_parser import ParsedReview
+    from gitlab_copilot_agent.comment_parser import ParsedReview, Resolution
     from gitlab_copilot_agent.gitlab_client import MRChange, MRDiffRef
+    from gitlab_copilot_agent.mapping_models import ResolutionBehavior
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger()
 
 
 def _parse_hunk_lines(diff: str, new_path: str) -> set[tuple[str, int]]:
@@ -60,6 +62,47 @@ def _is_valid_position(file: str, line: int, valid_positions: set[tuple[str, int
     return (file, line) in valid_positions
 
 
+def _handle_resolutions(
+    mr: object,  # gitlab MR object
+    resolutions: list[Resolution],
+    resolution_behavior: ResolutionBehavior,
+    allowed_discussion_ids: frozenset[str] = frozenset(),
+) -> int:
+    """Process resolutions per configured behavior. Returns count of resolved."""
+    if resolution_behavior == "off" or not resolutions:
+        return 0
+
+    resolved_count = 0
+    for r in resolutions:
+        if r.status == "not_addressed":
+            continue
+        if r.discussion_id not in allowed_discussion_ids:
+            log.warning(
+                "resolution_skipped_unknown_discussion",
+                discussion_id=r.discussion_id,
+            )
+            continue
+        try:
+            disc = mr.discussions.get(r.discussion_id)  # pyright: ignore[reportAttributeAccessIssue, reportUnknownVariableType, reportUnknownMemberType]
+
+            if resolution_behavior == "auto-resolve" and r.status == "resolved":
+                disc.notes.create({"body": f"✅ {r.message}"})  # pyright: ignore[reportUnknownMemberType]
+                disc.resolved = True  # pyright: ignore[reportAttributeAccessIssue]
+                disc.save()  # pyright: ignore[reportUnknownMemberType]
+                resolved_count += 1
+            elif r.status in ("resolved", "partial"):
+                prefix = "✅" if r.status == "resolved" else "⚠️"
+                disc.notes.create({"body": f"{prefix} {r.message}"})  # pyright: ignore[reportUnknownMemberType]
+        except Exception:
+            log.warning(
+                "resolution_action_failed",
+                discussion_id=r.discussion_id,
+                exc_info=True,
+            )
+
+    return resolved_count
+
+
 async def post_review(
     gitlab_client: gl.Gitlab,
     project_id: int,
@@ -67,6 +110,8 @@ async def post_review(
     diff_refs: MRDiffRef,
     review: ParsedReview,
     changes: list[MRChange],
+    resolution_behavior: ResolutionBehavior = "suggest",
+    allowed_discussion_ids: frozenset[str] = frozenset(),
 ) -> None:
     """Post inline comments and summary note to a GitLab MR.
 
@@ -94,20 +139,20 @@ async def post_review(
 
             # Skip comments on files not in the diff entirely
             if c.file not in diff_files:
-                log.info("Skipping comment on file not in diff: %s:%d", c.file, c.line)
+                log.info("comment_skipped_not_in_diff", file=c.file, line=c.line)
                 continue
 
             # Validate position before attempting inline comment
             if not _is_valid_position(c.file, c.line, valid_positions):
                 log.warning(
-                    "Comment position not in diff hunk, using fallback note for %s:%d",
-                    c.file,
-                    c.line,
+                    "comment_position_invalid",
+                    file=c.file,
+                    line=c.line,
                 )
                 try:
                     mr.notes.create({"body": f"{body}\n\n`{c.file}:{c.line}`"})
                 except Exception:
-                    log.warning("Fallback note failed for %s:%d", c.file, c.line, exc_info=True)
+                    log.warning("fallback_note_failed", file=c.file, line=c.line, exc_info=True)
                 continue
 
             # Position is valid, attempt inline comment
@@ -127,16 +172,24 @@ async def post_review(
                     }
                 )
             except Exception:
-                log.warning("Inline comment failed for %s:%d", c.file, c.line, exc_info=True)
+                log.warning("inline_comment_failed", file=c.file, line=c.line, exc_info=True)
                 try:
                     mr.notes.create({"body": f"{body}\n\n`{c.file}:{c.line}`"})
                 except Exception:
                     log.warning(
-                        "Fallback note also failed for %s:%d",
-                        c.file,
-                        c.line,
+                        "fallback_note_also_failed",
+                        file=c.file,
+                        line=c.line,
                         exc_info=True,
                     )
+
+        # Handle resolutions for prior feedback
+        if review.resolutions:
+            resolved = _handle_resolutions(
+                mr, review.resolutions, resolution_behavior, allowed_discussion_ids
+            )
+            if resolved > 0:
+                log.info("discussions_resolved", count=resolved)
 
         mr.notes.create({"body": f"## Code Review Summary\n\n{review.summary}"})
 

--- a/src/gitlab_copilot_agent/config.py
+++ b/src/gitlab_copilot_agent/config.py
@@ -6,6 +6,8 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings
 
+from gitlab_copilot_agent.mapping_models import ResolutionBehavior
+
 
 class JiraSettings(BaseModel):
     """Jira configuration — all optional. Service runs review-only without these."""
@@ -195,6 +197,13 @@ class Settings(BaseSettings):
         default=True,
         description="Re-review MRs when new commits are pushed (dedup per commit). "
         "When false, each MR is reviewed only once (dedup per MR).",
+    )
+
+    # Resolution behavior
+    resolution_behavior: ResolutionBehavior = Field(
+        default="suggest",
+        description="Default behavior when agent feedback is addressed: "
+        "auto-resolve, suggest, or off",
     )
 
     # Jira (all optional — service runs review-only without these)

--- a/src/gitlab_copilot_agent/discussion_engine.py
+++ b/src/gitlab_copilot_agent/discussion_engine.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 import structlog
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
+from gitlab_copilot_agent.comment_parser import Resolution
 from gitlab_copilot_agent.task_executor import TaskExecutor, TaskParams, TaskResult
 
 if TYPE_CHECKING:
@@ -46,6 +47,9 @@ class DiscussionResponse(BaseModel):
     has_code_changes: bool = Field(
         default=False, description="True if the LLM output contained a files_changed JSON block"
     )
+    resolution: Resolution | None = Field(
+        default=None, description="Resolution determination for the triggering thread"
+    )
 
 
 def build_discussion_prompt(
@@ -66,7 +70,7 @@ def build_discussion_prompt(
     )
 
     # The triggering thread — this is the conversation the developer is in
-    prompt += "## Current Thread\n\n"
+    prompt += f"## Current Thread (discussion ID: {triggering_discussion.discussion_id})\n\n"
     for note in triggering_discussion.notes:
         role = (
             "Agent" if note.author_id == discussion_history.agent.user_id else note.author_username
@@ -101,14 +105,25 @@ def build_discussion_prompt(
     return prompt
 
 
+def _parse_resolution(data: dict[str, object]) -> Resolution | None:
+    """Extract a Resolution from a parsed JSON object, if present."""
+    raw_res = data.get("resolution")
+    if not isinstance(raw_res, dict):
+        return None
+    try:
+        return Resolution.model_validate(raw_res)
+    except (ValidationError, KeyError, ValueError):
+        return None
+
+
 def parse_discussion_response(raw: str) -> DiscussionResponse:
     """Parse the LLM's discussion response.
 
     If the output ends with a ``files_changed`` JSON block (same format as
     the coding prompt), the reply is the text before the block and
-    ``has_code_changes`` is True.  Otherwise the entire output is the reply.
+    ``has_code_changes`` is True.  If the JSON block contains a ``resolution``
+    key, it is parsed as a Resolution.  Otherwise the entire output is the reply.
     """
-    # Check for trailing JSON block with files_changed (coding prompt format)
     json_match = re.search(r"```json\s*\n(\{.*?\})\s*\n```\s*$", raw, re.DOTALL)
     if json_match:
         try:
@@ -117,7 +132,16 @@ def parse_discussion_response(raw: str) -> DiscussionResponse:
                 reply = raw[: json_match.start()].strip()
                 if not reply:
                     reply = data.get("summary", "Changes applied.")
-                return DiscussionResponse(reply=reply, has_code_changes=True)
+                resolution = _parse_resolution(data)
+                return DiscussionResponse(
+                    reply=reply, has_code_changes=True, resolution=resolution
+                )
+            if "resolution" in data:
+                reply = raw[: json_match.start()].strip()
+                if not reply:
+                    reply = "Acknowledged."
+                resolution = _parse_resolution(data)
+                return DiscussionResponse(reply=reply, resolution=resolution)
         except (json.JSONDecodeError, ValidationError):
             pass
 

--- a/src/gitlab_copilot_agent/discussion_orchestrator.py
+++ b/src/gitlab_copilot_agent/discussion_orchestrator.py
@@ -30,6 +30,7 @@ from gitlab_copilot_agent.git_operations import (
     validate_clone_url_host,
 )
 from gitlab_copilot_agent.gitlab_client import GitLabClient
+from gitlab_copilot_agent.mapping_models import ResolutionBehavior
 from gitlab_copilot_agent.models import NoteWebhookPayload
 from gitlab_copilot_agent.prompt_defaults import get_prompt
 from gitlab_copilot_agent.task_executor import (
@@ -62,6 +63,7 @@ async def handle_discussion_interaction(
     agent_identity: AgentIdentity,
     project_token: str | None = None,
     repo_locks: DistributedLock | None = None,
+    resolution_behavior: ResolutionBehavior = "suggest",
 ) -> None:
     """Handle an @mention or thread-reply interaction on an MR.
 
@@ -178,6 +180,38 @@ async def handle_discussion_interaction(
                 disc_obj = gl_mr.discussions.get(triggering.discussion_id)
                 await asyncio.to_thread(disc_obj.notes.create, {"body": response.reply})
                 await bound_log.ainfo("discussion_reply_posted")
+
+                # 8. Handle resolution if the LLM determined one
+                # Only auto-resolve threads originally created by the agent
+                first_note = triggering.notes[0] if triggering.notes else None
+                is_agent_thread = (
+                    first_note is not None
+                    and triggering.is_inline
+                    and first_note.author_id == agent_identity.user_id
+                )
+                if response.resolution and resolution_behavior != "off" and is_agent_thread:
+                    try:
+                        if (
+                            response.resolution.status == "resolved"
+                            and resolution_behavior == "auto-resolve"
+                        ):
+                            disc_obj.resolved = True
+                            await asyncio.to_thread(disc_obj.save)
+                            await bound_log.ainfo(
+                                "discussion_auto_resolved",
+                                discussion_id=triggering.discussion_id,
+                            )
+                        elif response.resolution.status == "partial":
+                            await bound_log.ainfo(
+                                "discussion_partial_resolution",
+                                discussion_id=triggering.discussion_id,
+                            )
+                    except Exception:
+                        await bound_log.awarning(
+                            "discussion_resolution_failed",
+                            discussion_id=triggering.discussion_id,
+                            exc_info=True,
+                        )
 
             except TaskExecutionError as exc:
                 error_str = str(exc)

--- a/src/gitlab_copilot_agent/gitlab_client.py
+++ b/src/gitlab_copilot_agent/gitlab_client.py
@@ -100,6 +100,12 @@ class GitLabClientProtocol(Protocol):
     async def resolve_project(self, id_or_path: str | int) -> int: ...
     async def list_mr_discussions(self, project_id: int, mr_iid: int) -> list[Discussion]: ...
     async def get_current_user(self) -> AgentIdentity: ...
+    async def resolve_discussion(
+        self, project_id: int, mr_iid: int, discussion_id: str
+    ) -> None: ...
+    async def reply_to_discussion(
+        self, project_id: int, mr_iid: int, discussion_id: str, body: str
+    ) -> None: ...
 
 
 class GitLabClient:
@@ -109,11 +115,28 @@ class GitLabClient:
 
     async def get_mr_details(self, project_id: int, mr_iid: int) -> MRDetails:
         def _fetch() -> MRDetails:
+            import time
+
             project = self._gl.projects.get(project_id)
             mr = project.mergerequests.get(mr_iid)
-            changes_data: dict[str, object] = mr.changes()  # pyright: ignore[reportAssignmentType]
 
-            diff_refs = MRDiffRef.model_validate(changes_data["diff_refs"])
+            # Retry when diff_refs is null (GitLab race on freshly-created MRs)
+            raw_diff_refs: object | None = None
+            changes_data: dict[str, object] = {}
+            for attempt in range(5):
+                changes_data = mr.changes()  # pyright: ignore[reportAssignmentType]
+                raw_diff_refs = changes_data.get("diff_refs")
+                if raw_diff_refs is not None:
+                    break
+                time.sleep(min(2**attempt, 8))
+
+            if raw_diff_refs is None:
+                msg = (
+                    f"diff_refs is null for MR !{mr_iid} in project {project_id} "
+                    f"after retries — GitLab may still be computing the diff"
+                )
+                raise RuntimeError(msg)
+            diff_refs = MRDiffRef.model_validate(raw_diff_refs)
 
             raw_changes = changes_data.get("changes", [])
             assert isinstance(raw_changes, list)
@@ -304,3 +327,28 @@ class GitLabClient:
             )
 
         return await asyncio.to_thread(_fetch)
+
+    async def resolve_discussion(self, project_id: int, mr_iid: int, discussion_id: str) -> None:
+        """Resolve a discussion thread via the GitLab API."""
+
+        def _resolve() -> None:
+            project = self._gl.projects.get(project_id)
+            mr = project.mergerequests.get(mr_iid)
+            disc = mr.discussions.get(discussion_id)
+            disc.resolved = True
+            disc.save()
+
+        await asyncio.to_thread(_resolve)
+
+    async def reply_to_discussion(
+        self, project_id: int, mr_iid: int, discussion_id: str, body: str
+    ) -> None:
+        """Post a reply to an existing discussion thread."""
+
+        def _reply() -> None:
+            project = self._gl.projects.get(project_id)
+            mr = project.mergerequests.get(mr_iid)
+            disc = mr.discussions.get(discussion_id)
+            disc.notes.create({"body": body})
+
+        await asyncio.to_thread(_reply)

--- a/src/gitlab_copilot_agent/mapping_models.py
+++ b/src/gitlab_copilot_agent/mapping_models.py
@@ -12,7 +12,11 @@ models, and emits the rendered JSON that populates ``JIRA_PROJECT_MAP``.
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+ResolutionBehavior = Literal["auto-resolve", "suggest", "off"]
 
 
 class Defaults(BaseModel):
@@ -42,6 +46,11 @@ class Defaults(BaseModel):
     in_review_status: str = Field(
         default="In Review",
         description="Default Jira status set after MR creation",
+    )
+    resolution_behavior: ResolutionBehavior = Field(
+        default="suggest",
+        description="Default behavior when agent feedback is addressed: "
+        "auto-resolve, suggest, or off",
     )
 
 
@@ -81,6 +90,10 @@ class Binding(BaseModel):
     in_review_status: str | None = Field(
         default=None,
         description="Override the in-review status for this binding",
+    )
+    resolution_behavior: ResolutionBehavior | None = Field(
+        default=None,
+        description="Override the resolution behavior for this binding",
     )
 
     @model_validator(mode="after")
@@ -153,6 +166,7 @@ class MappingFile(BaseModel):
                 trigger_status=b.trigger_status or self.defaults.trigger_status,
                 in_progress_status=b.in_progress_status or self.defaults.in_progress_status,
                 in_review_status=b.in_review_status or self.defaults.in_review_status,
+                resolution_behavior=b.resolution_behavior or self.defaults.resolution_behavior,
             )
         return RenderedMap(mappings=rendered_bindings)
 
@@ -179,6 +193,10 @@ class RenderedBinding(BaseModel):
     in_review_status: str = Field(
         default="In Review",
         description="Resolved Jira status set after MR creation",
+    )
+    resolution_behavior: ResolutionBehavior = Field(
+        default="suggest",
+        description="Resolved behavior when agent feedback is addressed",
     )
 
 

--- a/src/gitlab_copilot_agent/orchestrator.py
+++ b/src/gitlab_copilot_agent/orchestrator.py
@@ -26,6 +26,7 @@ from gitlab_copilot_agent.telemetry import get_tracer
 if TYPE_CHECKING:
     from gitlab_copilot_agent.config import Settings
     from gitlab_copilot_agent.credential_registry import CredentialRegistry
+    from gitlab_copilot_agent.mapping_models import ResolutionBehavior
     from gitlab_copilot_agent.models import MergeRequestWebhookPayload
     from gitlab_copilot_agent.task_executor import TaskExecutor
 
@@ -39,6 +40,8 @@ async def handle_review(
     executor: TaskExecutor,
     project_token: str | None = None,
     credential_registry: CredentialRegistry | None = None,
+    resolution_behavior: ResolutionBehavior = "suggest",
+    credential_ref: str = "default",
 ) -> None:
     """Full review pipeline: clone → review → parse → post comments."""
     mr = payload.object_attributes
@@ -74,7 +77,7 @@ async def handle_review(
                 try:
                     discussions = await gl_client.list_mr_discussions(project.id, mr.iid)
                     agent_identity = await credential_registry.resolve_identity(
-                        "default", settings.gitlab_url
+                        credential_ref, settings.gitlab_url
                     )
                     discussion_history = DiscussionHistory(
                         discussions=discussions, agent=agent_identity
@@ -109,6 +112,7 @@ async def handle_review(
                 review_req,
                 diff_text=diff_text,
                 discussion_history=discussion_history,
+                head_sha=mr.last_commit.id,
             )
             parsed = parse_review(raw_result.summary)
 
@@ -119,8 +123,28 @@ async def handle_review(
 
             gl = gitlab.Gitlab(settings.gitlab_url, private_token=token)
 
+            # Build allowlist of discussion IDs from agent's prior unresolved feedback.
+            # Fail closed: empty set when history unavailable (no resolutions attempted).
+            allowed_ids: set[str] = set()
+            if discussion_history:
+                for disc in discussion_history.discussions:
+                    if disc.is_resolved or not disc.is_inline:
+                        continue
+                    if not disc.notes:
+                        continue
+                    if disc.notes[0].author_id == discussion_history.agent.user_id:
+                        allowed_ids.add(disc.discussion_id)
+            allowed_discussion_ids = frozenset(allowed_ids)
+
             await post_review(
-                gl, project.id, mr.iid, mr_details.diff_refs, parsed, mr_details.changes
+                gl,
+                project.id,
+                mr.iid,
+                mr_details.diff_refs,
+                parsed,
+                mr_details.changes,
+                resolution_behavior=resolution_behavior,
+                allowed_discussion_ids=allowed_discussion_ids,
             )
             bound_log.info("comments_posted")
             outcome = "success"

--- a/src/gitlab_copilot_agent/project_registry.py
+++ b/src/gitlab_copilot_agent/project_registry.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from gitlab_copilot_agent.credential_registry import CredentialRegistry
 from gitlab_copilot_agent.gitlab_client import GitLabClient
-from gitlab_copilot_agent.mapping_models import RenderedMap
+from gitlab_copilot_agent.mapping_models import RenderedMap, ResolutionBehavior
 
 log = structlog.get_logger()
 
@@ -28,6 +28,9 @@ class ResolvedProject(BaseModel):
     trigger_status: str = Field(default="AI Ready", description="Jira trigger status")
     in_progress_status: str = Field(default="In Progress", description="Jira in-progress status")
     in_review_status: str = Field(default="In Review", description="Jira in-review status")
+    resolution_behavior: ResolutionBehavior = Field(
+        default="suggest", description="Resolution behavior for this project"
+    )
 
 
 class ProjectRegistry:
@@ -80,6 +83,7 @@ class ProjectRegistry:
                     trigger_status=binding.trigger_status,
                     in_progress_status=binding.in_progress_status,
                     in_review_status=binding.in_review_status,
+                    resolution_behavior=binding.resolution_behavior,
                 )
             )
         registry = cls(projects)

--- a/src/gitlab_copilot_agent/prompt_defaults.py
+++ b/src/gitlab_copilot_agent/prompt_defaults.py
@@ -79,19 +79,30 @@ not just `search.py`).
 CRITICAL: Only comment on files and lines that are PART OF THE DIFF provided
 in the user message. Do not review or comment on files that are not in the diff.
 
-Output your review as a JSON array:
+Output your review as a JSON object (NOT a JSON array) with "comments" and
+"resolutions" keys. Do NOT output a bare JSON array like [{...}] — always
+wrap comments inside a {"comments": [...], "resolutions": [...]} object:
 ```json
-[
-  {
-    "file": "src/full/path/to/file.py",
-    "line": 42,
-    "severity": "error|warning|info",
-    "comment": "Description of the issue",
-    "suggestion": "replacement code for the line(s)",
-    "suggestion_start_offset": 0,
-    "suggestion_end_offset": 0
-  }
-]
+{
+  "comments": [
+    {
+      "file": "src/full/path/to/file.py",
+      "line": 42,
+      "severity": "error|warning|info",
+      "comment": "Description of the issue",
+      "suggestion": "replacement code for the line(s)",
+      "suggestion_start_offset": 0,
+      "suggestion_end_offset": 0
+    }
+  ],
+  "resolutions": [
+    {
+      "discussion_id": "abc123",
+      "status": "resolved|not_addressed|partial",
+      "message": "Brief explanation"
+    }
+  ]
+}
 ```
 
 Suggestion fields:
@@ -106,8 +117,11 @@ Suggestion fields:
   For example, to replace just the commented line, use offsets 0, 0.
   To replace a 3-line block (1 above + commented + 1 below), use 1, 1.
 
-After the JSON array, add a brief summary paragraph.
-If the code looks good, return an empty array and say so in the summary.
+Always include both "comments" and "resolutions" arrays (use empty arrays when
+there are no items). The "resolutions" array is populated when prior feedback
+exists — see resolution evaluation instructions below.
+After the JSON object, add a brief summary paragraph.
+If the code looks good, return empty arrays and say so in the summary.
 """
 
 DEFAULT_DISCUSSION_PROMPT = """\
@@ -136,7 +150,26 @@ listing the files you changed (same format as the coding prompt):
 }
 ```
 
-If you did NOT make code changes (question, resolution, or explanation),
+If the developer is signaling that prior feedback has been addressed (e.g.,
+"fixed", "done", "addressed", "resolved"), evaluate whether the issue is
+truly resolved and end your reply with a JSON block:
+
+```json
+{
+  "resolution": {
+    "discussion_id": "<current thread discussion ID>",
+    "status": "resolved|not_addressed|partial",
+    "message": "Brief explanation"
+  }
+}
+```
+
+Status values:
+- "resolved": The feedback issue has been fully addressed
+- "not_addressed": The issue remains despite the developer's claim
+- "partial": Some aspects addressed but others remain
+
+If you did NOT make code changes AND there is no resolution signal,
 just respond with your answer — no JSON block needed.
 
 Guidelines:

--- a/src/gitlab_copilot_agent/review_engine.py
+++ b/src/gitlab_copilot_agent/review_engine.py
@@ -10,7 +10,7 @@ import structlog
 from pydantic import BaseModel, ConfigDict, Field
 
 from gitlab_copilot_agent.config import Settings
-from gitlab_copilot_agent.prompt_defaults import DEFAULT_REVIEW_PROMPT, get_prompt
+from gitlab_copilot_agent.prompt_defaults import get_prompt
 from gitlab_copilot_agent.task_executor import TaskExecutor, TaskParams, TaskResult
 
 if TYPE_CHECKING:
@@ -34,7 +34,32 @@ in Agent's Prior Feedback, even if line numbers have shifted.
 feedback still applies — do not re-comment.\
 """
 
-REVIEW_SYSTEM_PROMPT = DEFAULT_REVIEW_PROMPT
+_RESOLUTION_EVAL_INSTRUCTIONS = """\
+## Resolution Evaluation
+
+For each item in "Agent's Prior Feedback (Unresolved)" above, evaluate whether
+the new diff addresses the feedback. Include a "resolutions" array in your JSON
+output with one entry per prior feedback item:
+
+```json
+{
+  "resolutions": [
+    {
+      "discussion_id": "<discussion_id from prior feedback>",
+      "status": "resolved|not_addressed|partial",
+      "message": "Brief explanation of why the feedback is/isn't addressed"
+    }
+  ]
+}
+```
+
+Status values:
+- "resolved": The code change fully addresses the feedback
+- "not_addressed": The feedback issue remains in the code
+- "partial": Some aspects addressed but others remain (always explain what's left)
+
+If there is no prior feedback, return an empty resolutions array.\
+"""
 
 
 class ReviewRequest(BaseModel):
@@ -60,7 +85,7 @@ def _format_prior_feedback(history: DiscussionHistory) -> str:
     Returns the complete section (header + grouped comments + rules) or an
     empty string when no qualifying comments exist.
     """
-    comments_by_file: dict[str, list[tuple[int | None, str]]] = defaultdict(list)
+    comments_by_file: dict[str, list[tuple[int | None, str, str]]] = defaultdict(list)
 
     for disc in history.discussions:
         if disc.is_resolved or not disc.is_inline:
@@ -87,7 +112,7 @@ def _format_prior_feedback(history: DiscussionHistory) -> str:
             except ValueError:
                 line_num = None
         body = _strip_comment_formatting(first_note.body)
-        comments_by_file[file_path].append((line_num, body))
+        comments_by_file[file_path].append((line_num, body, disc.discussion_id))
 
     if not comments_by_file:
         return ""
@@ -95,11 +120,11 @@ def _format_prior_feedback(history: DiscussionHistory) -> str:
     lines = ["## Agent's Prior Feedback (Unresolved)\n"]
     for file_path in sorted(comments_by_file):
         lines.append(f"### {file_path}")
-        for line_num, body in sorted(
+        for line_num, body, disc_id in sorted(
             comments_by_file[file_path], key=lambda c: (c[0] is None, c[0] or 0)
         ):
             prefix = f"Line {line_num}" if line_num is not None else "General"
-            lines.append(f"- {prefix}: {body}")
+            lines.append(f"- {prefix}: {body} [discussion: {disc_id}]")
         lines.append("")  # blank line between files
 
     lines.append(_PRIOR_FEEDBACK_RULES)
@@ -139,6 +164,7 @@ def build_review_prompt(
         prior_section = _format_prior_feedback(discussion_history)
         if prior_section:
             prompt += f"\n\n{prior_section}"
+            prompt += f"\n\n{_RESOLUTION_EVAL_INSTRUCTIONS}"
     return prompt
 
 
@@ -150,11 +176,15 @@ async def run_review(
     review_request: ReviewRequest,
     diff_text: str | None = None,
     discussion_history: DiscussionHistory | None = None,
+    head_sha: str = "",
 ) -> TaskResult:
     """Run a Copilot agent review and return the structured result."""
+    task_id = f"review-{review_request.source_branch}"
+    if head_sha:
+        task_id = f"{task_id}-{head_sha[:12]}"
     task = TaskParams(
         task_type="review",
-        task_id=f"review-{review_request.source_branch}",
+        task_id=task_id,
         repo_url=repo_url,
         branch=review_request.source_branch,
         system_prompt=get_prompt(settings, "review"),

--- a/src/gitlab_copilot_agent/task_runner.py
+++ b/src/gitlab_copilot_agent/task_runner.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import os
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -50,6 +51,40 @@ _RETRY_PROMPT = (
     '{"summary": "Brief description of changes", "files_changed": ["path/to/file.py"]}\n'
     "```"
 )
+
+_REVIEW_RETRY_PROMPT = (
+    "Your review output used a JSON array instead of a JSON object. "
+    "Reformat your ENTIRE review as a JSON object with 'comments' and "
+    "'resolutions' keys — do NOT use a bare array:\n\n"
+    "```json\n"
+    "{\n"
+    '  "comments": [{...}, ...],\n'
+    '  "resolutions": []\n'
+    "}\n"
+    "```\n\n"
+    "After the JSON object, add a brief summary paragraph."
+)
+
+
+def _review_response_validator(response: str) -> str | None:
+    """Return a follow-up prompt if the review response uses array instead of object format."""
+    if not response.strip():
+        return _REVIEW_RETRY_PROMPT
+
+    from gitlab_copilot_agent.comment_parser import parse_review
+
+    parsed = parse_review(response)
+    if parsed.comments:
+        return None
+    # Check if the LLM output a JSON array instead of an object
+    stripped = response.strip()
+    fence_match = re.search(r"```json\s*\n(\[.*?\])\s*\n```", stripped, re.DOTALL)
+    if fence_match:
+        return _REVIEW_RETRY_PROMPT
+    idx = stripped.find("[")
+    if idx != -1 and (stripped.find("{") == -1 or idx < stripped.find("{")):
+        return _REVIEW_RETRY_PROMPT
+    return None
 
 
 def _coding_response_validator(response: str) -> str | None:
@@ -316,7 +351,13 @@ async def run_task() -> int:  # noqa: C901 — dispatch routing requires branchi
             prompt,
             user_prompt,
             task_type=task_type,
-            validate_response=_coding_response_validator if task_type == "coding" else None,
+            validate_response=(
+                _coding_response_validator
+                if task_type == "coding"
+                else _review_response_validator
+                if task_type == "review"
+                else None
+            ),
             plugins=plugins,
         )
         await bound_log.ainfo(

--- a/src/gitlab_copilot_agent/webhook.py
+++ b/src/gitlab_copilot_agent/webhook.py
@@ -68,6 +68,14 @@ async def _process_review(request: Request, payload: MergeRequestWebhookPayload)
     credential_registry: CredentialRegistry | None = getattr(
         request.app.state, "credential_registry", None
     )
+    resolution_behavior = settings.resolution_behavior
+    credential_ref = "default"
+    if registry is not None:
+        resolved = registry.get_by_project_id(project_id)
+        if resolved is not None:
+            resolution_behavior = resolved.resolution_behavior
+            credential_ref = resolved.credential_ref
+
     bound = log.bind(project_id=project_id, mr_iid=mr.iid, head_sha=head_sha)
     bound.info("background_review_starting")
     try:
@@ -77,6 +85,8 @@ async def _process_review(request: Request, payload: MergeRequestWebhookPayload)
             executor,
             project_token=project_token,
             credential_registry=credential_registry,
+            resolution_behavior=resolution_behavior,
+            credential_ref=credential_ref,
         )
         review_tracker.mark(project_id, mr.iid, head_sha)
         # Also mark in shared dedup store so the poller won't re-review
@@ -143,6 +153,14 @@ async def _process_discussion(
     repo_locks = request.app.state.repo_locks
     registry: ProjectRegistry | None = getattr(request.app.state, "project_registry", None)
     project_token = _resolve_project_token(payload.project.id, registry, settings.gitlab_token)
+
+    # Resolve resolution behavior from project registry or global settings
+    resolution_behavior = settings.resolution_behavior
+    if registry is not None:
+        resolved_project = registry.get_by_project_id(payload.project.id)
+        if resolved_project is not None:
+            resolution_behavior = resolved_project.resolution_behavior
+
     bound = log.bind(
         project_id=payload.project.id,
         mr_iid=payload.merge_request.iid if payload.merge_request else None,
@@ -157,6 +175,7 @@ async def _process_discussion(
             agent_identity,
             project_token=project_token,
             repo_locks=repo_locks,
+            resolution_behavior=resolution_behavior,
         )
         bound.info("background_discussion_completed")
     except Exception:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ GITLAB_TOKEN = "test-token"
 WEBHOOK_SECRET = "test-secret"
 GITHUB_TOKEN = "gho_test_token"
 HEADERS = {"X-Gitlab-Token": WEBHOOK_SECRET}
+RESOLUTION_BEHAVIOR = "suggest"
 
 # Jira constants
 JIRA_URL = "https://jira.example.com"
@@ -83,8 +84,8 @@ MR_PAYLOAD: dict[str, Any] = {
 
 FAKE_REVIEW_OUTPUT = (
     "```json\n"
-    '[{"file": "src/main.py", "line": 10, "severity": "warning", '
-    '"comment": "Consider error handling here"}]\n'
+    '{"comments": [{"file": "src/main.py", "line": 10, "severity": "warning", '
+    '"comment": "Consider error handling here"}], "resolutions": []}\n'
     "```\n"
     "Overall the changes look reasonable."
 )

--- a/tests/e2e/.env.e2e
+++ b/tests/e2e/.env.e2e
@@ -18,3 +18,4 @@ JIRA_TRIGGER_STATUS="AI Ready"
 JIRA_POLL_INTERVAL=5
 COPILOT_PLUGINS=/opt/test-marketplace/plugins/e2e-greeter
 COPILOT_PLUGIN_MARKETPLACES=/opt/test-marketplace
+RESOLUTION_BEHAVIOR=suggest

--- a/tests/e2e/mock_gitlab.py
+++ b/tests/e2e/mock_gitlab.py
@@ -142,6 +142,16 @@ async def get_discussion(project_id: int, mr_iid: int, discussion_id: str) -> di
     return {"id": discussion_id, "notes": []}
 
 
+@app.put("/api/v4/projects/{project_id}/merge_requests/{mr_iid}/discussions/{discussion_id}")
+async def resolve_discussion(
+    project_id: int, mr_iid: int, discussion_id: str, request: Request
+) -> dict:
+    """Record a discussion resolution."""
+    body = await request.json()
+    discussions.append({"_type": "resolve", "discussion_id": discussion_id, **body})
+    return {"id": discussion_id, "resolved": body.get("resolved", True)}
+
+
 @app.post(
     "/api/v4/projects/{project_id}/merge_requests/{mr_iid}/discussions/{discussion_id}/notes"
 )

--- a/tests/e2e/mock_llm.py
+++ b/tests/e2e/mock_llm.py
@@ -14,17 +14,20 @@ app = FastAPI()
 
 # Canned review matching comment_parser.py's expected format
 CANNED_REVIEW = json.dumps(
-    [
-        {
-            "file": "app.py",
-            "line": 1,
-            "severity": "info",
-            "comment": "E2E test review comment — import os is unused.",
-            "suggestion": None,
-            "suggestion_start_offset": 0,
-            "suggestion_end_offset": 0,
-        }
-    ]
+    {
+        "comments": [
+            {
+                "file": "app.py",
+                "line": 1,
+                "severity": "info",
+                "comment": "E2E test review comment — import os is unused.",
+                "suggestion": None,
+                "suggestion_start_offset": 0,
+                "suggestion_end_offset": 0,
+            }
+        ],
+        "resolutions": [],
+    }
 )
 
 CANNED_REVIEW_RESPONSE = f"""```json

--- a/tests/test_comment_parser.py
+++ b/tests/test_comment_parser.py
@@ -1,13 +1,23 @@
 """Tests for comment parsing."""
 
-from gitlab_copilot_agent.comment_parser import parse_review
+from gitlab_copilot_agent.comment_parser import (
+    ParsedReview,
+    Resolution,
+    ReviewComment,
+    parse_review,
+)
+
+DISCUSSION_ID_ALPHA = "disc_abc123"
+DISCUSSION_ID_BETA = "disc_def456"
+RESOLUTION_STATUS_RESOLVED = "resolved"
+RESOLUTION_MSG = "Acknowledged — fix verified"
 
 
 def test_parse_structured_json_in_code_fence() -> None:
     raw = (
         "Here is my review:\n```json\n"
-        '[{"file": "src/main.py", "line": 10, "severity": "error", '
-        '"comment": "Missing null check"}]\n```\n'
+        '{"comments": [{"file": "src/main.py", "line": 10, "severity": "error", '
+        '"comment": "Missing null check"}], "resolutions": []}\n```\n'
         "Overall the code needs work."
     )
     result = parse_review(raw)
@@ -19,15 +29,18 @@ def test_parse_structured_json_in_code_fence() -> None:
     assert "needs work" in result.summary
 
 
-def test_parse_bare_json_array() -> None:
-    raw = '[{"file": "a.py", "line": 1, "severity": "info", "comment": "ok"}]\nLooks good.'
+def test_parse_bare_json_object() -> None:
+    raw = (
+        '{"comments": [{"file": "a.py", "line": 1, "severity": "info", '
+        '"comment": "ok"}], "resolutions": []}\nLooks good.'
+    )
     result = parse_review(raw)
     assert len(result.comments) == 1
     assert "Looks good" in result.summary
 
 
-def test_parse_empty_array() -> None:
-    raw = "```json\n[]\n```\nAll good, no issues found."
+def test_parse_empty_object() -> None:
+    raw = '```json\n{"comments": [], "resolutions": []}\n```\nAll good, no issues found.'
     result = parse_review(raw)
     assert len(result.comments) == 0
     assert "no issues" in result.summary
@@ -41,7 +54,7 @@ def test_parse_freetext_fallback() -> None:
 
 
 def test_parse_malformed_json_fallback() -> None:
-    raw = "```json\n[{broken json}]\n```\nSome summary."
+    raw = "```json\n{broken json}\n```\nSome summary."
     result = parse_review(raw)
     assert len(result.comments) == 0
     assert len(result.summary) > 0
@@ -50,9 +63,9 @@ def test_parse_malformed_json_fallback() -> None:
 def test_parse_skips_invalid_items() -> None:
     raw = (
         "```json\n"
-        '[{"file": "a.py", "line": 5, "comment": "good"}, '
+        '{"comments": [{"file": "a.py", "line": 5, "comment": "good"}, '
         '"not an object", '
-        '{"missing_required": true}]\n```\nDone.'
+        '{"missing_required": true}], "resolutions": []}\n```\nDone.'
     )
     result = parse_review(raw)
     assert len(result.comments) == 1
@@ -62,9 +75,9 @@ def test_parse_skips_invalid_items() -> None:
 def test_parse_comment_with_suggestion() -> None:
     raw = (
         "```json\n"
-        '[{"file": "calc.py", "line": 8, "severity": "error", '
+        '{"comments": [{"file": "calc.py", "line": 8, "severity": "error", '
         '"comment": "Missing type hints", '
-        '"suggestion": "def add(a: int, b: int) -> int:"}]\n```\nDone.'
+        '"suggestion": "def add(a: int, b: int) -> int:"}], "resolutions": []}\n```\nDone.'
     )
     result = parse_review(raw)
     assert len(result.comments) == 1
@@ -77,10 +90,11 @@ def test_parse_comment_with_suggestion() -> None:
 def test_parse_comment_with_multiline_suggestion() -> None:
     raw = (
         "```json\n"
-        '[{"file": "calc.py", "line": 10, "severity": "warning", '
+        '{"comments": [{"file": "calc.py", "line": 10, "severity": "warning", '
         '"comment": "Refactor block", '
         '"suggestion": "    x = 1\\n    y = 2", '
-        '"suggestion_start_offset": 2, "suggestion_end_offset": 1}]\n```\nDone.'
+        '"suggestion_start_offset": 2, "suggestion_end_offset": 1}], "resolutions": []}'
+        "\n```\nDone."
     )
     result = parse_review(raw)
     c = result.comments[0]
@@ -92,8 +106,119 @@ def test_parse_comment_with_multiline_suggestion() -> None:
 def test_parse_comment_without_suggestion_has_none() -> None:
     raw = (
         "```json\n"
-        '[{"file": "a.py", "line": 1, "severity": "info", "comment": "Looks fine"}]\n```\nOk.'
+        '{"comments": [{"file": "a.py", "line": 1, "severity": "info", '
+        '"comment": "Looks fine"}], "resolutions": []}\n```\nOk.'
     )
     result = parse_review(raw)
     assert result.comments[0].suggestion is None
     assert result.comments[0].suggestion_start_offset == 0
+
+
+# ---------------------------------------------------------------------------
+# Resolution model tests
+# ---------------------------------------------------------------------------
+
+
+def test_resolution_model_valid() -> None:
+    r = Resolution(
+        discussion_id=DISCUSSION_ID_ALPHA,
+        status=RESOLUTION_STATUS_RESOLVED,
+        message=RESOLUTION_MSG,
+    )
+    assert r.discussion_id == DISCUSSION_ID_ALPHA
+    assert r.status == RESOLUTION_STATUS_RESOLVED
+    assert r.message == RESOLUTION_MSG
+
+
+def test_parsed_review_empty_resolutions_by_default() -> None:
+    review = ParsedReview(
+        comments=[
+            ReviewComment(file="a.py", line=1, comment="ok"),
+        ],
+        summary="All good.",
+    )
+    assert review.resolutions == []
+
+
+def test_parse_review_object_with_resolutions() -> None:
+    """JSON object with comments and resolutions → both extracted."""
+    raw = (
+        "```json\n"
+        '{"comments": [{"file": "src/main.py", "line": 10, "severity": "warning", '
+        '"comment": "Consider error handling"}], '
+        '"resolutions": [{"discussion_id": "' + DISCUSSION_ID_ALPHA + '", '
+        '"status": "' + RESOLUTION_STATUS_RESOLVED + '", '
+        '"message": "' + RESOLUTION_MSG + '"}]}\n'
+        "```\n"
+        "Overall the changes look reasonable."
+    )
+    result = parse_review(raw)
+    assert len(result.comments) == 1
+    assert result.comments[0].file == "src/main.py"
+    assert len(result.resolutions) == 1
+    assert result.resolutions[0].discussion_id == DISCUSSION_ID_ALPHA
+    assert result.resolutions[0].status == RESOLUTION_STATUS_RESOLVED
+    assert result.resolutions[0].message == RESOLUTION_MSG
+    assert "reasonable" in result.summary
+
+
+def test_parse_review_object_empty_resolutions() -> None:
+    """JSON object with empty resolutions → empty list."""
+    raw = (
+        "```json\n"
+        '{"comments": [{"file": "a.py", "line": 1, "severity": "info", '
+        '"comment": "ok"}], "resolutions": []}\n```\nLooks good.'
+    )
+    result = parse_review(raw)
+    assert len(result.comments) == 1
+    assert result.resolutions == []
+
+
+def test_parse_review_summary_after_json() -> None:
+    """Text after JSON block is extracted as summary."""
+    raw = (
+        '```json\n{"comments": [], "resolutions": []}\n```\nThe code looks clean. No issues found.'
+    )
+    result = parse_review(raw)
+    assert result.comments == []
+    assert result.resolutions == []
+    assert "No issues found" in result.summary
+
+
+def test_parsed_review_with_resolutions() -> None:
+    resolutions = [
+        Resolution(
+            discussion_id=DISCUSSION_ID_ALPHA,
+            status=RESOLUTION_STATUS_RESOLVED,
+            message=RESOLUTION_MSG,
+        ),
+        Resolution(
+            discussion_id=DISCUSSION_ID_BETA,
+            status="partial",
+            message="Partially addressed",
+        ),
+    ]
+    review = ParsedReview(
+        comments=[],
+        summary="Review complete.",
+        resolutions=resolutions,
+    )
+    assert len(review.resolutions) == 2
+    assert review.resolutions[0].discussion_id == DISCUSSION_ID_ALPHA
+    assert review.resolutions[1].status == "partial"
+
+
+def test_parse_review_bare_json_with_braces_in_summary() -> None:
+    """Bare JSON followed by summary containing braces → comments extracted correctly."""
+    raw = (
+        '{"comments": [{"file": "src/app.py", "line": 5, "severity": "warning", '
+        '"comment": "Missing validation"}], "resolutions": []}'
+        "\nHere is a code sample with braces: `if x { return y; }` end."
+    )
+    result = parse_review(raw)
+    assert len(result.comments) == 1
+    assert result.comments[0].file == "src/app.py"
+    assert result.comments[0].line == 5
+    assert result.comments[0].comment == "Missing validation"
+    assert "braces" in result.summary
+    assert "{ return y; }" in result.summary

--- a/tests/test_comment_poster.py
+++ b/tests/test_comment_poster.py
@@ -2,8 +2,8 @@
 
 from unittest.mock import MagicMock
 
-from gitlab_copilot_agent.comment_parser import ParsedReview, ReviewComment
-from gitlab_copilot_agent.comment_poster import post_review
+from gitlab_copilot_agent.comment_parser import ParsedReview, Resolution, ReviewComment
+from gitlab_copilot_agent.comment_poster import _handle_resolutions, post_review
 from tests.conftest import DIFF_REFS, MR_IID, PROJECT_ID, make_mr_changes
 
 
@@ -213,3 +213,183 @@ async def test_file_not_in_changes_is_skipped() -> None:
     assert mr.discussions.create.call_count == 0
     # Only summary note (file not in diff is skipped, not posted as fallback)
     assert mr.notes.create.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Resolution handling tests
+# ---------------------------------------------------------------------------
+
+DISC_ID_ONE = "disc_res_001"
+DISC_ID_TWO = "disc_res_002"
+RESOLUTION_MSG_RESOLVED = "Fix verified — error handling added"
+RESOLUTION_MSG_PARTIAL = "Null check added but edge case remains"
+RESOLUTION_MSG_NOT_ADDRESSED = "Issue still present"
+
+
+def _make_resolution(
+    discussion_id: str = DISC_ID_ONE,
+    status: str = "resolved",
+    message: str = RESOLUTION_MSG_RESOLVED,
+) -> Resolution:
+    return Resolution(discussion_id=discussion_id, status=status, message=message)
+
+
+def test_handle_resolutions_off() -> None:
+    """resolution_behavior='off' → no actions taken."""
+    mr = MagicMock()
+    resolutions = [_make_resolution()]
+    result = _handle_resolutions(mr, resolutions, "off")
+    assert result == 0
+    mr.discussions.get.assert_not_called()
+
+
+def test_handle_resolutions_auto_resolve_resolved() -> None:
+    """auto-resolve + resolved → reply with ✅ + resolve thread."""
+    mr = MagicMock()
+    disc = mr.discussions.get.return_value
+    resolutions = [_make_resolution(status="resolved")]
+
+    result = _handle_resolutions(
+        mr,
+        resolutions,
+        "auto-resolve",
+        allowed_discussion_ids=frozenset({DISC_ID_ONE}),
+    )
+
+    assert result == 1
+    mr.discussions.get.assert_called_once_with(DISC_ID_ONE)
+    disc.notes.create.assert_called_once()
+    body = disc.notes.create.call_args[0][0]["body"]
+    assert "✅" in body
+    assert RESOLUTION_MSG_RESOLVED in body
+    assert disc.resolved is True
+    disc.save.assert_called_once()
+
+
+def test_handle_resolutions_auto_resolve_partial() -> None:
+    """auto-resolve + partial → reply with ⚠️, NO resolve."""
+    mr = MagicMock()
+    disc = mr.discussions.get.return_value
+    resolutions = [_make_resolution(status="partial", message=RESOLUTION_MSG_PARTIAL)]
+
+    result = _handle_resolutions(
+        mr,
+        resolutions,
+        "auto-resolve",
+        allowed_discussion_ids=frozenset({DISC_ID_ONE}),
+    )
+
+    assert result == 0
+    disc.notes.create.assert_called_once()
+    body = disc.notes.create.call_args[0][0]["body"]
+    assert "⚠️" in body
+    assert RESOLUTION_MSG_PARTIAL in body
+    disc.save.assert_not_called()
+
+
+def test_handle_resolutions_suggest_resolved() -> None:
+    """suggest + resolved → reply with ✅ only, no resolve."""
+    mr = MagicMock()
+    disc = mr.discussions.get.return_value
+    resolutions = [_make_resolution(status="resolved")]
+
+    result = _handle_resolutions(
+        mr,
+        resolutions,
+        "suggest",
+        allowed_discussion_ids=frozenset({DISC_ID_ONE}),
+    )
+
+    assert result == 0
+    disc.notes.create.assert_called_once()
+    body = disc.notes.create.call_args[0][0]["body"]
+    assert "✅" in body
+    disc.save.assert_not_called()
+
+
+def test_handle_resolutions_not_addressed_skipped() -> None:
+    """not_addressed → no action taken."""
+    mr = MagicMock()
+    resolutions = [_make_resolution(status="not_addressed", message=RESOLUTION_MSG_NOT_ADDRESSED)]
+
+    result = _handle_resolutions(
+        mr,
+        resolutions,
+        "auto-resolve",
+        allowed_discussion_ids=frozenset({DISC_ID_ONE}),
+    )
+
+    assert result == 0
+    mr.discussions.get.assert_not_called()
+
+
+def test_handle_resolutions_error_logged(caplog: object) -> None:
+    """Exception during resolve → logged, not raised."""
+    mr = MagicMock()
+    mr.discussions.get.side_effect = Exception("API error")
+    resolutions = [_make_resolution()]
+
+    result = _handle_resolutions(
+        mr,
+        resolutions,
+        "auto-resolve",
+        allowed_discussion_ids=frozenset({DISC_ID_ONE}),
+    )
+
+    assert result == 0
+
+
+async def test_post_review_with_resolution_behavior() -> None:
+    """resolution_behavior flows through post_review to _handle_resolutions."""
+    gl = MagicMock()
+    mr_mock = gl.projects.get(PROJECT_ID).mergerequests.get(MR_IID)
+    disc_mock = mr_mock.discussions.get.return_value
+
+    resolutions = [_make_resolution()]
+    review = ParsedReview(
+        comments=[],
+        summary="Review complete.",
+        resolutions=resolutions,
+    )
+    await post_review(
+        gl,
+        PROJECT_ID,
+        MR_IID,
+        DIFF_REFS,
+        review,
+        make_mr_changes(),
+        resolution_behavior="auto-resolve",
+        allowed_discussion_ids=frozenset({DISC_ID_ONE}),
+    )
+
+    mr_mock.discussions.get.assert_called_once_with(DISC_ID_ONE)
+    disc_mock.notes.create.assert_called_once()
+    assert disc_mock.resolved is True
+    disc_mock.save.assert_called_once()
+    # Summary note still posted
+    assert mr_mock.notes.create.call_count == 1
+
+
+def test_handle_resolutions_rejects_unknown_discussion_id() -> None:
+    """Resolution with discussion_id not in allowlist is skipped with warning log."""
+    mr = MagicMock()
+    resolutions = [_make_resolution(discussion_id="disc_unknown")]
+    allowed = frozenset({DISC_ID_ONE, DISC_ID_TWO})
+
+    result = _handle_resolutions(mr, resolutions, "auto-resolve", allowed_discussion_ids=allowed)
+
+    assert result == 0
+    mr.discussions.get.assert_not_called()
+
+
+def test_handle_resolutions_empty_allowlist_blocks_all() -> None:
+    """When allowed_discussion_ids is empty, all resolutions are skipped (fail closed)."""
+    mr = MagicMock()
+    resolutions = [_make_resolution(status="resolved")]
+
+    result = _handle_resolutions(
+        mr, resolutions, "auto-resolve", allowed_discussion_ids=frozenset()
+    )
+
+    assert result == 0
+    mr.discussions.get.assert_not_called()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -285,3 +285,25 @@ def test_no_deprecation_warning_without_agent_username() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
         make_settings()  # should not raise
+
+
+# -- Resolution behavior config tests --
+
+
+def test_resolution_behavior_default() -> None:
+    """Settings with defaults has resolution_behavior='suggest'."""
+    settings = make_settings()
+    assert settings.resolution_behavior == "suggest"
+
+
+def test_resolution_behavior_valid_values() -> None:
+    """All valid resolution_behavior values are accepted."""
+    for value in ("auto-resolve", "suggest", "off"):
+        settings = make_settings(resolution_behavior=value)
+        assert settings.resolution_behavior == value
+
+
+def test_resolution_behavior_invalid() -> None:
+    """Settings with invalid resolution_behavior raises ValidationError."""
+    with pytest.raises(ValidationError, match="resolution_behavior"):
+        make_settings(resolution_behavior="invalid")

--- a/tests/test_discussion_engine.py
+++ b/tests/test_discussion_engine.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import AsyncMock
 
+from gitlab_copilot_agent.comment_parser import Resolution
 from gitlab_copilot_agent.discussion_engine import (
     DiscussionResponse,
     build_discussion_prompt,
@@ -169,6 +170,15 @@ class TestBuildDiscussionPrompt:
         prompt = build_discussion_prompt(_make_mr_details(), history, disc)
         assert prompt.endswith("Respond to the latest message in the Current Thread above.")
 
+    def test_build_discussion_prompt_includes_discussion_id(self) -> None:
+        """Prompt contains the triggering discussion ID for LLM reference."""
+        agent = _make_agent()
+        disc = _make_discussion(discussion_id="disc-xyz-999")
+        history = DiscussionHistory(discussions=[disc], agent=agent)
+        prompt = build_discussion_prompt(_make_mr_details(), history, disc)
+        assert "disc-xyz-999" in prompt
+        assert "discussion ID: disc-xyz-999" in prompt
+
 
 # -- Response parsing tests --
 
@@ -247,3 +257,96 @@ class TestRunDiscussion:
         assert task.user_prompt == user_prompt
         assert task.repo_url == EXAMPLE_CLONE_URL
         assert task.branch == SOURCE_BRANCH
+
+
+# -- Resolution parsing tests --
+
+RESOLUTION_DISCUSSION_ID = "disc-res-001"
+RESOLUTION_MESSAGE = "The input validation has been added."
+
+
+def _make_resolution(
+    discussion_id: str = RESOLUTION_DISCUSSION_ID,
+    status: str = "resolved",
+    message: str = RESOLUTION_MESSAGE,
+) -> Resolution:
+    return Resolution(discussion_id=discussion_id, status=status, message=message)
+
+
+class TestDiscussionResponseResolution:
+    def test_discussion_response_with_resolution(self) -> None:
+        """DiscussionResponse can be created with a Resolution field."""
+        res = _make_resolution()
+        resp = DiscussionResponse(reply="Got it.", resolution=res)
+        assert resp.resolution is not None
+        assert resp.resolution.discussion_id == RESOLUTION_DISCUSSION_ID
+        assert resp.resolution.status == "resolved"
+        assert resp.resolution.message == RESOLUTION_MESSAGE
+
+    def test_discussion_response_resolution_none_by_default(self) -> None:
+        """DiscussionResponse().resolution defaults to None."""
+        resp = DiscussionResponse(reply="Hello")
+        assert resp.resolution is None
+
+
+class TestParseDiscussionResponseResolution:
+    def test_parse_discussion_response_with_resolution_json(self) -> None:
+        """Raw output with resolution JSON → resolution parsed."""
+        raw = (
+            "I've verified the fix.\n\n"
+            "```json\n"
+            '{"resolution": {"discussion_id": "disc-res-001", '
+            '"status": "resolved", "message": "Fix confirmed."}}'
+            "\n```"
+        )
+        result = parse_discussion_response(raw)
+        assert result.has_code_changes is False
+        assert result.resolution is not None
+        assert result.resolution.discussion_id == RESOLUTION_DISCUSSION_ID
+        assert result.resolution.status == "resolved"
+        assert result.resolution.message == "Fix confirmed."
+        assert "verified the fix" in result.reply.lower()
+
+    def test_parse_discussion_response_without_resolution(self) -> None:
+        """Regular reply → resolution is None."""
+        raw = "This looks good to me."
+        result = parse_discussion_response(raw)
+        assert result.resolution is None
+        assert result.has_code_changes is False
+
+    def test_parse_discussion_response_with_files_and_resolution(self) -> None:
+        """JSON block with both files_changed and resolution → both extracted."""
+        raw = (
+            "Applied the fix.\n\n"
+            "```json\n"
+            '{"summary": "Added validation", "files_changed": ["src/app.py"], '
+            '"resolution": {"discussion_id": "disc-res-001", '
+            '"status": "resolved", "message": "Validation added."}}'
+            "\n```"
+        )
+        result = parse_discussion_response(raw)
+        assert result.has_code_changes is True
+        assert result.resolution is not None
+        assert result.resolution.status == "resolved"
+        assert "Applied the fix" in result.reply
+
+    def test_parse_resolution_only_json_no_text_before(self) -> None:
+        """Resolution-only JSON with no text before → reply defaults to 'Acknowledged.'."""
+        raw = (
+            "```json\n"
+            '{"resolution": {"discussion_id": "disc-res-001", '
+            '"status": "resolved", "message": "Done."}}'
+            "\n```"
+        )
+        result = parse_discussion_response(raw)
+        assert result.reply == "Acknowledged."
+        assert result.resolution is not None
+
+    def test_parse_resolution_invalid_resolution_ignored(self) -> None:
+        """Malformed resolution in JSON → resolution is None, reply extracted."""
+        raw = 'Checked.\n\n```json\n{"resolution": "not-a-dict"}\n```'
+        result = parse_discussion_response(raw)
+        # resolution key exists but value is not a dict → resolution is None
+        # but the JSON still had a "resolution" key, so reply is extracted
+        assert result.resolution is None
+        assert "Checked" in result.reply

--- a/tests/test_discussion_orchestrator.py
+++ b/tests/test_discussion_orchestrator.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from gitlab_copilot_agent.comment_parser import Resolution
 from gitlab_copilot_agent.discussion_engine import DiscussionResponse
 from gitlab_copilot_agent.discussion_models import (
     AgentIdentity,
@@ -100,12 +101,13 @@ def _make_discussion_note(
 def _make_discussion(
     discussion_id: str = DISCUSSION_ID,
     notes: list[DiscussionNote] | None = None,
+    is_inline: bool = False,
 ) -> Discussion:
     return Discussion(
         discussion_id=discussion_id,
         notes=notes or [_make_discussion_note()],
         is_resolved=False,
-        is_inline=False,
+        is_inline=is_inline,
     )
 
 
@@ -499,3 +501,267 @@ async def test_deleted_branch_replies_with_warning(
     reply = disc_obj.notes.create.call_args[0][0]["body"]
     assert "deleted" in reply or "inaccessible" in reply
     assert SOURCE_BRANCH in reply
+
+
+# -- Resolution handling tests --
+
+RESOLUTION_DISCUSSION_ID = DISCUSSION_ID
+RESOLUTION_MESSAGE = "Fix confirmed."
+
+
+def _make_resolution(
+    discussion_id: str = RESOLUTION_DISCUSSION_ID,
+    status: str = "resolved",
+    message: str = RESOLUTION_MESSAGE,
+) -> Resolution:
+    return Resolution(discussion_id=discussion_id, status=status, message=message)
+
+
+@patch(f"{_MOD}.gitlab.Gitlab")
+@patch(f"{_MOD}.parse_discussion_response")
+@patch(f"{_MOD}.build_discussion_prompt")
+@patch(f"{_MOD}.run_discussion")
+@patch(f"{_MOD}.GitLabClient")
+async def test_discussion_interaction_auto_resolve(
+    mock_client_cls: MagicMock,
+    mock_run: AsyncMock,
+    mock_build: MagicMock,
+    mock_parse: MagicMock,
+    mock_gl_cls: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """resolution_behavior='auto-resolve' + resolved → thread resolved via API."""
+    from gitlab_copilot_agent.discussion_orchestrator import handle_discussion_interaction
+
+    gl_client = AsyncMock()
+    mock_client_cls.return_value = gl_client
+    gl_client.clone_repo.return_value = tmp_path
+    gl_client.get_mr_details.return_value = MagicMock()
+    # Triggering discussion must be agent-authored + inline for auto-resolve
+    gl_client.list_mr_discussions.return_value = [
+        _make_discussion(
+            notes=[_make_discussion_note(author_id=AGENT_USER_ID)],
+            is_inline=True,
+        )
+    ]
+
+    mock_run.return_value = ReviewResult(summary=REPLY_TEXT)
+    mock_build.return_value = "prompt"
+    mock_parse.return_value = DiscussionResponse(
+        reply=REPLY_TEXT,
+        resolution=_make_resolution(status="resolved"),
+    )
+
+    disc_obj = _gl_thread_mock()
+    _wire_gitlab_sdk(mock_gl_cls, disc_obj)
+
+    executor = AsyncMock()
+    await handle_discussion_interaction(
+        make_settings(),
+        _make_payload(),
+        executor,
+        _make_agent(),
+        resolution_behavior="auto-resolve",
+    )
+
+    # Reply posted
+    disc_obj.notes.create.assert_called_once()
+    # Thread resolved
+    assert disc_obj.resolved is True
+    disc_obj.save.assert_called_once()
+
+
+@patch(f"{_MOD}.gitlab.Gitlab")
+@patch(f"{_MOD}.parse_discussion_response")
+@patch(f"{_MOD}.build_discussion_prompt")
+@patch(f"{_MOD}.run_discussion")
+@patch(f"{_MOD}.GitLabClient")
+async def test_discussion_interaction_suggest_no_resolve(
+    mock_client_cls: MagicMock,
+    mock_run: AsyncMock,
+    mock_build: MagicMock,
+    mock_parse: MagicMock,
+    mock_gl_cls: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """resolution_behavior='suggest' + resolved → reply posted, thread NOT resolved."""
+    from gitlab_copilot_agent.discussion_orchestrator import handle_discussion_interaction
+
+    gl_client = AsyncMock()
+    mock_client_cls.return_value = gl_client
+    gl_client.clone_repo.return_value = tmp_path
+    gl_client.get_mr_details.return_value = MagicMock()
+    gl_client.list_mr_discussions.return_value = [_make_discussion()]
+
+    mock_run.return_value = ReviewResult(summary=REPLY_TEXT)
+    mock_build.return_value = "prompt"
+    mock_parse.return_value = DiscussionResponse(
+        reply=REPLY_TEXT,
+        resolution=_make_resolution(status="resolved"),
+    )
+
+    disc_obj = _gl_thread_mock()
+    _wire_gitlab_sdk(mock_gl_cls, disc_obj)
+
+    executor = AsyncMock()
+    await handle_discussion_interaction(
+        make_settings(),
+        _make_payload(),
+        executor,
+        _make_agent(),
+        resolution_behavior="suggest",
+    )
+
+    # Reply posted
+    disc_obj.notes.create.assert_called_once()
+    # Thread NOT resolved (suggest mode only posts reply)
+    disc_obj.save.assert_not_called()
+
+
+@patch(f"{_MOD}.gitlab.Gitlab")
+@patch(f"{_MOD}.parse_discussion_response")
+@patch(f"{_MOD}.build_discussion_prompt")
+@patch(f"{_MOD}.run_discussion")
+@patch(f"{_MOD}.GitLabClient")
+async def test_discussion_interaction_off_no_action(
+    mock_client_cls: MagicMock,
+    mock_run: AsyncMock,
+    mock_build: MagicMock,
+    mock_parse: MagicMock,
+    mock_gl_cls: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """resolution_behavior='off' → no resolution action at all."""
+    from gitlab_copilot_agent.discussion_orchestrator import handle_discussion_interaction
+
+    gl_client = AsyncMock()
+    mock_client_cls.return_value = gl_client
+    gl_client.clone_repo.return_value = tmp_path
+    gl_client.get_mr_details.return_value = MagicMock()
+    gl_client.list_mr_discussions.return_value = [_make_discussion()]
+
+    mock_run.return_value = ReviewResult(summary=REPLY_TEXT)
+    mock_build.return_value = "prompt"
+    mock_parse.return_value = DiscussionResponse(
+        reply=REPLY_TEXT,
+        resolution=_make_resolution(status="resolved"),
+    )
+
+    disc_obj = _gl_thread_mock()
+    _wire_gitlab_sdk(mock_gl_cls, disc_obj)
+
+    executor = AsyncMock()
+    await handle_discussion_interaction(
+        make_settings(),
+        _make_payload(),
+        executor,
+        _make_agent(),
+        resolution_behavior="off",
+    )
+
+    # Reply still posted
+    disc_obj.notes.create.assert_called_once()
+    # No resolution action
+    disc_obj.save.assert_not_called()
+
+
+@patch(f"{_MOD}.gitlab.Gitlab")
+@patch(f"{_MOD}.parse_discussion_response")
+@patch(f"{_MOD}.build_discussion_prompt")
+@patch(f"{_MOD}.run_discussion")
+@patch(f"{_MOD}.GitLabClient")
+async def test_discussion_interaction_partial_never_resolved(
+    mock_client_cls: MagicMock,
+    mock_run: AsyncMock,
+    mock_build: MagicMock,
+    mock_parse: MagicMock,
+    mock_gl_cls: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Partial resolution → never auto-resolved regardless of behavior."""
+    from gitlab_copilot_agent.discussion_orchestrator import handle_discussion_interaction
+
+    gl_client = AsyncMock()
+    mock_client_cls.return_value = gl_client
+    gl_client.clone_repo.return_value = tmp_path
+    gl_client.get_mr_details.return_value = MagicMock()
+    gl_client.list_mr_discussions.return_value = [_make_discussion()]
+
+    mock_run.return_value = ReviewResult(summary=REPLY_TEXT)
+    mock_build.return_value = "prompt"
+    mock_parse.return_value = DiscussionResponse(
+        reply=REPLY_TEXT,
+        resolution=_make_resolution(status="partial"),
+    )
+
+    disc_obj = _gl_thread_mock()
+    _wire_gitlab_sdk(mock_gl_cls, disc_obj)
+
+    executor = AsyncMock()
+    await handle_discussion_interaction(
+        make_settings(),
+        _make_payload(),
+        executor,
+        _make_agent(),
+        resolution_behavior="auto-resolve",
+    )
+
+    # Reply posted
+    disc_obj.notes.create.assert_called_once()
+    # Partial → never resolved
+    disc_obj.save.assert_not_called()
+
+
+@patch(f"{_MOD}.gitlab.Gitlab")
+@patch(f"{_MOD}.parse_discussion_response")
+@patch(f"{_MOD}.build_discussion_prompt")
+@patch(f"{_MOD}.run_discussion")
+@patch(f"{_MOD}.GitLabClient")
+async def test_discussion_interaction_resolution_error_logged(
+    mock_client_cls: MagicMock,
+    mock_run: AsyncMock,
+    mock_build: MagicMock,
+    mock_parse: MagicMock,
+    mock_gl_cls: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Exception during resolution → logged, not raised."""
+    from gitlab_copilot_agent.discussion_orchestrator import handle_discussion_interaction
+
+    gl_client = AsyncMock()
+    mock_client_cls.return_value = gl_client
+    gl_client.clone_repo.return_value = tmp_path
+    gl_client.get_mr_details.return_value = MagicMock()
+    gl_client.list_mr_discussions.return_value = [
+        _make_discussion(
+            notes=[_make_discussion_note(author_id=AGENT_USER_ID)],
+            is_inline=True,
+        )
+    ]
+
+    mock_run.return_value = ReviewResult(summary=REPLY_TEXT)
+    mock_build.return_value = "prompt"
+    mock_parse.return_value = DiscussionResponse(
+        reply=REPLY_TEXT,
+        resolution=_make_resolution(status="resolved"),
+    )
+
+    disc_obj = _gl_thread_mock()
+    # Make save() raise to simulate resolution failure
+    disc_obj.save.side_effect = RuntimeError("GitLab API error")
+    _wire_gitlab_sdk(mock_gl_cls, disc_obj)
+
+    executor = AsyncMock()
+    # Should NOT raise — resolution errors are swallowed and logged
+    await handle_discussion_interaction(
+        make_settings(),
+        _make_payload(),
+        executor,
+        _make_agent(),
+        resolution_behavior="auto-resolve",
+    )
+
+    # Reply still posted successfully
+    disc_obj.notes.create.assert_called_once()
+    # save() was attempted
+    disc_obj.save.assert_called_once()

--- a/tests/test_gitlab_client.py
+++ b/tests/test_gitlab_client.py
@@ -350,3 +350,34 @@ async def test_get_current_user(mock_gl: MagicMock) -> None:
     assert isinstance(identity, AgentIdentity)
     assert identity.user_id == BOT_USER_ID
     assert identity.username == BOT_USERNAME
+
+
+# -- resolve_discussion / reply_to_discussion tests --
+
+RESOLVE_REPLY_BODY = "✅ Feedback addressed — marking resolved."
+
+
+async def test_resolve_discussion(mock_gl: MagicMock) -> None:
+    """Verify resolve_discussion sets resolved=True and calls save()."""
+    disc_mock = MagicMock()
+    mr_mock = mock_gl.projects.get.return_value.mergerequests.get.return_value
+    mr_mock.discussions.get.return_value = disc_mock
+
+    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
+    await client.resolve_discussion(PROJECT_ID, MR_IID, DISCUSSION_ID)
+
+    mock_gl.projects.get.assert_called_with(PROJECT_ID)
+    assert disc_mock.resolved is True
+    disc_mock.save.assert_called_once()
+
+
+async def test_reply_to_discussion(mock_gl: MagicMock) -> None:
+    """Verify reply_to_discussion posts a note with the given body."""
+    disc_mock = MagicMock()
+    mr_mock = mock_gl.projects.get.return_value.mergerequests.get.return_value
+    mr_mock.discussions.get.return_value = disc_mock
+
+    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
+    await client.reply_to_discussion(PROJECT_ID, MR_IID, DISCUSSION_ID, RESOLVE_REPLY_BODY)
+
+    disc_mock.notes.create.assert_called_once_with({"body": RESOLVE_REPLY_BODY})

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -285,6 +285,31 @@ async def test_discussion_threads_flow_through_pipeline(
 
 
 @patch("gitlab_copilot_agent.orchestrator.post_review", new_callable=AsyncMock)
+@patch("gitlab_copilot_agent.orchestrator.run_review", new_callable=AsyncMock)
+@patch("gitlab_copilot_agent.orchestrator.GitLabClient")
+@patch("gitlab_copilot_agent.orchestrator.gitlab.Gitlab")
+async def test_resolution_behavior_flows_to_post_review(
+    mock_gl_class: MagicMock,
+    mock_client_class: MagicMock,
+    mock_run_review: AsyncMock,
+    mock_post_review: AsyncMock,
+) -> None:
+    """resolution_behavior parameter flows from handle_review to post_review."""
+    _setup_mocks(mock_client_class, mock_run_review)
+
+    await handle_review(
+        make_settings(),
+        make_webhook_payload(),
+        AsyncMock(),
+        resolution_behavior="auto-resolve",
+    )
+
+    mock_post_review.assert_awaited_once()
+    post_kwargs = mock_post_review.call_args[1]
+    assert post_kwargs["resolution_behavior"] == "auto-resolve"
+
+
+@patch("gitlab_copilot_agent.orchestrator.post_review", new_callable=AsyncMock)
 @patch("gitlab_copilot_agent.orchestrator.GitLabClient")
 @patch("gitlab_copilot_agent.orchestrator.gitlab.Gitlab")
 async def test_prior_feedback_rendered_in_prompt(

--- a/tests/test_mapping_models.py
+++ b/tests/test_mapping_models.py
@@ -33,6 +33,8 @@ IN_REVIEW_STATUS = "In Review"
 CUSTOM_TRIGGER = "Ready for Dev"
 CUSTOM_IN_PROGRESS = "Development"
 CUSTOM_IN_REVIEW = "Code Review"
+RESOLUTION_BEHAVIOR_DEFAULT = "suggest"
+RESOLUTION_BEHAVIOR_AUTO = "auto-resolve"
 
 
 # ---------------------------------------------------------------------------
@@ -333,3 +335,49 @@ class TestStatusFields:
         rendered = m.render()
         assert rendered.mappings[JIRA_KEY_PROJ].trigger_status == CUSTOM_TRIGGER
         assert rendered.mappings[JIRA_KEY_OPS].trigger_status == TRIGGER_STATUS
+
+
+# ---------------------------------------------------------------------------
+# Resolution behavior
+# ---------------------------------------------------------------------------
+
+
+class TestResolutionBehavior:
+    def test_defaults_resolution_behavior_default(self) -> None:
+        d = Defaults()
+        assert d.resolution_behavior == RESOLUTION_BEHAVIOR_DEFAULT
+
+    def test_binding_resolution_behavior_override(self) -> None:
+        """Binding override flows through render()."""
+        data = _minimal_mapping(
+            bindings=[_minimal_binding(resolution_behavior=RESOLUTION_BEHAVIOR_AUTO)],
+        )
+        m = MappingFile(**data)
+        rendered = m.render()
+        assert rendered.mappings[JIRA_KEY_PROJ].resolution_behavior == RESOLUTION_BEHAVIOR_AUTO
+
+    def test_binding_resolution_behavior_none_uses_default(self) -> None:
+        """None binding falls back to defaults."""
+        data = _minimal_mapping()
+        m = MappingFile(**data)
+        rendered = m.render()
+        assert rendered.mappings[JIRA_KEY_PROJ].resolution_behavior == RESOLUTION_BEHAVIOR_DEFAULT
+
+    def test_rendered_binding_resolution_behavior(self) -> None:
+        rb = RenderedBinding(
+            repo=REPO_SERVICE_A,
+            target_branch=DEFAULT_BRANCH,
+            credential_ref=DEFAULT_CRED,
+            resolution_behavior=RESOLUTION_BEHAVIOR_AUTO,
+        )
+        assert rb.resolution_behavior == RESOLUTION_BEHAVIOR_AUTO
+
+    def test_defaults_invalid_resolution_behavior_rejected(self) -> None:
+        """Invalid resolution_behavior value raises ValidationError."""
+        with pytest.raises(ValidationError):
+            Defaults(resolution_behavior="invalid_value")  # type: ignore[arg-type]
+
+    def test_binding_invalid_resolution_behavior_rejected(self) -> None:
+        """Invalid resolution_behavior value on Binding raises ValidationError."""
+        with pytest.raises(ValidationError):
+            Binding(**_minimal_binding(resolution_behavior="invalid_value"))

--- a/tests/test_review_engine.py
+++ b/tests/test_review_engine.py
@@ -321,3 +321,56 @@ def test_format_prior_feedback_skips_null_position() -> None:
     history = _make_history(discussions=[disc])
 
     assert _format_prior_feedback(history) == ""
+
+
+# -- Discussion ID and resolution eval instruction tests --
+
+
+def test_prior_feedback_includes_discussion_id() -> None:
+    """Prior feedback lines contain [discussion: ...] tag."""
+    note = _make_agent_note(body="**[WARNING]** Consider error handling")
+    disc = _make_discussion(discussion_id="disc-tag-test", notes=[note])
+    history = _make_history(discussions=[disc])
+
+    result = _format_prior_feedback(history)
+
+    assert "[discussion: disc-tag-test]" in result
+    assert "Consider error handling" in result
+
+
+def test_resolution_eval_instructions_present_when_prior_feedback() -> None:
+    """Resolution evaluation instructions appended when prior feedback exists."""
+    note = _make_agent_note(body="**[WARNING]** Consider error handling")
+    disc = _make_discussion(notes=[note])
+    history = _make_history(discussions=[disc])
+
+    prompt = build_review_prompt(
+        _make_request(), diff_text="some diff", discussion_history=history
+    )
+
+    assert "## Resolution Evaluation" in prompt
+    assert "resolved|not_addressed|partial" in prompt
+    assert "discussion_id" in prompt
+
+
+def test_no_resolution_eval_instructions_without_prior_feedback() -> None:
+    """No resolution evaluation instructions when no prior feedback exists."""
+    # No discussion history at all
+    prompt = build_review_prompt(_make_request(), diff_text="some diff")
+    assert "Resolution Evaluation" not in prompt
+
+    # Empty discussions
+    history = _make_history(discussions=[])
+    prompt = build_review_prompt(
+        _make_request(), diff_text="some diff", discussion_history=history
+    )
+    assert "Resolution Evaluation" not in prompt
+
+    # All resolved discussions
+    note = _make_agent_note()
+    disc = _make_discussion(notes=[note], is_resolved=True)
+    history = _make_history(discussions=[disc])
+    prompt = build_review_prompt(
+        _make_request(), diff_text="some diff", discussion_history=history
+    )
+    assert "Resolution Evaluation" not in prompt

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -16,6 +16,7 @@ from gitlab_copilot_agent.task_runner import (
     _get_required_env,
     _list_changed_paths,
     _parse_task_payload,
+    _review_response_validator,
     _store_result,
     run_task,
 )
@@ -193,7 +194,39 @@ class TestCodingResponseValidator:
         assert result is not None
 
 
-class TestParseAgentOutput:
+class TestReviewResponseValidator:
+    def test_valid_object_format_returns_none(self) -> None:
+        raw = (
+            '```json\n{"comments": [{"file": "a.py", "line": 1, '
+            '"severity": "info", "comment": "ok"}], "resolutions": []}\n```\nSummary.'
+        )
+        assert _review_response_validator(raw) is None
+
+    def test_json_array_in_fence_returns_retry(self) -> None:
+        raw = (
+            '```json\n[{"file": "a.py", "line": 1, '
+            '"severity": "info", "comment": "ok"}]\n```\nSummary.'
+        )
+        result = _review_response_validator(raw)
+        assert result is not None
+        assert "JSON object" in result
+
+    def test_bare_json_array_returns_retry(self) -> None:
+        raw = '[{"file": "a.py", "line": 1, "severity": "info", "comment": "ok"}]\nSummary.'
+        result = _review_response_validator(raw)
+        assert result is not None
+
+    def test_empty_response_returns_retry(self) -> None:
+        result = _review_response_validator("")
+        assert result is not None
+
+    def test_whitespace_only_response_returns_retry(self) -> None:
+        result = _review_response_validator("   \n  ")
+        assert result is not None
+
+    def test_freetext_no_json_returns_none(self) -> None:
+        assert _review_response_validator("The code looks great, no issues.") is None
+
     def test_valid_block(self) -> None:
         out = parse_agent_output(VALID_AGENT_OUTPUT)
         assert out is not None


### PR DESCRIPTION
## What

Add configurable auto-resolution of the agent's addressed feedback threads on GitLab MRs. When prior feedback is addressed — by code push or developer reply — the agent detects this and acts according to a per-project configurable behavior.

Closes #321 (Feature 3)

## Why

When the agent reviews an MR and leaves feedback, developers address that feedback in subsequent pushes or by replying "fixed". Currently the agent has no way to acknowledge or resolve those threads, creating noise — old addressed threads stay open, requiring manual cleanup.

## How

### Three behaviors (configurable via `RESOLUTION_BEHAVIOR` env var + per-project YAML override):
- **`auto-resolve`**: Resolves thread via GitLab API with ✅ acknowledgment reply
- **`suggest`** (default): Posts acknowledgment reply, thread stays open for manual review
- **`off`**: No action taken on addressed feedback

### Two trigger paths:
- **Push-trigger**: When new commits are pushed, the LLM evaluates its prior unresolved feedback against the new diff and outputs resolution determinations
- **Reply-trigger**: When a developer replies "fixed"/"done" to agent feedback, the discussion handler evaluates and acts per config

### Key design decisions:
- Partial fixes are **never** auto-resolved regardless of config
- Resolution errors are logged but never fail the review
- LLM-supplied `discussion_id` values are validated against an allowlist of the agent's own prior feedback (OWASP finding fix)
- `ResolutionBehavior = Literal["auto-resolve", "suggest", "off"]` enforced across all config models
- Parser uses `json.JSONDecoder().raw_decode()` for bare-JSON fallback to handle braces in summary text

### Files changed (33 files, ~1300 additions):

**Source (12)**: comment_parser, comment_poster, config, discussion_engine, discussion_orchestrator, gitlab_client, mapping_models, orchestrator, project_registry, prompt_defaults, review_engine, webhook

**Tests (10)**: 685 tests, 92.48% coverage

**Infra (4)**: variables-apps.tf, container-apps.tf, dev.tfvars, staging.tfvars

**Docs (5)**: configuration-reference, module-reference, data-models, request-flows, architecture-overview

**E2E (2)**: mock_gitlab.py (PUT resolve endpoint), .env.e2e

## Testing

- `uv run pytest`: 685 passed, 92.48% coverage (≥90% threshold)
- `uv run ruff check`: All checks passed
- `uv run pyright src/`: 0 errors
- Cross-model code review (GPT-5.4): 3 High + 1 Medium findings — all fixed
- OWASP security review (GPT-5.4): 2 findings — all fixed

## Deployment

`RESOLUTION_BEHAVIOR` defaults to `suggest` — no action required on deploy. Terraform plan will show a new env block in the container app (safe to apply).