### PR TITLE
fix(ci): add concurrency group to deploy workflow to prevent TF state race

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,9 @@ env:
 
 jobs:
   deploy:
+    concurrency:
+      group: tf-state-access
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     outputs:


### PR DESCRIPTION
## What

Add a job-level `concurrency` group (`tf-state-access`) to `deploy.yml` so only one deploy job runs at a time across all callers (cd-dev, cd-staging, manual dispatch).

## Why

CD Dev and CD Staging both call `deploy.yml`, which toggles public network access on the shared TF state storage account. When both run concurrently, one workflow's "Disable" step cuts off the other mid-`terraform apply`, causing 403 errors on state save and a held lock.

**Root cause timeline (April 7):**
| Time (UTC) | Event |
|---|---|
| 18:51:48 | CD Staging terraform apply starts |
| **18:52:03** | **CD Dev disables storage public access** |
| 18:52:41 | CD Staging state save → 403 (38s propagation delay) |

## How

```yaml
concurrency:
  group: tf-state-access
  cancel-in-progress: false
```

Deploys queue instead of cancelling (`cancel-in-progress: false`) so no deployment is dropped. Typical deploy is ~2 minutes, so queuing impact is minimal.

## OWASP Self-Review

- [x] Broken Access Control — N/A
- [x] Cryptographic Failures — N/A
- [x] Injection — N/A
- [x] Insecure Design — improves (prevents race on shared infra)
- [x] Security Misconfiguration — N/A
- [x] Software/Data Integrity — protects CI/CD from state corruption
- [x] All other categories — N/A

## Code Review

Cross-vendor review (GPT-5.4) passed with no findings.

Closes #348