### PR TITLE
feat(review): add discussion summary activity section to overview comment

### DIFF
--- a/docs/wiki/module-reference.md
+++ b/docs/wiki/module-reference.md
@@ -468,14 +468,17 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 ---
 
 ### `comment_poster.py`
-**Purpose**: Post review comments to GitLab MR as inline discussions and summary. Handles resolution actions for prior feedback. Embeds SHA marker in summary note for incremental review tracking.
+**Purpose**: Post review comments to GitLab MR as inline discussions and summary. Handles resolution actions for prior feedback. Embeds SHA marker in summary note for incremental review tracking. Composes a structured activity summary (posting outcomes + resolution stats) into the summary note.
 
 **Key Functions**:
-- `post_review(gitlab_client: gl.Gitlab, project_id: int, mr_iid: int, diff_refs: MRDiffRef, review: ParsedReview, changes: list[MRChange], resolution_behavior: str = "suggest", allowed_discussion_ids: frozenset[str] = frozenset(), head_sha: str = "") -> None`: Post inline comments + resolve/acknowledge prior feedback + summary with SHA marker
+- `post_review(gitlab_client: gl.Gitlab, project_id: int, mr_iid: int, diff_refs: MRDiffRef, review: ParsedReview, changes: list[MRChange], resolution_behavior: str = "suggest", allowed_discussion_ids: frozenset[str] = frozenset(), head_sha: str = "") -> None`: Post inline comments + resolve/acknowledge prior feedback + summary with SHA marker and activity section
   - Validates comment positions against diff hunks
   - Falls back to note with file:line context if position invalid
+  - Tracks posting outcomes (inline, fallback, skipped) via counters
   - Processes resolutions via `_handle_resolutions()` before posting summary
+  - When comments or resolutions are nonzero, inserts activity section between summary text and SHA marker
   - When `head_sha` provided, appends `format_sha_marker(head_sha)` to summary note body
+- `_build_activity_section(posted_inline: int, posted_fallback: int, resolutions: list[Resolution], resolved_count: int) -> str`: Compose markdown activity summary from posting outcomes and resolution data. Returns empty string when all counts are zero. Includes: new comments (inline + fallback total), threads resolved, partial resolutions — with singular/plural handling
 - `_handle_resolutions(mr: object, resolutions: list[Resolution], resolution_behavior: str) -> int`: Process resolutions per configured behavior (auto-resolve/suggest/off). Returns count of resolved threads
 - `_parse_hunk_lines(diff: str, new_path: str) -> set[tuple[str, int]]`: Extract valid (file, line) positions from unified diff
 - `_is_valid_position(file: str, line: int, valid_positions: set[tuple[str, int]]) -> bool`: Check if position valid
@@ -789,7 +792,7 @@ All use `frozen=True` config.
 | `jira_client.py` | Clients | 117 | Jira API client |
 | `git_operations.py` | Utils | 194 | Git CLI wrappers |
 | `comment_parser.py` | Utils | 75 | Review parsing |
-| `comment_poster.py` | Utils | 137 | Comment posting |
+| `comment_poster.py` | Utils | 184 | Comment posting + activity summary |
 | `repo_config.py` | Utils | 184 | Repo config discovery |
 | `models.py` | Data | 79 | Webhook models |
 | `jira_models.py` | Data | 87 | Jira API models |

--- a/src/gitlab_copilot_agent/comment_poster.py
+++ b/src/gitlab_copilot_agent/comment_poster.py
@@ -20,6 +20,32 @@ if TYPE_CHECKING:
 log = structlog.get_logger()
 
 
