### PR TITLE
feat(review): add incremental MR review via SHA marker

### DIFF
--- a/docs/adr/0009-incremental-review-sha-marker.md
+++ b/docs/adr/0009-incremental-review-sha-marker.md
@@ -1,0 +1,37 @@
+# 0009. SHA Marker for Incremental MR Review State
+
+## Status
+
+Accepted
+
+## Context
+
+Feature 5 (incremental review) needs to know the SHA of the last-reviewed commit to compute an incremental diff. Three mechanisms were evaluated: `oldrev` from webhook payloads, in-memory state on the poller, and a hidden SHA marker embedded in GitLab overview notes.
+
+## Options Considered
+
+### Option A: `oldrev` from webhook + in-memory poller dict
+- Pros: `oldrev` is directly available on webhook update events; no GitLab state needed for webhook path.
+- Cons: `oldrev` reflects last push, not last review (skipped reviews produce wrong diffs). Poller path has no `oldrev` — the GitLab MR list API doesn't return it. In-memory dict is lost on restart.
+
+### Option B: SHA marker in GitLab overview notes
+- Pros: Tracks actual last-reviewed SHA. Survives restarts and deploys. Works identically for webhook and poller paths. Self-healing — absent marker triggers full review.
+- Cons: Requires parsing overview notes. Depends on summary note being posted successfully.
+
+### Option C: Extend DeduplicationStore protocol with value retrieval
+- Pros: Reuses existing infrastructure.
+- Cons: Requires protocol change across all backends (MemoryDedup, Azure). Boolean-only design is intentional for simplicity. Over-engineered for this use case.
+
+## Decision
+
+Option B. Embed `<!-- mr-review-agent: last_reviewed_sha={sha} -->` in the summary note posted after each review. Extract via regex on subsequent reviews. When no marker is found (first review, missed review, post-deploy), fall back to full MR diff — which is the correct behavior for those cases.
+
+The diff selection logic uses marker presence as the single decision point, regardless of webhook action type (open/update/reopen). This eliminates action-based branching and makes the system self-healing.
+
+## Consequences
+
+- Positive: Works for both webhook and poller paths with zero poller changes.
+- Positive: Self-healing — missed reviews automatically get full coverage on the next trigger.
+- Positive: Simplifies orchestrator logic to one branch (marker found vs not found).
+- Negative: First review after Feature 5 deployment always does a full diff (no pre-existing markers). This is acceptable and correct.
+- Negative: If summary note posting fails, next review falls back to full diff. Acceptable degradation.

--- a/docs/wiki/concurrency-and-state.md
+++ b/docs/wiki/concurrency-and-state.md
@@ -261,6 +261,28 @@ await dedup.mark_seen(key, ttl_seconds=86400)
 
 ---
 
+### 4. Incremental Review SHA Marker
+
+**Key**: Hidden HTML comment in summary note body (`<!-- mr-review-agent: last_reviewed_sha={sha} -->`)
+
+**Storage**: GitLab overview note (persisted by GitLab, not in-memory)
+
+**Purpose**: Track the last-reviewed commit SHA for incremental diff computation.
+
+**Mechanism**:
+1. After each review, the SHA marker is embedded in the summary note via `comment_poster.py`
+2. On subsequent reviews, `orchestrator.py` calls `extract_last_reviewed_sha()` to find the marker
+3. If found, the Compare API computes the diff between the marker SHA and current head SHA
+4. If not found (first review, deploy, or failed post), falls back to full MR diff
+
+**Self-Healing**: Absent marker → full review (correct behavior for first review or post-deploy).
+
+**Not a Dedup Mechanism**: The SHA marker does not prevent duplicate reviews — that's handled by `ReviewedMRTracker` and `DeduplicationStore`. The marker only controls diff scope.
+
+See ADR-0009 for the design decision.
+
+---
+
 ## ReviewedMRTracker
 
 **Purpose**: In-memory tracker for reviewed (project_id, mr_iid, head_sha) tuples.

--- a/docs/wiki/data-models.md
+++ b/docs/wiki/data-models.md
@@ -210,7 +210,7 @@ Models for MR discussion history, shared by review and discussion flows. All mod
 | `is_system` | `bool` | — | True for system-generated notes |
 | `resolved` | `bool \| None` | `None` | Resolution status (None if not resolvable) |
 | `resolvable` | `bool` | `False` | Whether the note can be resolved |
-| `position` | `dict[str, object] \| None` | `None` | Diff position: new_path, old_path, new_line, old_line |
+| `position` | `dict[str, object] \| None` | `None` | Diff position: new_path, old_path, new_line, old_line, head_sha |
 
 ---
 

--- a/docs/wiki/module-reference.md
+++ b/docs/wiki/module-reference.md
@@ -36,7 +36,7 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 - `_process_discussion(request: Request, payload: NoteWebhookPayload, agent_identity: AgentIdentity) -> None`: Background task for discussion interactions. Resolves per-project `resolution_behavior` from project registry
 
 **Key Constants**:
-- `HANDLED_ACTIONS = frozenset({"open", "update"})`: MR actions that trigger review
+- `HANDLED_ACTIONS = frozenset({"open", "update", "reopen"})`: MR actions that trigger review
 
 **Internal Imports**: `models`, `orchestrator`, `discussion_orchestrator`, `discussion_models`, `metrics`, `concurrency`, `project_registry`, `credential_registry`
 
@@ -96,6 +96,7 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
   - Clones repo
   - Fetches MR details (title, description, diff_refs, changes)
   - If `credential_registry` provided: fetches discussions via `list_mr_discussions()`, resolves agent identity via `resolve_identity()`, builds `DiscussionHistory`
+  - Extracts last-reviewed SHA marker via `extract_last_reviewed_sha()`; calls `compare_commits()` for incremental diff when marker found, falls back to full MR diff otherwise
   - Builds diff text from MR changes
   - Calls `run_review()` with diff text and discussion history
   - Parses structured review via `parse_review()`
@@ -103,7 +104,7 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
   - Passes `resolution_behavior` to `post_review()` for prior feedback resolution
   - Emits `reviews_total` and `reviews_duration` metrics
 
-**Internal Imports**: `config`, `models`, `task_executor`, `gitlab_client`, `review_engine`, `comment_parser`, `comment_poster`, `metrics`, `telemetry`, `discussion_models`, `credential_registry`
+**Internal Imports**: `config`, `models`, `task_executor`, `gitlab_client`, `review_engine`, `comment_parser`, `comment_poster`, `metrics`, `telemetry`, `discussion_models`, `credential_registry`, `incremental`
 
 **Depended On By**: `webhook.py`, `gitlab_poller.py`
 
@@ -188,9 +189,9 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 - `ReviewRequest`: MR metadata (title, description, source/target branches)
 
 **Key Functions**:
-- `build_review_prompt(req: ReviewRequest, diff_text: str | None = None, discussion_history: DiscussionHistory | None = None) -> str`: Build user prompt; includes diff inline when available and injects prior unresolved feedback
-- `run_review(executor: TaskExecutor, settings: Settings, repo_path: str, repo_url: str, review_request: ReviewRequest, diff_text: str | None = None, discussion_history: DiscussionHistory | None = None) -> TaskResult`: Execute review task and return structured result
-- `_format_prior_feedback(history: DiscussionHistory) -> str`: Render agent's unresolved inline comments as a prompt section. Includes `[discussion: {id}]` tags for LLM resolution referencing
+- `build_review_prompt(req: ReviewRequest, diff_text: str | None = None, discussion_history: DiscussionHistory | None = None, is_incremental: bool = False, head_sha: str = "") -> str`: Build user prompt; includes diff inline when available, injects prior unresolved feedback with outdated position annotations, and labels incremental diffs
+- `run_review(executor: TaskExecutor, settings: Settings, repo_path: str, repo_url: str, review_request: ReviewRequest, diff_text: str | None = None, discussion_history: DiscussionHistory | None = None, head_sha: str = "", is_incremental: bool = False) -> TaskResult`: Execute review task and return structured result. Appends `head_sha` to task ID for dedup
+- `_format_prior_feedback(history: DiscussionHistory, current_head_sha: str = "") -> str`: Render agent's unresolved inline comments as a prompt section. Includes `[discussion: {id}]` tags for LLM resolution referencing. Annotates comments whose `position.head_sha` differs from `current_head_sha` as outdated
 - `_strip_comment_formatting(body: str) -> str`: Remove agent-added severity prefix and suggestion blocks from a comment
 
 **Internal Imports**: `config`, `prompt_defaults`, `task_executor`, `discussion_models` (TYPE_CHECKING)