+def _build_activity_section(
+    posted_inline: int,
+    posted_fallback: int,
+    resolutions: list[Resolution],
+    resolved_count: int,
+) -> str:
+    """Compose a markdown activity summary from posting outcomes and resolution data.
+
+    Returns empty string when all counts are zero (clean review with no prior threads).
+    """
+    lines: list[str] = []
+    total_posted = posted_inline + posted_fallback
+    if total_posted:
+        lines.append(f"- **{total_posted}** new comment{'s' if total_posted != 1 else ''}")
+    if resolved_count:
+        lines.append(f"- **{resolved_count}** thread{'s' if resolved_count != 1 else ''} resolved")
+    partial_count = sum(1 for r in resolutions if r.status == "partial")
+    if partial_count:
+        lines.append(
+            f"- **{partial_count}** partial resolution{'s' if partial_count != 1 else ''}"
+        )
+    if not lines:
+        return ""
+    return "### 📊 Review Activity\n\n" + "\n".join(lines)
+
+
 def _parse_hunk_lines(diff: str, new_path: str) -> set[tuple[str, int]]:
     """Extract valid new_line positions from unified diff hunks.
 
@@ -133,6 +159,11 @@ async def post_review(
             diff_files.add(change.new_path)
             valid_positions |= _parse_hunk_lines(change.diff, change.new_path)
 
+        # Track posting outcomes for activity summary
+        posted_inline = 0
+        posted_fallback = 0
+        skipped = 0
+
         for c in review.comments:
             body = f"**[{c.severity.upper()}]** {c.comment}"
             if c.suggestion is not None:
@@ -143,6 +174,7 @@ async def post_review(
             # Skip comments on files not in the diff entirely
             if c.file not in diff_files:
                 log.info("comment_skipped_not_in_diff", file=c.file, line=c.line)
+                skipped += 1
                 continue
 
             # Validate position before attempting inline comment
@@ -154,8 +186,10 @@ async def post_review(
                 )
                 try:
                     mr.notes.create({"body": f"{body}\n\n`{c.file}:{c.line}`"})
+                    posted_fallback += 1
                 except Exception:
                     log.warning("fallback_note_failed", file=c.file, line=c.line, exc_info=True)
+                    skipped += 1
                 continue
 
             # Position is valid, attempt inline comment
@@ -174,10 +208,12 @@ async def post_review(
                         },
                     }
                 )
+                posted_inline += 1
             except Exception:
                 log.warning("inline_comment_failed", file=c.file, line=c.line, exc_info=True)
                 try:
                     mr.notes.create({"body": f"{body}\n\n`{c.file}:{c.line}`"})
+                    posted_fallback += 1
                 except Exception:
                     log.warning(
                         "fallback_note_also_failed",
@@ -185,8 +221,10 @@ async def post_review(
                         line=c.line,
                         exc_info=True,
                     )
+                    skipped += 1
 
         # Handle resolutions for prior feedback
+        resolved = 0
         if review.resolutions:
             resolved = _handle_resolutions(
                 mr, review.resolutions, resolution_behavior, allowed_discussion_ids
@@ -194,7 +232,13 @@ async def post_review(
             if resolved > 0:
                 log.info("discussions_resolved", count=resolved)
 
+        # Compose summary note with optional activity section
         summary_body = f"## Code Review Summary\n\n{review.summary}"
+        activity = _build_activity_section(
+            posted_inline, posted_fallback, review.resolutions or [], resolved
+        )
+        if activity:
+            summary_body += f"\n\n{activity}"
         if head_sha:
             summary_body += f"\n\n{format_sha_marker(head_sha)}"
         mr.notes.create({"body": summary_body})

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -3,7 +3,7 @@
 # Tests: 1. Webhook MR review, 2. Jira polling, 3. @mention thread interaction,
 #        4. GitLab polling, 5. Hot-reload config, 6. Plugin install,
 #        7. Graceful shutdown, 8. Discussion history capture,
-#        9. Incremental review.
+#        9. Incremental review, 10. Discussion summary activity section.
 # Usage: ./tests/e2e/run.sh [agent-url] [mock-gitlab-url] [mock-jira-url]
 set -euo pipefail
 
@@ -447,6 +447,47 @@ poll_until "$MOCK_GITLAB_URL/discussions" \
     "Waiting for incremental review comments" || { kubectl logs -l app.kubernetes.io/name=gitlab-copilot-agent --tail=50 2>/dev/null || true; exit 1; }
 
 echo "PASS: Incremental review posted comments"
+
+# === TEST 10: Discussion Summary — Activity Section (#321 Feature 6) ===
+echo ""; echo "--- Test 10: Discussion Summary Activity Section ---"
+curl -sf -X DELETE "$MOCK_GITLAB_URL/discussions" > /dev/null
+curl -sf -X DELETE "$MOCK_GITLAB_URL/mock/discussions" > /dev/null
+
+echo -n "Sending webhook (MR with comments to trigger activity section)..."
+send_webhook '{
+    "object_kind": "merge_request",
+    "user": {"id": 1, "username": "e2e-test"},
+    "project": {"id": 999, "path_with_namespace": "test/e2e-repo",
+                "git_http_url": "http://host.k3d.internal:9999/repo.git"},
+    "object_attributes": {"iid": 610, "title": "Activity section test MR", "description": "Feature 6 E2E",
+        "action": "open", "source_branch": "main", "target_branch": "main",
+        "last_commit": {"id": "f6a610f6a610f6a610f6a610f6a610f6a610f6a6", "message": "test activity section"}, "url": "http://mock/mr/610", "oldrev": null}
+}'
+
+poll_until "$MOCK_GITLAB_URL/discussions" \
+    "import sys,json; d=json.load(sys.stdin); print(len(d) if d else 0)" \
+    "Waiting for review with activity section" || { kubectl logs -l app.kubernetes.io/name=gitlab-copilot-agent --tail=50 2>/dev/null || true; exit 1; }
+
+echo -n "Verifying summary note contains Review Activity section..."
+ACTIVITY_OK=$(curl -sf "$MOCK_GITLAB_URL/discussions" | python3 -c "
+import sys, json
+ds = json.load(sys.stdin)
+# Summary notes are recorded with _type='note' and contain the review summary header
+summary_notes = [d for d in ds if d.get('_type') == 'note' and 'Code Review Summary' in d.get('body', '')]
+has_activity = any('Review Activity' in d.get('body', '') for d in summary_notes)
+print('yes' if has_activity else 'no')")
+[ "$ACTIVITY_OK" = "yes" ] && echo " ✅" || { echo " ❌ (activity section not found in summary note)"; exit 1; }
+
+echo -n "Verifying SHA marker coexists in summary note..."
+SHA_OK=$(curl -sf "$MOCK_GITLAB_URL/discussions" | python3 -c "
+import sys, json
+ds = json.load(sys.stdin)
+summary_notes = [d for d in ds if d.get('_type') == 'note' and 'Code Review Summary' in d.get('body', '')]
+has_marker = any('mr-review-agent: last_reviewed_sha=' in d.get('body', '') for d in summary_notes)
+print('yes' if has_marker else 'no')")
+[ "$SHA_OK" = "yes" ] && echo " ✅" || { echo " ❌ (SHA marker not found in summary note)"; exit 1; }
+
+echo "PASS: Summary note contains activity section and SHA marker"
 
 echo ""; echo "=== ALL E2E TESTS PASSED ==="
 exit 0

--- a/tests/test_comment_poster.py
+++ b/tests/test_comment_poster.py
@@ -3,7 +3,11 @@
 from unittest.mock import MagicMock
 
 from gitlab_copilot_agent.comment_parser import ParsedReview, Resolution, ReviewComment
-from gitlab_copilot_agent.comment_poster import _handle_resolutions, post_review
+from gitlab_copilot_agent.comment_poster import (
+    _build_activity_section,
+    _handle_resolutions,
+    post_review,
+)
 from tests.conftest import DIFF_REFS, MR_IID, PROJECT_ID, make_mr_changes
 
 
@@ -438,3 +442,181 @@ async def test_summary_note_no_marker_when_empty_sha() -> None:
     mr = gl.projects.get(PROJECT_ID).mergerequests.get(MR_IID)
     body = mr.notes.create.call_args[0][0]["body"]
     assert "<!-- mr-review-agent:" not in body
+
+
+# -- Activity section tests --
+
+ACTIVITY_HEADER = "### 📊 Review Activity"
+
+
+def test_build_activity_section_all_zero() -> None:
+    """All counts zero → empty string."""
+    result = _build_activity_section(0, 0, [], 0)
+    assert result == ""
+
+
+def test_build_activity_section_comments_only() -> None:
+    """Only new comments → single bullet with count."""
+    result = _build_activity_section(3, 0, [], 0)
+    assert ACTIVITY_HEADER in result
+    assert "- **3** new comments" in result
+    assert "resolved" not in result
+    assert "partial" not in result
+
+
+def test_build_activity_section_single_comment() -> None:
+    """Singular form for 1 comment."""
+    result = _build_activity_section(1, 0, [], 0)
+    assert "- **1** new comment" in result
+    assert "comments" not in result
+
+
+def test_build_activity_section_inline_plus_fallback() -> None:
+    """Inline + fallback counts are summed for total."""
+    result = _build_activity_section(2, 1, [], 0)
+    assert "- **3** new comments" in result
+
+
+def test_build_activity_section_resolved_only() -> None:
+    """Only resolved threads → single bullet."""
+    result = _build_activity_section(0, 0, [], 5)
+    assert ACTIVITY_HEADER in result
+    assert "- **5** threads resolved" in result
+    assert "new comment" not in result
+
+
+def test_build_activity_section_single_resolved() -> None:
+    """Singular form for 1 thread resolved."""
+    result = _build_activity_section(0, 0, [], 1)
+    assert "- **1** thread resolved" in result
+    assert "threads" not in result
+
+
+def test_build_activity_section_partial_only() -> None:
+    """Only partial resolutions → single bullet."""
+    resolutions = [
+        _make_resolution(status="partial", message="Partially fixed"),
+        _make_resolution(discussion_id=DISC_ID_TWO, status="partial", message="Also partial"),
+    ]
+    result = _build_activity_section(0, 0, resolutions, 0)
+    assert ACTIVITY_HEADER in result
+    assert "- **2** partial resolutions" in result
+
+
+def test_build_activity_section_single_partial() -> None:
+    """Singular form for 1 partial resolution."""
+    resolutions = [_make_resolution(status="partial", message="Partial")]
+    result = _build_activity_section(0, 0, resolutions, 0)
+    assert "- **1** partial resolution" in result
+    assert "resolutions" not in result
+
+
+def test_build_activity_section_all_nonzero() -> None:
+    """All counts nonzero → all bullets present."""
+    resolutions = [
+        _make_resolution(status="partial", message="Partial"),
+        _make_resolution(discussion_id=DISC_ID_TWO, status="resolved", message="Fixed"),
+    ]
+    result = _build_activity_section(2, 1, resolutions, 3)
+    assert ACTIVITY_HEADER in result
+    assert "- **3** new comments" in result
+    assert "- **3** threads resolved" in result
+    assert "- **1** partial resolution" in result
+
+
+def test_build_activity_section_ignores_non_partial_resolutions() -> None:
+    """Only 'partial' status counted; resolved and not_addressed are not partial."""
+    resolutions = [
+        _make_resolution(status="resolved", message="Fixed"),
+        _make_resolution(discussion_id=DISC_ID_TWO, status="not_addressed", message="Nope"),
+    ]
+    result = _build_activity_section(0, 0, resolutions, 0)
+    assert result == ""
+
+
+# -- Summary composition with activity section --
+
+
+async def test_summary_contains_activity_section_with_comments() -> None:
+    """Summary note includes activity section when comments are posted."""
+    gl = MagicMock()
+    review = ParsedReview(
+        comments=[ReviewComment(file="src/main.py", line=2, severity="error", comment="Bug")],
+        summary="Issues found.",
+    )
+    await post_review(
+        gl, PROJECT_ID, MR_IID, DIFF_REFS, review, make_mr_changes(), head_sha=SHA_MARKER_VALUE
+    )
+
+    mr = gl.projects.get(PROJECT_ID).mergerequests.get(MR_IID)
+    body = mr.notes.create.call_args[0][0]["body"]
+    # Activity section between summary and SHA marker
+    assert "Issues found." in body
+    assert ACTIVITY_HEADER in body
+    assert SHA_MARKER_COMMENT in body
+    # Verify order: summary → activity → sha marker
+    summary_pos = body.index("Issues found.")
+    activity_pos = body.index(ACTIVITY_HEADER)
+    marker_pos = body.index(SHA_MARKER_COMMENT)
+    assert summary_pos < activity_pos < marker_pos
+
+
+async def test_summary_omits_activity_section_when_zero() -> None:
+    """Summary note has no activity section when no comments and no resolutions."""
+    gl = MagicMock()
+    review = ParsedReview(comments=[], summary="All good.")
+    await post_review(
+        gl, PROJECT_ID, MR_IID, DIFF_REFS, review, make_mr_changes(), head_sha=SHA_MARKER_VALUE
+    )
+
+    mr = gl.projects.get(PROJECT_ID).mergerequests.get(MR_IID)
+    body = mr.notes.create.call_args[0][0]["body"]
+    assert ACTIVITY_HEADER not in body
+    assert "All good." in body
+    assert SHA_MARKER_COMMENT in body
+
+
+async def test_summary_sha_marker_extractable_with_activity_section() -> None:
+    """SHA marker remains extractable even when activity section is present."""
+    from gitlab_copilot_agent.incremental import _SHA_MARKER_RE
+
+    gl = MagicMock()
+    review = ParsedReview(
+        comments=[ReviewComment(file="src/main.py", line=2, severity="error", comment="Bug")],
+        summary="Review.",
+    )
+    await post_review(
+        gl, PROJECT_ID, MR_IID, DIFF_REFS, review, make_mr_changes(), head_sha=SHA_MARKER_VALUE
+    )
+
+    mr = gl.projects.get(PROJECT_ID).mergerequests.get(MR_IID)
+    body = mr.notes.create.call_args[0][0]["body"]
+    match = _SHA_MARKER_RE.search(body)
+    assert match is not None
+    assert match.group(1) == SHA_MARKER_VALUE
+
+
+async def test_summary_activity_section_with_resolutions() -> None:
+    """Activity section includes resolution stats when resolutions present."""
+    gl = MagicMock()
+    mr_mock = gl.projects.get(PROJECT_ID).mergerequests.get(MR_IID)
+
+    resolutions = [_make_resolution(status="resolved")]
+    review = ParsedReview(comments=[], summary="Review.", resolutions=resolutions)
+    await post_review(
+        gl,
+        PROJECT_ID,
+        MR_IID,
+        DIFF_REFS,
+        review,
+        make_mr_changes(),
+        resolution_behavior="auto-resolve",
+        allowed_discussion_ids=frozenset({DISC_ID_ONE}),
+        head_sha=SHA_MARKER_VALUE,
+    )
+
+    body = mr_mock.notes.create.call_args[0][0]["body"]
+    assert ACTIVITY_HEADER in body
+    assert "thread" in body
+    assert "resolved" in body
+    assert SHA_MARKER_COMMENT in body


### PR DESCRIPTION
## What

Add posting outcome counters and a structured activity summary section to the existing review summary note. The activity section is inserted between the LLM summary text and the SHA marker after each review cycle.

## Why

Issue #321, Feature 6: Users need visibility into what the review agent did — how many comments were posted inline vs. fallback, how many threads were resolved, and how many partial resolutions were suggested.

## How

- Add `posted_inline`, `posted_fallback`, `skipped` counters to the inline comment loop in `comment_poster.py`
- Add `_build_activity_section()` helper that composes a markdown activity summary from posting outcomes
- Insert activity section between LLM summary and SHA marker in the existing summary note
- Activity section omitted entirely when all counts are zero (clean review with no prior threads)
- SHA marker coexistence preserved for `extract_last_reviewed_sha()` compatibility

## Testing

- 14 new unit tests for `_build_activity_section()` edge cases and summary composition
- E2E test scenario (Test 10) verifies activity section appears in summary note
- All 729 tests pass, 96.99% coverage

## Documentation

- `docs/wiki/module-reference.md` updated with `_build_activity_section()` entry

Part of #321 (Feature 6)