@@ -391,6 +392,7 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
   - `get_current_user() -> AgentIdentity`: Discover authenticated user identity
   - `resolve_discussion(project_id: int, mr_iid: int, discussion_id: str) -> None`: Resolve a discussion thread (sets resolved=True)
   - `reply_to_discussion(project_id: int, mr_iid: int, discussion_id: str, body: str) -> None`: Post a reply to an existing discussion thread
+  - `compare_commits(project_id: int, from_sha: str, to_sha: str) -> list[MRChange]`: Compare two commits via the Repository Compare API. Returns file changes between SHAs in MRChange format for incremental diff computation
 
 **Internal Imports**: `git_operations`
 
@@ -466,20 +468,39 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 ---
 
 ### `comment_poster.py`
-**Purpose**: Post review comments to GitLab MR as inline discussions and summary. Handles resolution actions for prior feedback.
+**Purpose**: Post review comments to GitLab MR as inline discussions and summary. Handles resolution actions for prior feedback. Embeds SHA marker in summary note for incremental review tracking.
 
 **Key Functions**:
-- `post_review(gitlab_client: gl.Gitlab, project_id: int, mr_iid: int, diff_refs: MRDiffRef, review: ParsedReview, changes: list[MRChange], resolution_behavior: str = "suggest") -> None`: Post inline comments + resolve/acknowledge prior feedback + summary
+- `post_review(gitlab_client: gl.Gitlab, project_id: int, mr_iid: int, diff_refs: MRDiffRef, review: ParsedReview, changes: list[MRChange], resolution_behavior: str = "suggest", allowed_discussion_ids: frozenset[str] = frozenset(), head_sha: str = "") -> None`: Post inline comments + resolve/acknowledge prior feedback + summary with SHA marker
   - Validates comment positions against diff hunks
   - Falls back to note with file:line context if position invalid
   - Processes resolutions via `_handle_resolutions()` before posting summary
+  - When `head_sha` provided, appends `format_sha_marker(head_sha)` to summary note body
 - `_handle_resolutions(mr: object, resolutions: list[Resolution], resolution_behavior: str) -> int`: Process resolutions per configured behavior (auto-resolve/suggest/off). Returns count of resolved threads
 - `_parse_hunk_lines(diff: str, new_path: str) -> set[tuple[str, int]]`: Extract valid (file, line) positions from unified diff
 - `_is_valid_position(file: str, line: int, valid_positions: set[tuple[str, int]]) -> bool`: Check if position valid
 
-**Internal Imports**: `comment_parser`, `gitlab_client`
+**Internal Imports**: `comment_parser`, `gitlab_client`, `incremental`
 
 **Depended On By**: `orchestrator.py`
+
+---
+
+### `incremental.py`
+**Purpose**: SHA marker utilities for incremental MR review. Embeds and extracts a hidden HTML comment in overview notes to track the last-reviewed commit SHA.
+
+**Key Functions**:
+- `extract_last_reviewed_sha(discussion_history: DiscussionHistory | None) -> str | None`: Scans overview notes in reverse chronological order for the SHA marker
+- `format_sha_marker(head_sha: str) -> str`: Generates the hidden HTML comment marker
+
+**Key Constants**:
+- `_SHA_MARKER_RE`: Regex matching `<!-- mr-review-agent: last_reviewed_sha=([a-f0-9]{7,40}) -->`
+
+**Internal Imports**: `discussion_models` (TYPE_CHECKING only)
+
+**Depended On By**: `orchestrator.py` (extraction), `comment_poster.py` (formatting)
+
+**ADR**: 0009-incremental-review-sha-marker.md
 
 ---
 

--- a/docs/wiki/request-flows.md
+++ b/docs/wiki/request-flows.md
@@ -6,7 +6,7 @@ End-to-end data flows with sequence diagrams for each major operation.
 
 ## 1. Webhook MR Review
 
-Triggered when GitLab sends `merge_request` webhook with action `open` or `update` (with new commits).
+Triggered when GitLab sends `merge_request` webhook with action `open`, `update` (with new commits), or `reopen`.
 
 ```mermaid
 sequenceDiagram
@@ -52,7 +52,15 @@ sequenceDiagram
     
     ORCH->>ORCH: Build DiscussionHistory(discussions, agent)
     
-    Note over ORCH: build_review_prompt() renders<br/>prior feedback into prompt
+    ORCH->>ORCH: extract_last_reviewed_sha(discussion_history)
+    alt SHA marker found
+        ORCH->>GLCL: compare_commits(project_id, last_reviewed_sha, head_sha)
+        GLCL-->>ORCH: incremental changes (diff since last review)
+    else No marker (first review / post-deploy / failed post)
+        Note over ORCH: Use full MR diff
+    end
+    
+    Note over ORCH: build_review_prompt() renders<br/>prior feedback + outdated annotations into prompt
     
     ORCH->>EXEC: execute(TaskParams: review)
     alt LocalTaskExecutor
@@ -75,7 +83,7 @@ sequenceDiagram
     ORCH->>GLCL: get_mr_details(project_id, mr_iid)
     GLCL-->>ORCH: MRDetails (diff_refs, changes)
     
-    ORCH->>POST: post_review(gl, project_id, mr_iid, diff_refs, parsed, changes, resolution_behavior)
+    ORCH->>POST: post_review(gl, project_id, mr_iid, diff_refs, parsed, changes, resolution_behavior, head_sha)
     POST->>POST: _parse_hunk_lines() for all changes
     loop For each comment
         POST->>POST: _is_valid_position()
@@ -95,7 +103,7 @@ sequenceDiagram
             end
         end
     end
-    POST->>GL: mr.notes.create() (summary)
+    POST->>GL: mr.notes.create() (summary + SHA marker)
     POST-->>ORCH: Done
     
     ORCH->>GLCL: cleanup(repo_path)

--- a/src/gitlab_copilot_agent/comment_poster.py
+++ b/src/gitlab_copilot_agent/comment_poster.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 
 import structlog
 
+from gitlab_copilot_agent.incremental import format_sha_marker
+
 if TYPE_CHECKING:
     import gitlab as gl
 
@@ -112,6 +114,7 @@ async def post_review(
     changes: list[MRChange],
     resolution_behavior: ResolutionBehavior = "suggest",
     allowed_discussion_ids: frozenset[str] = frozenset(),
+    head_sha: str = "",
 ) -> None:
     """Post inline comments and summary note to a GitLab MR.
 
@@ -191,6 +194,9 @@ async def post_review(
             if resolved > 0:
                 log.info("discussions_resolved", count=resolved)
 
-        mr.notes.create({"body": f"## Code Review Summary\n\n{review.summary}"})
+        summary_body = f"## Code Review Summary\n\n{review.summary}"
+        if head_sha:
+            summary_body += f"\n\n{format_sha_marker(head_sha)}"
+        mr.notes.create({"body": summary_body})
 
     await asyncio.to_thread(_post)

--- a/src/gitlab_copilot_agent/gitlab_client.py
+++ b/src/gitlab_copilot_agent/gitlab_client.py
@@ -368,7 +368,8 @@ class GitLabClient:
             project = self._gl.projects.get(project_id)
             result: dict[str, object] = project.repository_compare(from_sha, to_sha)  # pyright: ignore[reportAssignmentType]
             raw_diffs = result.get("diffs", [])
-            assert isinstance(raw_diffs, list)
+            if not isinstance(raw_diffs, list):
+                return []
             changes: list[MRChange] = []
             for d in raw_diffs:  # pyright: ignore[reportUnknownVariableType]
                 if isinstance(d, dict):

--- a/src/gitlab_copilot_agent/gitlab_client.py
+++ b/src/gitlab_copilot_agent/gitlab_client.py
@@ -106,6 +106,9 @@ class GitLabClientProtocol(Protocol):
     async def reply_to_discussion(
         self, project_id: int, mr_iid: int, discussion_id: str, body: str
     ) -> None: ...
+    async def compare_commits(
+        self, project_id: int, from_sha: str, to_sha: str
+    ) -> list[MRChange]: ...
 
 
 class GitLabClient:
@@ -274,6 +277,7 @@ class GitLabClient:
                             "old_path": raw_pos.get("old_path"),  # pyright: ignore[reportUnknownMemberType]
                             "new_line": raw_pos.get("new_line"),  # pyright: ignore[reportUnknownMemberType]
                             "old_line": raw_pos.get("old_line"),  # pyright: ignore[reportUnknownMemberType]
+                            "head_sha": raw_pos.get("head_sha"),  # pyright: ignore[reportUnknownMemberType]
                         }
 
                     author = raw_note.get("author", {})
@@ -352,3 +356,23 @@ class GitLabClient:
             disc.notes.create({"body": body})
 
         await asyncio.to_thread(_reply)
+
+    async def compare_commits(self, project_id: int, from_sha: str, to_sha: str) -> list[MRChange]:
+        """Compare two commits via the Repository Compare API.
+
+        Returns file changes between from_sha and to_sha in the same
+        shape as MR changes, enabling reuse of existing diff assembly.
+        """
+
+        def _compare() -> list[MRChange]:
+            project = self._gl.projects.get(project_id)
+            result: dict[str, object] = project.repository_compare(from_sha, to_sha)  # pyright: ignore[reportAssignmentType]
+            raw_diffs = result.get("diffs", [])
+            assert isinstance(raw_diffs, list)
+            changes: list[MRChange] = []
+            for d in raw_diffs:  # pyright: ignore[reportUnknownVariableType]
+                if isinstance(d, dict):
+                    changes.append(MRChange.model_validate(d))
+            return changes
+
+        return await asyncio.to_thread(_compare)

--- a/src/gitlab_copilot_agent/incremental.py
+++ b/src/gitlab_copilot_agent/incremental.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from gitlab_copilot_agent.discussion_models import DiscussionHistory
 
 _SHA_MARKER_RE = re.compile(r"<!-- mr-review-agent: last_reviewed_sha=([a-f0-9]{7,40}) -->")
+_SHA_HEX_RE = re.compile(r"^[a-f0-9]{7,40}$")
 
 
 def extract_last_reviewed_sha(
@@ -40,4 +41,6 @@ def extract_last_reviewed_sha(
 
 def format_sha_marker(head_sha: str) -> str:
     """Generate the hidden SHA marker for embedding in summary notes."""
+    if not _SHA_HEX_RE.match(head_sha):
+        raise ValueError(f"Invalid SHA for marker: {head_sha!r}")
     return f"<!-- mr-review-agent: last_reviewed_sha={head_sha} -->"

--- a/src/gitlab_copilot_agent/incremental.py
+++ b/src/gitlab_copilot_agent/incremental.py
@@ -1,0 +1,43 @@
+"""SHA marker utilities for incremental MR review.
+
+Embeds and extracts a hidden HTML comment in overview notes to track
+the last-reviewed commit SHA.  See ADR-0009.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from gitlab_copilot_agent.discussion_models import DiscussionHistory
+
+_SHA_MARKER_RE = re.compile(r"<!-- mr-review-agent: last_reviewed_sha=([a-f0-9]{7,40}) -->")
+
+
+def extract_last_reviewed_sha(
+    discussion_history: DiscussionHistory | None,
+) -> str | None:
+    """Extract the last-reviewed SHA from the agent's most recent summary note.
+
+    Scans overview (non-inline) notes authored by the agent in reverse
+    chronological order for the hidden SHA marker.
+    """
+    if not discussion_history:
+        return None
+
+    for disc in reversed(discussion_history.discussions):
+        if disc.is_inline or disc.is_resolved:
+            continue
+        for note in reversed(disc.notes):
+            if note.author_id != discussion_history.agent.user_id:
+                continue
+            match = _SHA_MARKER_RE.search(note.body)
+            if match:
+                return match.group(1)
+    return None
+
+
+def format_sha_marker(head_sha: str) -> str:
+    """Generate the hidden SHA marker for embedding in summary notes."""
+    return f"<!-- mr-review-agent: last_reviewed_sha={head_sha} -->"

--- a/src/gitlab_copilot_agent/orchestrator.py
+++ b/src/gitlab_copilot_agent/orchestrator.py
@@ -18,6 +18,7 @@ from gitlab_copilot_agent.discussion_models import DiscussionHistory
 from gitlab_copilot_agent.error_messages import user_error_message
 from gitlab_copilot_agent.git_operations import validate_clone_url_host
 from gitlab_copilot_agent.gitlab_client import GitLabClient
+from gitlab_copilot_agent.incremental import extract_last_reviewed_sha
 from gitlab_copilot_agent.metrics import reviews_duration, reviews_total
 from gitlab_copilot_agent.review_engine import ReviewRequest, run_review
 from gitlab_copilot_agent.task_executor import TaskExecutionError
@@ -92,10 +93,36 @@ async def handle_review(
             else:
                 bound_log.debug("discussion_history_skipped", reason="no_credential_registry")
 
-            # Build diff text from MR changes so the LLM reviews only the diff
-            diff_text = "\n".join(
-                f"--- a/{c.old_path}\n+++ b/{c.new_path}\n{c.diff}" for c in mr_details.changes
-            )
+            # Build diff text — incremental when a prior review marker exists
+            head_sha = mr.last_commit.id
+            is_incremental = False
+            diff_text = ""
+            last_reviewed_sha = extract_last_reviewed_sha(discussion_history)
+
+            if last_reviewed_sha and last_reviewed_sha != head_sha:
+                try:
+                    incremental_changes = await gl_client.compare_commits(
+                        project.id, last_reviewed_sha, head_sha
+                    )
+                    if incremental_changes:
+                        diff_text = "\n".join(
+                            f"--- a/{c.old_path}\n+++ b/{c.new_path}\n{c.diff}"
+                            for c in incremental_changes
+                        )
+                        is_incremental = True
+                        bound_log.info(
+                            "incremental_review",
+                            from_sha=last_reviewed_sha[:12],
+                            to_sha=head_sha[:12],
+                            files_changed=len(incremental_changes),
+                        )
+                except Exception:
+                    bound_log.warning("incremental_diff_failed", exc_info=True)
+
+            if not is_incremental:
+                diff_text = "\n".join(
+                    f"--- a/{c.old_path}\n+++ b/{c.new_path}\n{c.diff}" for c in mr_details.changes
+                )
 
             review_req = ReviewRequest(
                 title=mr.title,
@@ -112,7 +139,8 @@ async def handle_review(
                 review_req,
                 diff_text=diff_text,
                 discussion_history=discussion_history,
-                head_sha=mr.last_commit.id,
+                head_sha=head_sha,
+                is_incremental=is_incremental,
             )
             parsed = parse_review(raw_result.summary)
 
@@ -145,6 +173,7 @@ async def handle_review(
                 mr_details.changes,
                 resolution_behavior=resolution_behavior,
                 allowed_discussion_ids=allowed_discussion_ids,
+                head_sha=head_sha,
             )
             bound_log.info("comments_posted")
             outcome = "success"

--- a/src/gitlab_copilot_agent/review_engine.py
+++ b/src/gitlab_copilot_agent/review_engine.py
@@ -79,13 +79,15 @@ def _strip_comment_formatting(body: str) -> str:
     return body.strip()
 
 
-def _format_prior_feedback(history: DiscussionHistory) -> str:
+def _format_prior_feedback(history: DiscussionHistory, current_head_sha: str = "") -> str:
     """Render the agent's unresolved inline comments as a prompt section.
 
     Returns the complete section (header + grouped comments + rules) or an
     empty string when no qualifying comments exist.
     """
-    comments_by_file: dict[str, list[tuple[int | None, str, str]]] = defaultdict(list)
+    comments_by_file: dict[str, list[tuple[int | None, str, str, dict[str, object] | None]]] = (
+        defaultdict(list)
+    )
 
     for disc in history.discussions:
         if disc.is_resolved or not disc.is_inline:
@@ -112,7 +114,9 @@ def _format_prior_feedback(history: DiscussionHistory) -> str:
             except ValueError:
                 line_num = None
         body = _strip_comment_formatting(first_note.body)
-        comments_by_file[file_path].append((line_num, body, disc.discussion_id))
+        comments_by_file[file_path].append(
+            (line_num, body, disc.discussion_id, first_note.position)
+        )
 
     if not comments_by_file:
         return ""
@@ -120,10 +124,18 @@ def _format_prior_feedback(history: DiscussionHistory) -> str:
     lines = ["## Agent's Prior Feedback (Unresolved)\n"]
     for file_path in sorted(comments_by_file):
         lines.append(f"### {file_path}")
-        for line_num, body, disc_id in sorted(
+        for line_num, body, disc_id, position in sorted(
             comments_by_file[file_path], key=lambda c: (c[0] is None, c[0] or 0)
         ):
+            position_head = position.get("head_sha") if position else None
+            is_outdated = (
+                current_head_sha
+                and isinstance(position_head, str)
+                and position_head != current_head_sha
+            )
             prefix = f"Line {line_num}" if line_num is not None else "General"
+            if is_outdated:
+                prefix += " (outdated position — line may have shifted)"
             lines.append(f"- {prefix}: {body} [discussion: {disc_id}]")
         lines.append("")  # blank line between files
 
@@ -135,6 +147,8 @@ def build_review_prompt(
     req: ReviewRequest,
     diff_text: str | None = None,
     discussion_history: DiscussionHistory | None = None,
+    is_incremental: bool = False,
+    head_sha: str = "",
 ) -> str:
     """Build the user prompt — includes the diff directly when available."""
     prompt = (
@@ -152,7 +166,15 @@ def build_review_prompt(
                 max_len=MAX_DIFF_CHARS,
             )
             diff_text = diff_text[:MAX_DIFF_CHARS] + "\n... (diff truncated)"
-        prompt += f"## Diff\n\n```diff\n{diff_text}\n```\n\n"
+        if is_incremental:
+            prompt += (
+                "## Incremental Diff (changes since last review)\n\n"
+                "You are reviewing ONLY the new changes since the last review. "
+                "Prior feedback on unchanged code is listed separately below.\n\n"
+            )
+        else:
+            prompt += "## Diff\n\n"
+        prompt += f"```diff\n{diff_text}\n```\n\n"
         prompt += "Review ONLY the changes shown in the diff above."
     else:
         prompt += (
@@ -161,7 +183,7 @@ def build_review_prompt(
         )
 
     if discussion_history:
-        prior_section = _format_prior_feedback(discussion_history)
+        prior_section = _format_prior_feedback(discussion_history, current_head_sha=head_sha)
         if prior_section:
             prompt += f"\n\n{prior_section}"
             prompt += f"\n\n{_RESOLUTION_EVAL_INSTRUCTIONS}"
@@ -177,6 +199,7 @@ async def run_review(
     diff_text: str | None = None,
     discussion_history: DiscussionHistory | None = None,
     head_sha: str = "",
+    is_incremental: bool = False,
 ) -> TaskResult:
     """Run a Copilot agent review and return the structured result."""
     task_id = f"review-{review_request.source_branch}"
@@ -188,7 +211,13 @@ async def run_review(
         repo_url=repo_url,
         branch=review_request.source_branch,
         system_prompt=get_prompt(settings, "review"),
-        user_prompt=build_review_prompt(review_request, diff_text, discussion_history),
+        user_prompt=build_review_prompt(
+            review_request,
+            diff_text,
+            discussion_history,
+            is_incremental=is_incremental,
+            head_sha=head_sha,
+        ),
         settings=settings,
         repo_path=repo_path,
     )

--- a/src/gitlab_copilot_agent/webhook.py
+++ b/src/gitlab_copilot_agent/webhook.py
@@ -25,7 +25,7 @@ log = structlog.get_logger()
 
 router = APIRouter()
 
-HANDLED_ACTIONS = frozenset({"open", "update"})
+HANDLED_ACTIONS = frozenset({"open", "update", "reopen"})
 
 
 def _resolve_project_token(
@@ -217,7 +217,9 @@ async def webhook(
         if action not in HANDLED_ACTIONS:
             return {"status": "ignored", "reason": f"action '{action}' not handled"}
 
-        # Skip title/description-only updates (no new commits)
+        # Skip title/description-only updates (no new commits).
+        # Note: "reopen" has no oldrev — it passes through to review.
+        # Diff scope is determined by SHA marker presence in orchestrator.py.
         if action == "update" and mr.oldrev is None:
             return {"status": "ignored", "reason": "no new commits"}
 

--- a/tests/e2e/mock_gitlab.py
+++ b/tests/e2e/mock_gitlab.py
@@ -29,6 +29,7 @@ pushes: list[dict] = []
 _open_mrs: list[dict] = []
 _mr_notes: dict[int, list[dict]] = {}  # mr_iid → notes list
 _seeded_discussions: list[dict] = []  # pre-seeded via POST /mock/discussions
+_compare_diffs: list[dict] = []  # controllable diffs for compare endpoint
 
 # Bare git repo created at startup
 _bare_repo: Path | None = None
@@ -91,6 +92,31 @@ async def get_mr(project_id: int, mr_iid: int) -> dict:
 async def get_mr_changes(project_id: int, mr_iid: int) -> dict:
     mr = await get_mr(project_id, mr_iid)
     return mr
+
+
+@app.get("/api/v4/projects/{project_id}/repository/compare")
+async def compare_commits(project_id: int, request: Request) -> dict:
+    """Mock Repository Compare API for incremental review."""
+    from_sha = request.query_params.get("from", "")
+    to_sha = request.query_params.get("to", "")
+    return {
+        "commit": {"id": to_sha},
+        "commits": [],
+        "diffs": _compare_diffs
+        if _compare_diffs
+        else [
+            {
+                "old_path": SAMPLE_FILE,
+                "new_path": SAMPLE_FILE,
+                "diff": SAMPLE_DIFF,
+                "new_file": False,
+                "deleted_file": False,
+                "renamed_file": False,
+            }
+        ],
+        "compare_timeout": False,
+        "compare_same_ref": from_sha == to_sha,
+    }
 
 
 @app.get("/api/v4/projects/{project_id}/merge_requests/{mr_iid}/discussions")
@@ -301,6 +327,21 @@ async def seed_discussions(request: Request) -> dict:
 async def clear_seeded_discussions() -> dict:
     """Clear pre-seeded discussions."""
     _seeded_discussions.clear()
+    return {"cleared": True}
+
+
+@app.post("/mock/compare-diffs")
+async def set_compare_diffs(request: Request) -> dict:
+    """Control what the compare endpoint returns."""
+    body = await request.json()
+    _compare_diffs.clear()
+    _compare_diffs.extend(body if isinstance(body, list) else [body])
+    return {"set": len(_compare_diffs)}
+
+
+@app.delete("/mock/compare-diffs")
+async def clear_compare_diffs() -> dict:
+    _compare_diffs.clear()
     return {"cleared": True}
 
 

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -2,7 +2,8 @@
 # E2E test: deploy agent to k3d, run all test flows against mock services.
 # Tests: 1. Webhook MR review, 2. Jira polling, 3. @mention thread interaction,
 #        4. GitLab polling, 5. Hot-reload config, 6. Plugin install,
-#        7. Graceful shutdown, 8. Discussion history capture.
+#        7. Graceful shutdown, 8. Discussion history capture,
+#        9. Incremental review.
 # Usage: ./tests/e2e/run.sh [agent-url] [mock-gitlab-url] [mock-jira-url]
 set -euo pipefail
 
@@ -366,6 +367,93 @@ print('yes' if has_review else 'no')")
 
 # Clean up seeded discussions
 curl -sf -X DELETE "$MOCK_GITLAB_URL/mock/discussions" > /dev/null
+
+# === TEST 9: Incremental Review with SHA Marker ===
+echo ""; echo "--- Test 9: Incremental Review ---"
+curl -sf "$MOCK_GITLAB_URL/discussions" -X DELETE > /dev/null
+curl -sf "$MOCK_GITLAB_URL/mock/discussions" -X DELETE > /dev/null
+curl -sf "$MOCK_GITLAB_URL/mock/compare-diffs" -X DELETE > /dev/null
+
+# 9a: First review — open event, should do full review
+FIRST_SHA="aaa111aaa111aaa111aaa111aaa111aaa111aaa1"
+echo -n "Sending first review webhook (open)..."
+send_webhook '{
+    "object_kind": "merge_request",
+    "user": {"id": 1, "username": "dev"},
+    "project": {"id": 999, "path_with_namespace": "test/repo",
+                "git_http_url": "http://host.k3d.internal:9999/repo.git"},
+    "object_attributes": {
+        "iid": 9,
+        "title": "Incremental test",
+        "description": "Test incremental review",
+        "action": "open",
+        "source_branch": "feature",
+        "target_branch": "main",
+        "last_commit": {"id": "'"$FIRST_SHA"'", "message": "first commit"},
+        "url": "'"$INTERNAL_GITLAB_URL"'/test/repo/-/merge_requests/9",
+        "oldrev": null
+    }
+}'
+
+poll_until "$MOCK_GITLAB_URL/discussions" \
+    "import sys,json; d=json.load(sys.stdin); print(len(d) if d else 0)" \
+    "Waiting for first review comments" || { kubectl logs -l app.kubernetes.io/name=gitlab-copilot-agent --tail=50 2>/dev/null || true; exit 1; }
+
+# Check summary note contains SHA marker
+echo -n "Checking summary note has SHA marker..."
+SUMMARY=$(curl -sf "$MOCK_GITLAB_URL/discussions" | python3 -c "
+import sys, json
+ds = json.load(sys.stdin)
+count = sum(1 for d in ds if d.get('_type') == 'note' and 'mr-review-agent: last_reviewed_sha=' in d.get('body', ''))
+print(count)")
+[ "$SUMMARY" -gt 0 ] && echo " ✅" || { echo " ❌ Summary note missing SHA marker"; exit 1; }
+
+# 9b: Seed the marker for second review
+curl -sf "$MOCK_GITLAB_URL/mock/discussions" -X POST -H 'Content-Type: application/json' -d '[{
+    "id": "incremental-marker-disc",
+    "individual_note": true,
+    "notes": [{
+        "id": 5000,
+        "type": "DiscussionNote",
+        "body": "## Code Review Summary\n\nLooks good.\n\n<!-- mr-review-agent: last_reviewed_sha='"$FIRST_SHA"' -->",
+        "author": {"id": 9999, "username": "mock-review-bot"},
+        "created_at": "2024-01-15T10:30:00Z",
+        "system": false,
+        "resolvable": false,
+        "resolved": false,
+        "position": null
+    }]
+}]' > /dev/null
+
+# Clear previous discussions for clean second review
+curl -sf "$MOCK_GITLAB_URL/discussions" -X DELETE > /dev/null
+
+# 9c: Second review — update event, should do incremental review
+SECOND_SHA="bbb222bbb222bbb222bbb222bbb222bbb222bbb2"
+echo -n "Sending second review webhook (update)..."
+send_webhook '{
+    "object_kind": "merge_request",
+    "user": {"id": 1, "username": "dev"},
+    "project": {"id": 999, "path_with_namespace": "test/repo",
+                "git_http_url": "http://host.k3d.internal:9999/repo.git"},
+    "object_attributes": {
+        "iid": 9,
+        "title": "Incremental test",
+        "description": "Test incremental review",
+        "action": "update",
+        "source_branch": "feature",
+        "target_branch": "main",
+        "last_commit": {"id": "'"$SECOND_SHA"'", "message": "second commit"},
+        "url": "'"$INTERNAL_GITLAB_URL"'/test/repo/-/merge_requests/9",
+        "oldrev": "'"$FIRST_SHA"'"
+    }
+}'
+
+poll_until "$MOCK_GITLAB_URL/discussions" \
+    "import sys,json; d=json.load(sys.stdin); print(len(d) if d else 0)" \
+    "Waiting for incremental review comments" || { kubectl logs -l app.kubernetes.io/name=gitlab-copilot-agent --tail=50 2>/dev/null || true; exit 1; }
+
+echo "PASS: Incremental review posted comments"
 
 echo ""; echo "=== ALL E2E TESTS PASSED ==="
 exit 0

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -396,17 +396,10 @@ send_webhook '{
 }'
 
 poll_until "$MOCK_GITLAB_URL/discussions" \
-    "import sys,json; d=json.load(sys.stdin); print(len(d) if d else 0)" \
+    "import sys,json; ds=json.load(sys.stdin); print(sum(1 for d in ds if d.get('_type')=='note' and 'mr-review-agent: last_reviewed_sha=' in d.get('body','')))" \
     "Waiting for first review comments" || { kubectl logs -l app.kubernetes.io/name=gitlab-copilot-agent --tail=50 2>/dev/null || true; exit 1; }
 
-# Check summary note contains SHA marker
-echo -n "Checking summary note has SHA marker..."
-SUMMARY=$(curl -sf "$MOCK_GITLAB_URL/discussions" | python3 -c "
-import sys, json
-ds = json.load(sys.stdin)
-count = sum(1 for d in ds if d.get('_type') == 'note' and 'mr-review-agent: last_reviewed_sha=' in d.get('body', ''))
-print(count)")
-[ "$SUMMARY" -gt 0 ] && echo " ✅" || { echo " ❌ Summary note missing SHA marker"; exit 1; }
+echo "PASS: Summary note contains SHA marker"
 
 # 9b: Seed the marker for second review
 curl -sf "$MOCK_GITLAB_URL/mock/discussions" -X POST -H 'Content-Type: application/json' -d '[{

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -72,7 +72,7 @@ send_webhook '{
                 "git_http_url": "http://host.k3d.internal:9999/repo.git"},
     "object_attributes": {"iid": 1, "title": "E2E test MR", "description": "E2E test",
         "action": "open", "source_branch": "main", "target_branch": "main",
-        "last_commit": {"id": "abc123", "message": "test"}, "url": "http://mock/mr/1", "oldrev": null}
+        "last_commit": {"id": "abc123abc123abc123abc123abc123abc123abc1", "message": "test"}, "url": "http://mock/mr/1", "oldrev": null}
 }'
 
 poll_until "$MOCK_GITLAB_URL/discussions" \
@@ -253,7 +253,7 @@ send_webhook '{
                 "git_http_url": "http://host.k3d.internal:9999/repo.git"},
     "object_attributes": {"iid": 99, "title": "Plugin test MR", "description": "Verify plugins",
         "action": "open", "source_branch": "main", "target_branch": "main",
-        "last_commit": {"id": "plugin123", "message": "plugin test"}, "url": "http://mock/mr/99", "oldrev": null}
+        "last_commit": {"id": "aaa111bbb222ccc333ddd444eee555fff666aaa1", "message": "plugin test"}, "url": "http://mock/mr/99", "oldrev": null}
 }'
 
 # Wait for the task to complete (review posted)
@@ -350,7 +350,7 @@ send_webhook '{
                 "git_http_url": "http://host.k3d.internal:9999/repo.git"},
     "object_attributes": {"iid": 321, "title": "Discussion history test MR", "description": "Test with prior feedback",
         "action": "open", "source_branch": "main", "target_branch": "main",
-        "last_commit": {"id": "disc321", "message": "test discussions"}, "url": "http://mock/mr/321", "oldrev": null}
+        "last_commit": {"id": "d15c321d15c321d15c321d15c321d15c321d15c3", "message": "test discussions"}, "url": "http://mock/mr/321", "oldrev": null}
 }'
 
 poll_until "$MOCK_GITLAB_URL/discussions" \

--- a/tests/test_comment_poster.py
+++ b/tests/test_comment_poster.py
@@ -393,3 +393,48 @@ def test_handle_resolutions_empty_allowlist_blocks_all() -> None:
 
     assert result == 0
     mr.discussions.get.assert_not_called()
+
+
+# -- SHA marker embedding tests --
+
+SHA_MARKER_VALUE = "abc123def"
+SHA_MARKER_COMMENT = f"<!-- mr-review-agent: last_reviewed_sha={SHA_MARKER_VALUE} -->"
+
+
+async def test_summary_note_contains_sha_marker() -> None:
+    """post_review with head_sha embeds the SHA marker in the summary note."""
+    gl = MagicMock()
+    review = ParsedReview(comments=[], summary="Review complete.")
+    await post_review(
+        gl,
+        PROJECT_ID,
+        MR_IID,
+        DIFF_REFS,
+        review,
+        make_mr_changes(),
+        head_sha=SHA_MARKER_VALUE,
+    )
+
+    mr = gl.projects.get(PROJECT_ID).mergerequests.get(MR_IID)
+    assert mr.notes.create.call_count == 1
+    body = mr.notes.create.call_args[0][0]["body"]
+    assert SHA_MARKER_COMMENT in body
+
+
+async def test_summary_note_no_marker_when_empty_sha() -> None:
+    """post_review with empty head_sha does not embed a SHA marker."""
+    gl = MagicMock()
+    review = ParsedReview(comments=[], summary="Review complete.")
+    await post_review(
+        gl,
+        PROJECT_ID,
+        MR_IID,
+        DIFF_REFS,
+        review,
+        make_mr_changes(),
+        head_sha="",
+    )
+
+    mr = gl.projects.get(PROJECT_ID).mergerequests.get(MR_IID)
+    body = mr.notes.create.call_args[0][0]["body"]
+    assert "<!-- mr-review-agent:" not in body

--- a/tests/test_gitlab_client.py
+++ b/tests/test_gitlab_client.py
@@ -381,3 +381,58 @@ async def test_reply_to_discussion(mock_gl: MagicMock) -> None:
     await client.reply_to_discussion(PROJECT_ID, MR_IID, DISCUSSION_ID, RESOLVE_REPLY_BODY)
 
     disc_mock.notes.create.assert_called_once_with({"body": RESOLVE_REPLY_BODY})
+
+
+# -- compare_commits tests --
+
+COMPARE_FROM_SHA = "from111"
+COMPARE_TO_SHA = "to222"
+COMPARE_DIFF = "@@ -1,3 +1,4 @@\n+added\n"
+COMPARE_PATH = "src/compare.py"
+
+
+async def test_compare_commits_returns_mr_changes(mock_gl: MagicMock) -> None:
+    """repository_compare returning diffs produces a list[MRChange]."""
+    mock_gl.projects.get.return_value.repository_compare.return_value = {
+        "diffs": [
+            {
+                "old_path": COMPARE_PATH,
+                "new_path": COMPARE_PATH,
+                "diff": COMPARE_DIFF,
+                "new_file": False,
+                "deleted_file": False,
+                "renamed_file": False,
+            }
+        ]
+    }
+
+    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
+    result = await client.compare_commits(PROJECT_ID, COMPARE_FROM_SHA, COMPARE_TO_SHA)
+
+    assert len(result) == 1
+    assert isinstance(result[0], MRChange)
+    assert result[0].new_path == COMPARE_PATH
+    assert result[0].diff == COMPARE_DIFF
+    mock_gl.projects.get.return_value.repository_compare.assert_called_once_with(
+        COMPARE_FROM_SHA, COMPARE_TO_SHA
+    )
+
+
+async def test_compare_commits_empty_diffs(mock_gl: MagicMock) -> None:
+    """repository_compare with no diffs returns empty list."""
+    mock_gl.projects.get.return_value.repository_compare.return_value = {"diffs": []}
+
+    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
+    result = await client.compare_commits(PROJECT_ID, COMPARE_FROM_SHA, COMPARE_TO_SHA)
+
+    assert result == []
+
+
+async def test_compare_commits_propagates_error(mock_gl: MagicMock) -> None:
+    """repository_compare raising an exception propagates to caller."""
+    mock_gl.projects.get.return_value.repository_compare.side_effect = RuntimeError("API failure")
+
+    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
+
+    with pytest.raises(RuntimeError, match="API failure"):
+        await client.compare_commits(PROJECT_ID, COMPARE_FROM_SHA, COMPARE_TO_SHA)

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1,0 +1,134 @@
+"""Tests for the incremental review SHA marker module."""
+
+from gitlab_copilot_agent.discussion_models import (
+    AgentIdentity,
+    Discussion,
+    DiscussionHistory,
+    DiscussionNote,
+)
+from gitlab_copilot_agent.incremental import (
+    _SHA_MARKER_RE,
+    extract_last_reviewed_sha,
+    format_sha_marker,
+)
+
+# -- Constants --
+
+AGENT_USER_ID = 99
+AGENT_USERNAME = "review-bot"
+HUMAN_USER_ID = 1
+HUMAN_USERNAME = "developer"
+SHA_FIRST = "aaa1111"
+SHA_SECOND = "bbb2222"
+TIMESTAMP_EARLY = "2026-04-06T10:00:00Z"
+TIMESTAMP_LATE = "2026-04-06T12:00:00Z"
+
+_AGENT = AgentIdentity(user_id=AGENT_USER_ID, username=AGENT_USERNAME)
+
+
+def _make_note(
+    *,
+    note_id: int = 1,
+    author_id: int = AGENT_USER_ID,
+    body: str = "Summary note",
+    created_at: str = TIMESTAMP_EARLY,
+) -> DiscussionNote:
+    return DiscussionNote(
+        note_id=note_id,
+        author_id=author_id,
+        author_username=AGENT_USERNAME if author_id == AGENT_USER_ID else HUMAN_USERNAME,
+        body=body,
+        created_at=created_at,
+        is_system=False,
+        resolved=None,
+        resolvable=False,
+        position=None,
+    )
+
+
+def _make_discussion(
+    discussion_id: str = "disc-1",
+    notes: list[DiscussionNote] | None = None,
+    is_inline: bool = False,
+    is_resolved: bool = False,
+) -> Discussion:
+    return Discussion(
+        discussion_id=discussion_id,
+        notes=notes or [],
+        is_inline=is_inline,
+        is_resolved=is_resolved,
+    )
+
+
+def _make_history(discussions: list[Discussion] | None = None) -> DiscussionHistory:
+    return DiscussionHistory(discussions=discussions or [], agent=_AGENT)
+
+
+# -- extract_last_reviewed_sha tests --
+
+
+def test_extract_sha_marker_found() -> None:
+    """Overview note with agent marker returns the SHA."""
+    marker_body = f"## Summary\n\n{format_sha_marker(SHA_FIRST)}"
+    note = _make_note(body=marker_body)
+    disc = _make_discussion(notes=[note])
+    history = _make_history(discussions=[disc])
+
+    assert extract_last_reviewed_sha(history) == SHA_FIRST
+
+
+def test_extract_sha_marker_not_found() -> None:
+    """Overview note without marker returns None."""
+    note = _make_note(body="Just a summary, no marker")
+    disc = _make_discussion(notes=[note])
+    history = _make_history(discussions=[disc])
+
+    assert extract_last_reviewed_sha(history) is None
+
+
+def test_extract_sha_marker_empty_history() -> None:
+    """None discussion history returns None."""
+    assert extract_last_reviewed_sha(None) is None
+
+
+def test_extract_sha_marker_skips_inline() -> None:
+    """Marker in an inline (DiffNote) discussion is skipped."""
+    marker_body = f"Inline comment\n{format_sha_marker(SHA_FIRST)}"
+    note = _make_note(body=marker_body)
+    disc = _make_discussion(notes=[note], is_inline=True)
+    history = _make_history(discussions=[disc])
+
+    assert extract_last_reviewed_sha(history) is None
+
+
+def test_extract_sha_marker_skips_non_agent() -> None:
+    """Marker in a human-authored note is skipped."""
+    marker_body = f"Human note\n{format_sha_marker(SHA_FIRST)}"
+    note = _make_note(author_id=HUMAN_USER_ID, body=marker_body)
+    disc = _make_discussion(notes=[note])
+    history = _make_history(discussions=[disc])
+
+    assert extract_last_reviewed_sha(history) is None
+
+
+def test_extract_sha_marker_multiple_picks_latest() -> None:
+    """Two overview notes with markers — returns the most recent one."""
+    early_body = f"First review\n{format_sha_marker(SHA_FIRST)}"
+    late_body = f"Second review\n{format_sha_marker(SHA_SECOND)}"
+    note_early = _make_note(note_id=1, body=early_body, created_at=TIMESTAMP_EARLY)
+    note_late = _make_note(note_id=2, body=late_body, created_at=TIMESTAMP_LATE)
+    disc_early = _make_discussion(discussion_id="disc-early", notes=[note_early])
+    disc_late = _make_discussion(discussion_id="disc-late", notes=[note_late])
+    # disc_late is later in the list → reversed() finds it first
+    history = _make_history(discussions=[disc_early, disc_late])
+
+    assert extract_last_reviewed_sha(history) == SHA_SECOND
+
+
+def test_format_sha_marker_roundtrip() -> None:
+    """format_sha_marker output is matched by the internal regex."""
+    marker = format_sha_marker(SHA_FIRST)
+    match = _SHA_MARKER_RE.search(marker)
+
+    assert match is not None
+    assert match.group(1) == SHA_FIRST

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -11,7 +11,7 @@ from gitlab_copilot_agent.discussion_models import (
     DiscussionHistory,
     DiscussionNote,
 )
-from gitlab_copilot_agent.gitlab_client import MRDetails
+from gitlab_copilot_agent.gitlab_client import MRChange, MRDetails
 from gitlab_copilot_agent.orchestrator import handle_review
 from gitlab_copilot_agent.task_executor import ReviewResult
 from tests.conftest import (
@@ -357,3 +357,144 @@ async def test_prior_feedback_rendered_in_prompt(
     assert "## Agent's Prior Feedback (Unresolved)" in prompt
     assert "Consider adding a null check here." in prompt
     assert "src/app.py" in prompt
+
+
+# -- Incremental review integration tests --
+
+_MARKER_SHA = "aaa1111aaa1111aaa1111aaa1111aaa1111aaa11"
+_NEW_HEAD_SHA = "bbb2222"
+_INCREMENTAL_DIFF = "@@ -1,3 +1,4 @@\n+incremental change\n"
+_INCREMENTAL_PATH = "src/incremental.py"
+
+
+def _make_marker_note(sha: str) -> DiscussionNote:
+    """Build an overview note containing a SHA marker, authored by the agent."""
+    marker = f"<!-- mr-review-agent: last_reviewed_sha={sha} -->"
+    return DiscussionNote(
+        note_id=900,
+        author_id=_AGENT_IDENTITY.user_id,
+        author_username=_AGENT_IDENTITY.username,
+        body=f"## Code Review Summary\n\nAll good.\n\n{marker}",
+        created_at="2026-04-06T12:00:00Z",
+        is_system=False,
+        resolved=None,
+        resolvable=False,
+        position=None,
+    )
+
+
+def _make_marker_discussion(sha: str) -> Discussion:
+    return Discussion(
+        discussion_id="disc-marker",
+        notes=[_make_marker_note(sha)],
+        is_resolved=False,
+        is_inline=False,
+    )
+
+
+@patch("gitlab_copilot_agent.orchestrator.post_review", new_callable=AsyncMock)
+@patch("gitlab_copilot_agent.orchestrator.GitLabClient")
+@patch("gitlab_copilot_agent.orchestrator.gitlab.Gitlab")
+async def test_incremental_review_with_marker(
+    mock_gl_class: MagicMock,
+    mock_client_class: MagicMock,
+    mock_post_review: AsyncMock,
+) -> None:
+    """Second review with SHA marker uses incremental diff via compare_commits."""
+    mock_gl_instance = mock_client_class.return_value
+    mock_gl_instance.clone_repo = AsyncMock(return_value="/tmp/fake-repo")
+    mock_gl_instance.cleanup = AsyncMock()
+    mock_gl_instance.get_mr_details = AsyncMock(
+        return_value=MRDetails(
+            title="Add feature",
+            description="Implements X",
+            diff_refs=DIFF_REFS,
+            changes=make_mr_changes(),
+        )
+    )
+
+    # list_mr_discussions returns the marker note from a prior review
+    mock_gl_instance.list_mr_discussions = AsyncMock(
+        return_value=[_make_marker_discussion(_MARKER_SHA)]
+    )
+    # compare_commits returns incremental changes
+    mock_gl_instance.compare_commits = AsyncMock(
+        return_value=[
+            MRChange(
+                old_path=_INCREMENTAL_PATH,
+                new_path=_INCREMENTAL_PATH,
+                diff=_INCREMENTAL_DIFF,
+                new_file=False,
+                deleted_file=False,
+                renamed_file=False,
+            )
+        ]
+    )
+
+    mock_executor = AsyncMock()
+    mock_executor.execute.return_value = ReviewResult(summary=FAKE_REVIEW_OUTPUT)
+
+    mock_registry = AsyncMock()
+    mock_registry.resolve_identity = AsyncMock(return_value=_AGENT_IDENTITY)
+
+    await handle_review(
+        make_settings(),
+        make_webhook_payload(),
+        mock_executor,
+        credential_registry=mock_registry,
+    )
+
+    # Verify compare_commits called with correct SHAs
+    mock_gl_instance.compare_commits.assert_awaited_once_with(PROJECT_ID, _MARKER_SHA, "abc123")
+
+    # Verify prompt contains incremental diff header
+    task_params = mock_executor.execute.call_args[0][0]
+    prompt = task_params.user_prompt
+    assert "Incremental Diff" in prompt
+    assert _INCREMENTAL_DIFF in prompt
+
+
+@patch("gitlab_copilot_agent.orchestrator.post_review", new_callable=AsyncMock)
+@patch("gitlab_copilot_agent.orchestrator.GitLabClient")
+@patch("gitlab_copilot_agent.orchestrator.gitlab.Gitlab")
+async def test_incremental_review_compare_fails_fallback(
+    mock_gl_class: MagicMock,
+    mock_client_class: MagicMock,
+    mock_post_review: AsyncMock,
+) -> None:
+    """compare_commits failure falls back to full diff."""
+    mock_gl_instance = mock_client_class.return_value
+    mock_gl_instance.clone_repo = AsyncMock(return_value="/tmp/fake-repo")
+    mock_gl_instance.cleanup = AsyncMock()
+    mock_gl_instance.get_mr_details = AsyncMock(
+        return_value=MRDetails(
+            title="Add feature",
+            description="Implements X",
+            diff_refs=DIFF_REFS,
+            changes=make_mr_changes(),
+        )
+    )
+    mock_gl_instance.list_mr_discussions = AsyncMock(
+        return_value=[_make_marker_discussion(_MARKER_SHA)]
+    )
+    mock_gl_instance.compare_commits = AsyncMock(side_effect=RuntimeError("Compare API error"))
+
+    mock_executor = AsyncMock()
+    mock_executor.execute.return_value = ReviewResult(summary=FAKE_REVIEW_OUTPUT)
+
+    mock_registry = AsyncMock()
+    mock_registry.resolve_identity = AsyncMock(return_value=_AGENT_IDENTITY)
+
+    await handle_review(
+        make_settings(),
+        make_webhook_payload(),
+        mock_executor,
+        credential_registry=mock_registry,
+    )
+
+    # Falls back to full diff — prompt should NOT contain incremental header
+    task_params = mock_executor.execute.call_args[0][0]
+    prompt = task_params.user_prompt
+    assert "Incremental Diff" not in prompt
+    # Full diff from mr_details.changes is used instead
+    assert DIFF_REFS.base_sha is not None  # sanity: details were loaded

--- a/tests/test_review_engine.py
+++ b/tests/test_review_engine.py
@@ -374,3 +374,59 @@ def test_no_resolution_eval_instructions_without_prior_feedback() -> None:
         _make_request(), diff_text="some diff", discussion_history=history
     )
     assert "Resolution Evaluation" not in prompt
+
+
+# -- Incremental diff header tests --
+
+INCREMENTAL_HEADER = "Incremental Diff"
+
+
+def test_build_prompt_incremental_header() -> None:
+    """is_incremental=True adds 'Incremental Diff' header to the prompt."""
+    prompt = build_review_prompt(_make_request(), diff_text="some diff", is_incremental=True)
+
+    assert INCREMENTAL_HEADER in prompt
+    assert "changes since last review" in prompt
+
+
+def test_build_prompt_full_no_header() -> None:
+    """is_incremental=False does NOT include 'Incremental Diff' header."""
+    prompt = build_review_prompt(_make_request(), diff_text="some diff", is_incremental=False)
+
+    assert INCREMENTAL_HEADER not in prompt
+
+
+# -- Outdated position annotation tests --
+
+OUTDATED_ANNOTATION = "(outdated position"
+POSITION_HEAD_SHA = "pos_head_abc"
+CURRENT_HEAD_SHA = "current_head_xyz"
+
+
+def test_prior_feedback_outdated_annotation() -> None:
+    """Position head_sha != current_head_sha adds '(outdated position' annotation."""
+    note = _make_agent_note()
+    note_dict = note.model_dump()
+    note_dict["position"]["head_sha"] = POSITION_HEAD_SHA
+    patched_note = DiscussionNote(**note_dict)
+    disc = _make_discussion(notes=[patched_note])
+    history = _make_history(discussions=[disc])
+
+    result = _format_prior_feedback(history, current_head_sha=CURRENT_HEAD_SHA)
+
+    assert OUTDATED_ANNOTATION in result
+
+
+def test_prior_feedback_current_no_annotation() -> None:
+    """Position head_sha == current_head_sha has no outdated annotation."""
+    note = _make_agent_note()
+    note_dict = note.model_dump()
+    note_dict["position"]["head_sha"] = CURRENT_HEAD_SHA
+    patched_note = DiscussionNote(**note_dict)
+    disc = _make_discussion(notes=[patched_note])
+    history = _make_history(discussions=[disc])
+
+    result = _format_prior_feedback(history, current_head_sha=CURRENT_HEAD_SHA)
+
+    assert OUTDATED_ANNOTATION not in result
+    assert "Consider error handling" in result

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -539,3 +539,26 @@ async def test_is_agent_directed_thread_participation(
     ]
     with patch("gitlab_copilot_agent.webhook.GitLabClient", return_value=mock_gl):
         assert await _is_agent_directed(payload, identity, request) is expected
+
+
+# -- Reopen event tests --
+
+
+async def test_reopen_triggers_review(client: AsyncClient) -> None:
+    """Webhook with action='reopen' is queued for review."""
+    payload = make_mr_payload(action="reopen")
+    resp = await client.post("/webhook", json=payload, headers=HEADERS)
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "queued"}
+
+
+async def test_reopen_no_oldrev_check(client: AsyncClient) -> None:
+    """Reopen with oldrev=None is still queued (not ignored like update)."""
+    payload = make_mr_payload(action="reopen")
+    # Ensure no oldrev key in the payload
+    payload["object_attributes"].pop("oldrev", None)
+    resp = await client.post("/webhook", json=payload, headers=HEADERS)
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "queued"}


### PR DESCRIPTION
## What

Add incremental MR review: track last-reviewed SHA via a hidden marker in overview notes, use the GitLab Compare API to compute the diff since last review, and fall back to full diff when no marker exists or the compare fails.

## Why

On push events to a previously reviewed MR, reviewing the full diff wastes LLM tokens and produces duplicate feedback on unchanged code. Incremental review focuses on only the new changes, improving quality and reducing noise.

## How

- **Compare API**: `GitLabClient.compare_commits()` calls `project.repository_compare()` to get the incremental diff between the marker SHA and current head.
- **Fallback**: No marker → full diff. Compare failure → full diff with warning log. Self-healing by design.
- **Reopen events**: Now handled via `HANDLED_ACTIONS` — diff scope determined by marker presence, not action type.
- **Outdated annotation**: Prior feedback with stale `position.head_sha` is annotated `(outdated position — line may have shifted)`, not excluded.

## Files Changed (19 files, +834/-30)

**New (3):**
- `docs/adr/0009-incremental-review-sha-marker.md` — ADR documenting SHA marker decision
- `src/gitlab_copilot_agent/incremental.py` — `extract_last_reviewed_sha()` + `format_sha_marker()`
- `tests/test_incremental.py` — 7 unit tests

**Source (5):**
- `gitlab_client.py` — `compare_commits()` + `head_sha` in position data
- `orchestrator.py` — Incremental diff selection via marker
- `comment_poster.py` — SHA marker in summary notes
- `review_engine.py` — Incremental prompt header + outdated annotation
- `webhook.py` — Added `reopen` to `HANDLED_ACTIONS`

**Tests (6):** 20 new tests across unit, integration, E2E

**Docs (4):** request-flows, concurrency-and-state, module-reference, data-models

## Validation

- `make lint`: All checks passed (ruff check, ruff format, pyright — 0 errors)
- `uv run pytest`: 715 passed, 92.58% coverage

Closes #321