### PR TITLE
feat(config): add config v2 models, AppContext container, and wire into app

### DIFF
--- a/.lint-baseline.json
+++ b/.lint-baseline.json
@@ -44,7 +44,7 @@
     "TC003": 1
   },
   "src/gitlab_copilot_agent/gitlab_poller.py": {
-    "D102": 2,
+    "D102": 1,
     "D107": 1,
     "TC001": 6
   },
@@ -62,7 +62,6 @@
     "D107": 1
   },
   "src/gitlab_copilot_agent/main.py": {
-    "D103": 1,
     "PLW2901": 1,
     "PTH207": 1
   },

--- a/.lint-baseline.json
+++ b/.lint-baseline.json
@@ -62,7 +62,7 @@
     "D107": 1
   },
   "src/gitlab_copilot_agent/main.py": {
-    "D103": 2,
+    "D103": 1,
     "PLW2901": 1,
     "PTH207": 1
   },
@@ -89,8 +89,7 @@
     "N806": 2
   },
   "src/gitlab_copilot_agent/webhook.py": {
-    "D103": 1,
-    "TC001": 3
+    "TC001": 2
   },
   "tests/e2e/mock_gitlab.py": {
     "PLW1510": 3,
@@ -124,8 +123,5 @@
   },
   "tests/test_process_sandbox.py": {
     "PTH110": 1
-  },
-  "tests/test_project_registry.py": {
-    "N806": 1
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint test build sandbox-image update-lint-baseline
+.PHONY: lint test build sandbox-image update-lint-baseline validate-config
 
 lint:
 	uv run python scripts/check_lint_baseline.py
@@ -16,6 +16,9 @@ build:
 
 sandbox-image:
 	./scripts/build-sandbox-image.sh
+
+validate-config:
+	uv run check-jsonschema --schemafile config.schema.json $${CONFIG_FILE:-config.yaml}
 
 # --- k3d local development ---
 K3D_CLUSTER    := copilot-agent-dev

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,56 @@
+# Example configuration — copy to config.yaml and customize.
+# Secrets (tokens, keys) are env vars, not in this file.
+# See docs/wiki/configuration-reference.md for full schema documentation.
+version: 2
+
+gitlab:
+  url: https://gitlab.example.com
+
+dispatch:
+  backend: local
+
+copilot:
+  model: gpt-4
+
+server:
+  log_level: info
+  # clone_dir: /tmp/repos
+  shutdown_timeout: 30
+  # webhook_ip_allowlist:      # CIDR ranges allowed to send webhooks (empty = allow all)
+  #   - "34.74.90.64/28"       # GitLab.com
+  #   - "34.74.226.0/24"       # GitLab.com
+  # trusted_proxies: []        # Reverse proxy CIDRs for X-Forwarded-For trust
+
+# prompts:
+#   system: null               # Global base prompt override
+#   review_suffix: null         # Appended to review prompt
+
+defaults:
+  target_branch: main
+  credential_ref: default
+  resolution_behavior: suggest
+  webhook: true
+  poll:
+    enabled: false
+    interval: 30
+    lookback_minutes: 60
+    review_on_push: true
+
+projects:
+  - repo: group/my-project
+    # credential_ref: default   # Override credential alias
+    # target_branch: main       # Override target branch
+    # webhook: true             # Override webhook trigger
+    # poll:                     # Override polling config
+    #   enabled: false
+    # copilot:                  # Override Copilot settings
+    #   model: gpt-4o
+    integrations: []
+
+integrations: []
+# - name: my-jira
+#   type: jira
+#   project_key: PROJ
+#   trigger_status: "AI Ready"
+#   in_progress_status: "In Progress"
+#   in_review_status: "In Review"

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,544 @@
+{
+  "$defs": {
+    "ConfigDefaults": {
+      "description": "Default values applied to every project unless overridden.",
+      "properties": {
+        "target_branch": {
+          "default": "main",
+          "description": "Default MR target branch",
+          "title": "Target Branch",
+          "type": "string"
+        },
+        "credential_ref": {
+          "default": "default",
+          "description": "Default credential alias",
+          "title": "Credential Ref",
+          "type": "string"
+        },
+        "resolution_behavior": {
+          "default": "suggest",
+          "description": "Default resolution behavior",
+          "enum": [
+            "auto-resolve",
+            "suggest",
+            "off"
+          ],
+          "title": "Resolution Behavior",
+          "type": "string"
+        },
+        "webhook": {
+          "default": true,
+          "description": "Default webhook trigger enabled",
+          "title": "Webhook",
+          "type": "boolean"
+        },
+        "poll": {
+          "$ref": "#/$defs/PollConfig",
+          "description": "Default polling configuration"
+        }
+      },
+      "title": "ConfigDefaults",
+      "type": "object"
+    },
+    "CopilotConfig": {
+      "description": "Copilot/LLM configuration \u2014 global defaults, overridable per-project.",
+      "properties": {
+        "model": {
+          "default": "gpt-4",
+          "description": "Default model for Copilot sessions",
+          "title": "Model",
+          "type": "string"
+        },
+        "plugins": {
+          "description": "Copilot CLI plugins",
+          "items": {
+            "type": "string"
+          },
+          "title": "Plugins",
+          "type": "array"
+        },
+        "marketplaces": {
+          "description": "Custom plugin marketplace URLs",
+          "items": {
+            "type": "string"
+          },
+          "title": "Marketplaces",
+          "type": "array"
+        }
+      },
+      "title": "CopilotConfig",
+      "type": "object"
+    },
+    "DispatchConfig": {
+      "description": "Task dispatch backend configuration.",
+      "properties": {
+        "backend": {
+          "default": "local",
+          "description": "Dispatch backend",
+          "enum": [
+            "local",
+            "k8s",
+            "aca"
+          ],
+          "title": "Backend",
+          "type": "string"
+        },
+        "k8s_namespace": {
+          "default": "default",
+          "description": "K8s namespace for Jobs",
+          "title": "K8S Namespace",
+          "type": "string"
+        },
+        "k8s_job_image": {
+          "default": "",
+          "description": "Docker image for Job pods",
+          "title": "K8S Job Image",
+          "type": "string"
+        },
+        "k8s_job_timeout": {
+          "default": 600,
+          "description": "Job timeout in seconds",
+          "title": "K8S Job Timeout",
+          "type": "integer"
+        },
+        "aca_subscription_id": {
+          "default": "",
+          "description": "Azure subscription ID",
+          "title": "Aca Subscription Id",
+          "type": "string"
+        },
+        "aca_resource_group": {
+          "default": "",
+          "description": "Azure resource group",
+          "title": "Aca Resource Group",
+          "type": "string"
+        },
+        "aca_job_name": {
+          "default": "",
+          "description": "ACA Job resource name",
+          "title": "Aca Job Name",
+          "type": "string"
+        },
+        "aca_job_timeout": {
+          "default": 600,
+          "description": "ACA Job timeout in seconds",
+          "title": "Aca Job Timeout",
+          "type": "integer"
+        }
+      },
+      "title": "DispatchConfig",
+      "type": "object"
+    },
+    "GitLabConfig": {
+      "description": "GitLab instance configuration.",
+      "properties": {
+        "url": {
+          "description": "GitLab instance URL",
+          "title": "Url",
+          "type": "string"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "title": "GitLabConfig",
+      "type": "object"
+    },
+    "JiraIntegrationConfig": {
+      "description": "Jira integration block.",
+      "properties": {
+        "name": {
+          "description": "Unique integration name, referenced by projects",
+          "title": "Name",
+          "type": "string"
+        },
+        "type": {
+          "const": "jira",
+          "description": "Integration type discriminator",
+          "title": "Type",
+          "type": "string"
+        },
+        "project_key": {
+          "description": "Jira project key (e.g. PROJ)",
+          "title": "Project Key",
+          "type": "string"
+        },
+        "trigger_status": {
+          "default": "AI Ready",
+          "description": "Jira status that triggers the agent",
+          "title": "Trigger Status",
+          "type": "string"
+        },
+        "in_progress_status": {
+          "default": "In Progress",
+          "description": "Status after agent pickup",
+          "title": "In Progress Status",
+          "type": "string"
+        },
+        "in_review_status": {
+          "default": "In Review",
+          "description": "Status after MR creation",
+          "title": "In Review Status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "type",
+        "project_key"
+      ],
+      "title": "JiraIntegrationConfig",
+      "type": "object"
+    },
+    "PollConfig": {
+      "description": "GitLab polling configuration.",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Enable GitLab API polling",
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "interval": {
+          "default": 30,
+          "description": "Polling interval in seconds",
+          "title": "Interval",
+          "type": "integer"
+        },
+        "lookback_minutes": {
+          "default": 60,
+          "description": "Minutes to look back on startup for recent MRs",
+          "title": "Lookback Minutes",
+          "type": "integer"
+        },
+        "review_on_push": {
+          "default": true,
+          "description": "Re-review MRs on new commits (dedup per commit). When false, each MR reviewed once (dedup per MR).",
+          "title": "Review On Push",
+          "type": "boolean"
+        }
+      },
+      "title": "PollConfig",
+      "type": "object"
+    },
+    "ProjectConfig": {
+      "description": "A single GitLab project entry.",
+      "properties": {
+        "repo": {
+          "description": "GitLab repo path_with_namespace (e.g. group/repo)",
+          "title": "Repo",
+          "type": "string"
+        },
+        "credential_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Credential alias; falls back to defaults",
+          "title": "Credential Ref"
+        },
+        "target_branch": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Target branch; falls back to defaults",
+          "title": "Target Branch"
+        },
+        "resolution_behavior": {
+          "anyOf": [
+            {
+              "enum": [
+                "auto-resolve",
+                "suggest",
+                "off"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Resolution behavior; falls back to defaults",
+          "title": "Resolution Behavior"
+        },
+        "webhook": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Webhook trigger; falls back to defaults",
+          "title": "Webhook"
+        },
+        "poll": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PollConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Polling config; falls back to defaults"
+        },
+        "copilot": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CopilotConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Per-project Copilot overrides"
+        },
+        "integrations": {
+          "description": "Integration names from the integrations list",
+          "items": {
+            "type": "string"
+          },
+          "title": "Integrations",
+          "type": "array"
+        }
+      },
+      "required": [
+        "repo"
+      ],
+      "title": "ProjectConfig",
+      "type": "object"
+    },
+    "PromptsConfig": {
+      "description": "System prompt overrides and suffixes.",
+      "properties": {
+        "system": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Global base prompt override",
+          "title": "System"
+        },
+        "system_suffix": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Appended to global base",
+          "title": "System Suffix"
+        },
+        "review": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Review prompt override",
+          "title": "Review"
+        },
+        "review_suffix": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Appended to review prompt",
+          "title": "Review Suffix"
+        },
+        "coding": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Coding prompt override",
+          "title": "Coding"
+        },
+        "coding_suffix": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Appended to coding prompt",
+          "title": "Coding Suffix"
+        },
+        "discussion": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Discussion prompt override",
+          "title": "Discussion"
+        },
+        "discussion_suffix": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Appended to discussion prompt",
+          "title": "Discussion Suffix"
+        }
+      },
+      "title": "PromptsConfig",
+      "type": "object"
+    },
+    "ServerConfig": {
+      "description": "Server operational configuration.",
+      "properties": {
+        "log_level": {
+          "default": "info",
+          "description": "Log level",
+          "title": "Log Level",
+          "type": "string"
+        },
+        "clone_dir": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Base directory for repo clones",
+          "title": "Clone Dir"
+        },
+        "shutdown_timeout": {
+          "default": 30,
+          "description": "Graceful shutdown timeout in seconds",
+          "exclusiveMinimum": 0,
+          "title": "Shutdown Timeout",
+          "type": "integer"
+        },
+        "webhook_ip_allowlist": {
+          "description": "CIDR ranges allowed to send webhooks. Empty = allow all. GitLab.com ranges: 34.74.90.64/28, 34.74.226.0/24",
+          "items": {
+            "type": "string"
+          },
+          "title": "Webhook Ip Allowlist",
+          "type": "array"
+        },
+        "trusted_proxies": {
+          "description": "CIDR ranges of trusted reverse proxies for X-Forwarded-For parsing",
+          "items": {
+            "type": "string"
+          },
+          "title": "Trusted Proxies",
+          "type": "array"
+        }
+      },
+      "title": "ServerConfig",
+      "type": "object"
+    }
+  },
+  "description": "Root config file model (version 2).\n\nThe YAML file is the primary non-secret config source. Secrets\n(tokens, connection strings) stay as env vars. A few operational\nenv vars (LOG_LEVEL, DISPATCH_BACKEND) can override YAML values.",
+  "properties": {
+    "version": {
+      "const": 2,
+      "description": "Schema version \u2014 must be 2",
+      "title": "Version",
+      "type": "integer"
+    },
+    "gitlab": {
+      "$ref": "#/$defs/GitLabConfig",
+      "description": "GitLab instance configuration"
+    },
+    "dispatch": {
+      "$ref": "#/$defs/DispatchConfig",
+      "description": "Dispatch backend config"
+    },
+    "copilot": {
+      "$ref": "#/$defs/CopilotConfig",
+      "description": "Global Copilot defaults"
+    },
+    "server": {
+      "$ref": "#/$defs/ServerConfig",
+      "description": "Server operational config"
+    },
+    "prompts": {
+      "$ref": "#/$defs/PromptsConfig",
+      "description": "Prompt overrides"
+    },
+    "defaults": {
+      "$ref": "#/$defs/ConfigDefaults",
+      "description": "Project defaults"
+    },
+    "projects": {
+      "description": "GitLab project definitions",
+      "items": {
+        "$ref": "#/$defs/ProjectConfig"
+      },
+      "title": "Projects",
+      "type": "array"
+    },
+    "integrations": {
+      "description": "Named integration configurations",
+      "items": {
+        "$ref": "#/$defs/JiraIntegrationConfig"
+      },
+      "title": "Integrations",
+      "type": "array"
+    }
+  },
+  "required": [
+    "version",
+    "gitlab"
+  ],
+  "title": "ConfigFile",
+  "type": "object"
+}

--- a/docs/adr/0007-yaml-mapping-credential-registry.md
+++ b/docs/adr/0007-yaml-mapping-credential-registry.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Accepted
+**Superseded** by [ADR-0010](0010-gitlab-centric-config-v2.md) (GitLab-centric config v2).
+
+The YAML mapping format and credential registry remain available for backward compatibility, but new deployments should use the config v2 schema.
 
 ## Context
 

--- a/docs/adr/0010-gitlab-centric-config-v2.md
+++ b/docs/adr/0010-gitlab-centric-config-v2.md
@@ -1,0 +1,58 @@
+# 0010. GitLab-Centric Config v2 Schema
+
+## Status
+
+Accepted — Supersedes ADR-0007
+
+## Context
+
+The service configuration was Jira-coupled: the YAML mapping file (`mapping_models.py`) organized projects by Jira project key, making it impossible to configure GitLab-only (review/discussion) projects without a Jira integration. Non-secret settings were split between the YAML mapping and ~40 environment variables in `config.py`, with no schema validation for the env vars and no way to override Copilot model or prompt settings per-project.
+
+Operators needed:
+- Projects without Jira (webhook-triggered review only)
+- Per-project Copilot model and plugin overrides
+- A single config file with schema validation for CI/CD pre-deploy checks
+- Named integrations referenced by projects (decoupling project identity from integration type)
+
+## Options Considered
+
+### Option A: Extend existing YAML mapping with optional Jira
+
+Add optional fields to the existing `MappingFile` / `Binding` models. Keep Jira key as the dict key but allow `null`.
+
+- Pros: Minimal change, backward-compatible
+- Cons: Jira key as dict key is semantically wrong for non-Jira projects. No natural place for per-project Copilot overrides, server config, or dispatch settings. Still requires env vars for everything else.
+
+### Option B: GitLab-centric config file with named integrations
+
+New `config_v2.py` with `ConfigFile` root model. Projects keyed by GitLab repo path. Integrations are named blocks referenced by projects. Service-level settings (dispatch, server, prompts, copilot defaults) move into the YAML file. Secrets stay as env vars.
+
+- Pros: Projects are first-class. Non-Jira projects are natural. Per-project overrides for copilot, polling, credentials. JSON Schema from Pydantic for CI/CD validation. Single file for all non-secret config.
+- Cons: Migration effort from v1 format. Two config systems coexist during transition.
+
+### Option C: Environment variables only
+
+Move all config to env vars with structured naming (e.g., `PROJECT_0_REPO`, `PROJECT_0_CREDENTIAL_REF`).
+
+- Pros: No YAML parsing. Works everywhere.
+- Cons: Unmanageable at scale. No schema validation. No per-project nesting. Array indexing in env vars is fragile.
+
+## Decision
+
+**Option B** — GitLab-centric YAML config with named integrations.
+
+The config file uses `version: 2` and is validated by Pydantic models with `ConfigDict(strict=True)`. Projects reference integrations by name. `ConfigFile.resolve_project()` applies `ConfigDefaults` for omitted fields. `load_config_file()` reads from the `CONFIG_FILE` env var (default: `config.yaml`) and emits S10 audit logs for marketplace URLs.
+
+Key design choices:
+- **Secrets stay as env vars** — tokens, connection strings, API keys never appear in the YAML file
+- **`projects[]` keyed by repo path** — GitLab identity is primary; Jira is an optional integration
+- **`integrations[]` as named blocks** — decouples integration config from project identity; extensible for future integration types
+- **Defaults cascade** — `ConfigDefaults` → `ProjectConfig` with `None` = inherit
+- **JSON Schema generation** — `ConfigFile.model_json_schema()` for pre-deploy validation via `check-jsonschema`
+
+## Consequences
+
+- v1 mapping format (`mapping_models.py`, `MappingFile`) is preserved for backward compatibility during migration
+- `ProjectRegistry.from_config()` added alongside existing `from_rendered_map()`
+- `mapping-helper` CLI gains `schema` and `validate-v2` subcommands
+- Config v2 is additive in Phase 1; full migration of `Settings` env vars into the YAML file is deferred to later phases

--- a/docs/adr/0011-typed-appcontext.md
+++ b/docs/adr/0011-typed-appcontext.md
@@ -24,9 +24,9 @@ Add a custom `State` subclass with typed attributes.
 
 ### Option B: Frozen dataclass on app.state
 
-Create a `@dataclass(frozen=True)` `AppContext` with typed fields for all services. Store it as `app.state.ctx`. Provide `get_services(request)` as a FastAPI `Depends()` accessor.
+Create a `@dataclass(frozen=True)` `AppContext` with typed fields for all services. Store it as `app.state.app_context`. Provide `get_app_context(request)` as a FastAPI `Depends()` accessor.
 
-- Pros: Full type safety. Single source of truth for service inventory. Immutability prevents accidental mutation. `get_services()` provides a clean injection point.
+- Pros: Full type safety. Single source of truth for service inventory. Immutability prevents accidental mutation. `get_app_context()` provides a clean injection point.
 - Cons: Mutable state (project_registry, pollers) can't live in a frozen dataclass. Hot-reload endpoint needs to swap project_registry.
 
 ### Option C: Full DI container (dependency-injector, etc.)
@@ -40,15 +40,15 @@ Use a third-party DI framework.
 
 **Option B** — Frozen `AppContext` dataclass with mutable state kept separately.
 
-Immutable services (`settings`, `executor`, `repo_locks`, `dedup_store`, `review_tracker`, `credential_registry`, `allowed_project_ids`) live in the frozen `AppContext` at `app.state.ctx`. Mutable state (`project_registry`, `jira_poller`, `gl_poller`) stays on `app.state` directly to support hot-reload via `/config/reload`.
+Immutable services (`settings`, `executor`, `repo_locks`, `dedup_store`, `review_tracker`, `credential_registry`, `allowed_project_ids`) live in the frozen `AppContext` at `app.state.app_context`. Mutable state (`project_registry`, `jira_poller`, `gl_poller`) stays on `app.state` directly to support hot-reload via `/config/reload`.
 
-`get_services(request: Request) -> AppContext` is the FastAPI dependency for typed access. It raises `RuntimeError` with a clear message if the context isn't initialized.
+`get_app_context(request: Request) -> AppContext` is the FastAPI dependency for typed access. It raises `RuntimeError` with a clear message if the context isn't initialized.
 
 Tests use `make_app_context(**overrides)` factory and `dataclasses.replace()` for per-test overrides.
 
 ## Consequences
 
-- All `getattr(app.state, ...)` calls in webhook.py replaced with `get_services(request)`
+- All `getattr(app.state, ...)` calls in webhook.py replaced with `get_app_context(request)`
 - `project_registry` access remains via `request.app.state.project_registry` (mutable, may be None)
 - Test fixtures simplified: `make_app_context()` replaces 7 individual `app.state.X = Y` lines
 - `pyright: ignore[reportPrivateUsage]` remains in `/config/reload` for poller internal mutation (hot-reload design constraint)

--- a/docs/adr/0011-typed-appcontext.md
+++ b/docs/adr/0011-typed-appcontext.md
@@ -1,0 +1,55 @@
+# 0011. Typed AppContext Replacing app.state Service Locator
+
+## Status
+
+Accepted
+
+## Context
+
+The FastAPI application stored all runtime services on `app.state` as untyped attributes — `app.state.settings`, `app.state.executor`, `app.state.credential_registry`, etc. (10 attributes total). Consumers accessed them via `request.app.state.settings` (no type safety) or `getattr(request.app.state, "project_registry", None)` (no compile-time checking). This pattern had several problems:
+
+1. **No type safety** — pyright couldn't verify that accessed attributes existed or had correct types
+2. **Implicit coupling** — no single place documented which services existed
+3. **Test fragility** — tests set/deleted individual `app.state` attributes with no factory or schema
+4. **Silent failures** — misspelling an attribute name produced `AttributeError` at runtime
+
+## Options Considered
+
+### Option A: Keep app.state, add type stubs
+
+Add a custom `State` subclass with typed attributes.
+
+- Pros: Minimal refactoring
+- Cons: Starlette's `State` uses `__getattr__` internally, defeating most static analysis. Still requires `getattr` for optional attributes.
+
+### Option B: Frozen dataclass on app.state
+
+Create a `@dataclass(frozen=True)` `AppContext` with typed fields for all services. Store it as `app.state.ctx`. Provide `get_services(request)` as a FastAPI `Depends()` accessor.
+
+- Pros: Full type safety. Single source of truth for service inventory. Immutability prevents accidental mutation. `get_services()` provides a clean injection point.
+- Cons: Mutable state (project_registry, pollers) can't live in a frozen dataclass. Hot-reload endpoint needs to swap project_registry.
+
+### Option C: Full DI container (dependency-injector, etc.)
+
+Use a third-party DI framework.
+
+- Pros: Established patterns, scope management
+- Cons: New dependency for a simple service set. Over-engineered for ~10 services. Framework lock-in.
+
+## Decision
+
+**Option B** — Frozen `AppContext` dataclass with mutable state kept separately.
+
+Immutable services (`settings`, `executor`, `repo_locks`, `dedup_store`, `review_tracker`, `credential_registry`, `allowed_project_ids`) live in the frozen `AppContext` at `app.state.ctx`. Mutable state (`project_registry`, `jira_poller`, `gl_poller`) stays on `app.state` directly to support hot-reload via `/config/reload`.
+
+`get_services(request: Request) -> AppContext` is the FastAPI dependency for typed access. It raises `RuntimeError` with a clear message if the context isn't initialized.
+
+Tests use `make_app_context(**overrides)` factory and `dataclasses.replace()` for per-test overrides.
+
+## Consequences
+
+- All `getattr(app.state, ...)` calls in webhook.py replaced with `get_services(request)`
+- `project_registry` access remains via `request.app.state.project_registry` (mutable, may be None)
+- Test fixtures simplified: `make_app_context()` replaces 7 individual `app.state.X = Y` lines
+- `pyright: ignore[reportPrivateUsage]` remains in `/config/reload` for poller internal mutation (hot-reload design constraint)
+- Future phases may introduce an `AtomicRef` wrapper to bring mutable state into a typed container

--- a/docs/wiki/architecture-overview.md
+++ b/docs/wiki/architecture-overview.md
@@ -89,7 +89,7 @@ graph TB
 ## Component Layers
 
 ### 1. HTTP Ingestion Layer
-- **`webhook.py`**: FastAPI endpoints for GitLab webhooks (merge_request, note). Uses `get_services()` for typed dependency access.
+- **`webhook.py`**: FastAPI endpoints for GitLab webhooks (merge_request, note). Uses `get_app_context()` for typed dependency access.
 - **`gitlab_poller.py`**: Background poller for MR discovery and @mention notes
 - **`jira_poller.py`**: Background poller for issues in "AI Ready" status
 
@@ -116,7 +116,7 @@ graph TB
 ### 5. Configuration & DI
 - **`config.py`**: `Settings` and `TaskRunnerSettings` loaded from environment variables (v1 config)
 - **`config_v2.py`**: GitLab-centric YAML config models (`ConfigFile`, `ProjectConfig`, `IntegrationConfig`), `load_config_file()`, audit logging for marketplace URLs
-- **`app_context.py`**: Frozen `AppContext` dataclass replacing `app.state` service locator. `get_services()` FastAPI dependency for typed access. Mutable state (project_registry, pollers) stays on `app.state` for hot-reload.
+- **`app_context.py`**: Frozen `AppContext` dataclass replacing `app.state` service locator. `get_app_context()` FastAPI dependency for typed access. Mutable state (project_registry, pollers) stays on `app.state` for hot-reload.
 - **`mapping_models.py`**: YAML mapping models for Jira→GitLab bindings (v1 config)
 - **`mapping_cli.py`**: CLI for `validate`, `show`, `render-json` (v1) and `schema`, `validate-v2` (v2)
 
@@ -221,7 +221,7 @@ graph TB
 **Validation**: Pydantic strict mode, HMAC for webhooks, URL validation for clones, frontmatter parsing for repo config
 
 ### Trusted Internal (Green Zone)
-- Application state (typed `AppContext` in `app_context.py`, stashed on `app.state.ctx`)
+- Application state (typed `AppContext` in `app_context.py`, stashed on `app.state.app_context`)
 - Python code in `src/gitlab_copilot_agent/`
 - Environment variables (loaded at startup)
 - YAML config file (`config_v2.py` models, loaded at startup via `load_config_file()`)

--- a/docs/wiki/architecture-overview.md
+++ b/docs/wiki/architecture-overview.md
@@ -89,7 +89,7 @@ graph TB
 ## Component Layers
 
 ### 1. HTTP Ingestion Layer
-- **`webhook.py`**: FastAPI endpoints for GitLab webhooks (merge_request, note)
+- **`webhook.py`**: FastAPI endpoints for GitLab webhooks (merge_request, note). Uses `get_services()` for typed dependency access.
 - **`gitlab_poller.py`**: Background poller for MR discovery and @mention notes
 - **`jira_poller.py`**: Background poller for issues in "AI Ready" status
 
@@ -113,17 +113,26 @@ graph TB
 - **`gitlab_client.py`**: GitLab REST API (MR details, comments, clone, create MR, resolve/reply to discussions)
 - **`jira_client.py`**: Jira REST API v3 (search, transitions, comments)
 
-### 5. Shared Utilities
+### 5. Configuration & DI
+- **`config.py`**: `Settings` and `TaskRunnerSettings` loaded from environment variables (v1 config)
+- **`config_v2.py`**: GitLab-centric YAML config models (`ConfigFile`, `ProjectConfig`, `IntegrationConfig`), `load_config_file()`, audit logging for marketplace URLs
+- **`container.py`**: Frozen `AppContext` dataclass replacing `app.state` service locator. `get_services()` FastAPI dependency for typed access. Mutable state (project_registry, pollers) stays on `app.state` for hot-reload.
+- **`mapping_models.py`**: YAML mapping models for Jira→GitLab bindings (v1 config)
+- **`mapping_cli.py`**: CLI for `validate`, `show`, `render-json` (v1) and `schema`, `validate-v2` (v2)
+
+### 6. Shared Utilities
 - **`git_operations.py`**: Git CLI wrappers (clone, branch, commit, push)
 - **`comment_parser.py`**: Extract structured review (comments + resolutions) from agent output
 - **`comment_poster.py`**: Post inline discussions to GitLab MR, handle resolution actions for prior feedback
 - **`repo_config.py`**: Discover repo-level skills, agents, instructions
 
-### 6. State & Concurrency
+### 7. State & Concurrency
 - **`concurrency.py`**: MemoryLock, MemoryDedup, ReviewedMRTracker, ProcessedIssueTracker, TaskQueue protocol, QueueMessage
+- **`credential_registry.py`**: Maps credential aliases to tokens, TTL-cached identity resolution (1hr default)
+- **`project_registry.py`**: Resolves project context at startup. Supports both v1 (`from_rendered_map`) and v2 (`from_config`) config sources. Optional `jira_project` enables review-only projects.
 - **`azure_storage.py`**: AzureStorageTaskQueue (Claim Check dispatch via Azure Storage Queue + Blob), BlobResultStore (result read/write to Blob Storage)
 
-### 7. Telemetry
+### 8. Telemetry
 - **`telemetry.py`**: OTEL tracing, metrics, log export
 - **`metrics.py`**: All 7 metrics instruments
 
@@ -212,9 +221,10 @@ graph TB
 **Validation**: Pydantic strict mode, HMAC for webhooks, URL validation for clones, frontmatter parsing for repo config
 
 ### Trusted Internal (Green Zone)
-- Application state (FastAPI app.state)
+- Application state (typed `AppContext` in `container.py`, stashed on `app.state.container`)
 - Python code in `src/gitlab_copilot_agent/`
 - Environment variables (loaded at startup)
+- YAML config file (`config_v2.py` models, loaded at startup via `load_config_file()`)
 - In-memory locks and dedup stores
 
 ### Semi-Trusted (Yellow Zone)

--- a/docs/wiki/architecture-overview.md
+++ b/docs/wiki/architecture-overview.md
@@ -116,7 +116,7 @@ graph TB
 ### 5. Configuration & DI
 - **`config.py`**: `Settings` and `TaskRunnerSettings` loaded from environment variables (v1 config)
 - **`config_v2.py`**: GitLab-centric YAML config models (`ConfigFile`, `ProjectConfig`, `IntegrationConfig`), `load_config_file()`, audit logging for marketplace URLs
-- **`container.py`**: Frozen `AppContext` dataclass replacing `app.state` service locator. `get_services()` FastAPI dependency for typed access. Mutable state (project_registry, pollers) stays on `app.state` for hot-reload.
+- **`app_context.py`**: Frozen `AppContext` dataclass replacing `app.state` service locator. `get_services()` FastAPI dependency for typed access. Mutable state (project_registry, pollers) stays on `app.state` for hot-reload.
 - **`mapping_models.py`**: YAML mapping models for Jira→GitLab bindings (v1 config)
 - **`mapping_cli.py`**: CLI for `validate`, `show`, `render-json` (v1) and `schema`, `validate-v2` (v2)
 
@@ -221,7 +221,7 @@ graph TB
 **Validation**: Pydantic strict mode, HMAC for webhooks, URL validation for clones, frontmatter parsing for repo config
 
 ### Trusted Internal (Green Zone)
-- Application state (typed `AppContext` in `container.py`, stashed on `app.state.container`)
+- Application state (typed `AppContext` in `app_context.py`, stashed on `app.state.ctx`)
 - Python code in `src/gitlab_copilot_agent/`
 - Environment variables (loaded at startup)
 - YAML config file (`config_v2.py` models, loaded at startup via `load_config_file()`)

--- a/docs/wiki/configuration-reference.md
+++ b/docs/wiki/configuration-reference.md
@@ -1,5 +1,97 @@
 # Configuration Reference
 
+The service uses two configuration sources:
+
+1. **YAML config file** (`config_v2.py` models) — non-secret service configuration: project definitions, integrations, dispatch backend, prompts, polling settings
+2. **Environment variables** (`config.py` / `Settings`) — secrets and runtime overrides: tokens, connection strings, auth credentials
+
+Secrets **never** go in the YAML file. The YAML file path is set via the `CONFIG_FILE` env var (default: `config.yaml`).
+
+---
+
+## Config v2 YAML Format
+
+The YAML config file uses `version: 2` and is validated by Pydantic models in `config_v2.py`. Generate the JSON Schema with `mapping-helper schema`. See `config.example.yaml` for a documented example.
+
+### Top-Level Structure
+
+```yaml
+version: 2                    # Required — must be 2
+
+gitlab:
+  url: https://gitlab.example.com  # Required — GitLab instance URL
+
+dispatch:
+  backend: local              # local | k8s | aca (default: local)
+
+copilot:
+  model: gpt-4                # Default model for Copilot sessions
+  plugins: []                 # Copilot CLI plugins
+  marketplaces: []            # Custom marketplace URLs (audit-logged at startup)
+
+server:
+  log_level: info
+  clone_dir: null             # Base directory for repo clones
+  shutdown_timeout: 30        # Graceful shutdown timeout (seconds)
+  webhook_ip_allowlist: []    # CIDR ranges allowed to send webhooks (empty = all)
+  trusted_proxies: []         # Reverse proxy CIDRs for X-Forwarded-For
+
+prompts:                      # Prompt overrides and suffixes
+  system: null
+  review_suffix: null
+  # ... (system_suffix, review, coding, coding_suffix, discussion, discussion_suffix)
+
+defaults:                     # Applied to every project unless overridden
+  target_branch: main
+  credential_ref: default
+  resolution_behavior: suggest  # auto-resolve | suggest | off
+  webhook: true
+  poll:
+    enabled: false
+    interval: 30
+    lookback_minutes: 60
+    review_on_push: true
+
+projects:                     # GitLab project definitions
+  - repo: group/my-project
+    credential_ref: default   # Override credential alias
+    target_branch: main       # Override target branch
+    resolution_behavior: suggest
+    webhook: true
+    poll:
+      enabled: false
+    copilot:                  # Per-project Copilot overrides
+      model: gpt-4o
+    integrations:             # References to named integrations
+      - my-jira
+
+integrations:                 # Named integration configurations
+  - name: my-jira
+    type: jira
+    project_key: PROJ
+    trigger_status: "AI Ready"
+    in_progress_status: "In Progress"
+    in_review_status: "In Review"
+```
+
+### Validation
+
+- `mapping-helper validate-v2 config.yaml` — full Pydantic validation
+- `mapping-helper schema > config.schema.json` — generate JSON Schema
+- Cross-field validators: integration refs must point to defined integrations, no duplicate repos
+
+### Config Delivery
+
+| Environment | Config Path |
+|---|---|
+| Local | `./config.yaml` (default) |
+| K8s | Helm ConfigMap → `/etc/copilot-agent/config.yaml` |
+| ACA | Terraform-rendered secret/volume |
+
+---
+
+## Environment Variables (v1)
+
 Every environment variable in `config.py`, grouped by category.
 
 ---

--- a/docs/wiki/data-models.md
+++ b/docs/wiki/data-models.md
@@ -4,6 +4,78 @@ All Pydantic models in the codebase, grouped by module and purpose.
 
 ---
 
+## Config v2 Models (`config_v2.py`)
+
+GitLab-centric YAML configuration. All models use `strict=True` validation.
+
+### `ConfigFile`
+**Purpose**: Root config model (version 2). Primary non-secret config source.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `version` | `Literal[2]` | — | Schema version, must be 2 |
+| `gitlab` | `GitLabConfig` | — | GitLab instance URL |
+| `dispatch` | `DispatchConfig` | `local` backend | Task dispatch backend |
+| `copilot` | `CopilotConfig` | `gpt-4` | Global Copilot defaults |
+| `server` | `ServerConfig` | defaults | Server operational config |
+| `prompts` | `PromptsConfig` | all `None` | Prompt overrides |
+| `defaults` | `ConfigDefaults` | defaults | Default values for projects |
+| `projects` | `list[ProjectConfig]` | `[]` | GitLab project definitions |
+| `integrations` | `list[IntegrationConfig]` | `[]` | Named integrations |
+
+**Validators**: `_validate_integration_refs` (all project integration refs must exist), `_validate_unique_repos` (no duplicate repos)
+
+**Methods**: `resolve_project(project)` — apply defaults to a project; `get_integration(name)` — lookup by name
+
+---
+
+### `ProjectConfig`
+**Purpose**: A single GitLab project. All fields except `repo` are optional and fall back to `ConfigDefaults`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `repo` | `str` | — | GitLab `path_with_namespace` |
+| `credential_ref` | `str \| None` | `None` | Credential alias |
+| `target_branch` | `str \| None` | `None` | MR target branch |
+| `resolution_behavior` | `ResolutionBehavior \| None` | `None` | `auto-resolve`, `suggest`, or `off` |
+| `webhook` | `bool \| None` | `None` | Webhook trigger enabled |
+| `poll` | `PollConfig \| None` | `None` | Polling configuration |
+| `copilot` | `CopilotConfig \| None` | `None` | Per-project Copilot overrides |
+| `integrations` | `list[str]` | `[]` | Integration names |
+
+---
+
+### `JiraIntegrationConfig`
+**Purpose**: Jira integration referenced by projects.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `str` | — | Unique name referenced by projects |
+| `type` | `Literal["jira"]` | — | Integration discriminator |
+| `project_key` | `str` | — | Jira project key |
+| `trigger_status` | `str` | `"AI Ready"` | Status that triggers agent |
+| `in_progress_status` | `str` | `"In Progress"` | Status after pickup |
+| `in_review_status` | `str` | `"In Review"` | Status after MR creation |
+
+---
+
+### `AppContext` (`container.py`)
+**Purpose**: Frozen dataclass holding all immutable service references. Created in lifespan, accessed via `get_services(request)`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `settings` | `Settings` | Environment-based config |
+| `executor` | `TaskExecutor` | Task execution backend |
+| `repo_locks` | `DistributedLock` | Concurrency locks |
+| `dedup_store` | `DeduplicationStore` | Deduplication tracking |
+| `review_tracker` | `ReviewedMRTracker` | In-memory SHA dedup |
+| `credential_registry` | `CredentialRegistry` | Token + identity resolution (TTL-cached) |
+| `allowed_project_ids` | `frozenset[int] \| None` | Project allowlist |
+
+**Note**: Mutable state (`project_registry`, pollers) stays on `app.state` directly for hot-reload support.
+
+---
+
 ## Webhook Models (`models.py`)
 
 All models use `strict=True` validation.

--- a/docs/wiki/data-models.md
+++ b/docs/wiki/data-models.md
@@ -60,7 +60,7 @@ GitLab-centric YAML configuration. All models use `strict=True` validation.
 ---
 
 ### `AppContext` (`app_context.py`)
-**Purpose**: Frozen dataclass holding all immutable service references. Created in lifespan, accessed via `get_services(request)`.
+**Purpose**: Frozen dataclass holding all immutable service references. Created in lifespan, accessed via `get_app_context(request)`.
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/docs/wiki/data-models.md
+++ b/docs/wiki/data-models.md
@@ -59,7 +59,7 @@ GitLab-centric YAML configuration. All models use `strict=True` validation.
 
 ---
 
-### `AppContext` (`container.py`)
+### `AppContext` (`app_context.py`)
 **Purpose**: Frozen dataclass holding all immutable service references. Created in lifespan, accessed via `get_services(request)`.
 
 | Field | Type | Description |

--- a/docs/wiki/module-reference.md
+++ b/docs/wiki/module-reference.md
@@ -10,7 +10,7 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 **Purpose**: FastAPI application entrypoint, lifespan management, poller startup.
 
 **Key Functions**:
-- `lifespan(app: FastAPI) -> AsyncIterator[None]`: Initialize telemetry, load settings, build credential/project registries, start pollers, graceful shutdown
+- `lifespan(app: FastAPI) -> AsyncIterator[None]`: Initialize telemetry, load settings, build `AppContext` container, start pollers, graceful shutdown
 - `health() -> dict[str, object]`: Health check endpoint, includes GitLab poller status if enabled
 - `config_reload(body: RenderedMap, request: Request) -> dict`: Hot-reload project registry from new mapping JSON (requires `X-Gitlab-Token` auth)
 - `_cleanup_stale_repos(clone_dir: str | None) -> None`: Remove leftover `mr-review-*` dirs on startup
@@ -19,7 +19,7 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 **Key Globals**:
 - `app: FastAPI`: FastAPI application instance with lifespan and webhook router
 
-**Internal Imports**: `config`, `telemetry`, `gitlab_client`, `gitlab_poller`, `jira_client`, `jira_poller`, `webhook`, `concurrency`, `state`, `task_executor`, `coding_orchestrator`, `git_operations`, `mapping_models`, `credential_registry`, `project_registry`
+**Internal Imports**: `config`, `container`, `telemetry`, `gitlab_client`, `gitlab_poller`, `jira_client`, `jira_poller`, `webhook`, `concurrency`, `state`, `task_executor`, `coding_orchestrator`, `git_operations`, `mapping_models`, `credential_registry`, `project_registry`
 
 **Depended On By**: Deployed as uvicorn entrypoint
 
@@ -31,14 +31,14 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 **Key Functions**:
 - `webhook(request: Request, background_tasks: BackgroundTasks, x_gitlab_token: str | None) -> dict[str, str]`: POST endpoint, validates HMAC, dispatches to background handlers
 - `_validate_webhook_token(received: str | None, expected: str) -> None`: HMAC comparison using `hmac.compare_digest`
-- `_process_review(request: Request, payload: MergeRequestWebhookPayload) -> None`: Background task for MR review. Resolves per-project `resolution_behavior` from project registry
+- `_process_review(request: Request, payload: MergeRequestWebhookPayload) -> None`: Background task for MR review. Uses `get_services()` for typed access to settings, executor, credential_registry. Resolves per-project `resolution_behavior` from project registry.
 - `_is_agent_directed(payload: NoteWebhookPayload, agent_identity: AgentIdentity, request: Request) -> bool`: Check if note @mentions the agent
-- `_process_discussion(request: Request, payload: NoteWebhookPayload, agent_identity: AgentIdentity) -> None`: Background task for discussion interactions. Resolves per-project `resolution_behavior` from project registry
+- `_process_discussion(request: Request, payload: NoteWebhookPayload, agent_identity: AgentIdentity) -> None`: Background task for discussion interactions. Uses `get_services()` for typed access. Resolves per-project `resolution_behavior` from project registry.
 
 **Key Constants**:
 - `HANDLED_ACTIONS = frozenset({"open", "update", "reopen"})`: MR actions that trigger review
 
-**Internal Imports**: `models`, `orchestrator`, `discussion_orchestrator`, `discussion_models`, `metrics`, `concurrency`, `project_registry`, `credential_registry`
+**Internal Imports**: `models`, `orchestrator`, `discussion_orchestrator`, `discussion_models`, `metrics`, `container`, `project_registry`
 
 **Depended On By**: `main.py` (includes router)
 
@@ -612,7 +612,7 @@ All use `frozen=True` config.
 ---
 
 ### `mapping_models.py`
-**Purpose**: Pydantic models for YAML source mappings and rendered JSON format.
+**Purpose**: Pydantic models for YAML source mappings and rendered JSON format (v1 config).
 
 **Key Models**:
 - `MappingSource`: YAML source with `defaults` + `bindings` list
@@ -623,14 +623,43 @@ All use `frozen=True` config.
 
 ---
 
+### `config_v2.py`
+**Purpose**: GitLab-centric YAML config models (v2). Replaces Jira-keyed `mapping_models.py` for project configuration.
+
+**Key Models**:
+- `ConfigFile`: Root model with `version: 2`, `gitlab`, `dispatch`, `copilot`, `server`, `prompts`, `defaults`, `projects`, `integrations`
+- `ProjectConfig`: Single GitLab project; all fields except `repo` are optional (fall back to `ConfigDefaults`)
+- `JiraIntegrationConfig`: Jira integration referenced by projects via name
+
+**Key Functions**:
+- `load_config_file(path: Path | None) -> ConfigFile`: Load + validate YAML, audit-log marketplace URLs (S10)
+
+**Depended On By**: `mapping_cli.py`, `project_registry.py`
+
+---
+
+### `container.py`
+**Purpose**: Frozen `AppContext` dataclass replacing `app.state` service locator. Provides typed dependency injection.
+
+**Key Types**:
+- `AppContext`: Frozen dataclass holding `settings`, `executor`, `repo_locks`, `dedup_store`, `review_tracker`, `credential_registry`, `allowed_project_ids`
+
+**Key Functions**:
+- `get_services(request: Request) -> AppContext`: FastAPI `Depends()` accessor
+
+**Depended On By**: `webhook.py`, `main.py`
+
+---
+
 ### `credential_registry.py`
-**Purpose**: Resolve credential aliases to GitLab tokens from environment.
+**Purpose**: Resolve credential aliases to GitLab tokens from environment. TTL-cached identity resolution.
 
 **Key Methods**:
 - `from_env() -> CredentialRegistry`: Reads `GITLAB_TOKEN` + `GITLAB_TOKEN__<ALIAS>` env vars
 - `resolve(credential_ref: str) -> str`: Returns token for alias, raises `KeyError` if unknown
+- `resolve_identity(credential_ref: str, gitlab_url: str) -> AgentIdentity`: TTL-cached identity lookup (default 1hr, `time.monotonic()`)
 
-**Depended On By**: `project_registry.py`, `main.py`
+**Depended On By**: `project_registry.py`, `main.py`, `gitlab_poller.py`
 
 ---
 
@@ -638,8 +667,8 @@ All use `frozen=True` config.
 **Purpose**: Fully resolved project context for runtime use.
 
 **Key Types**:
-- `ResolvedProject`: Frozen dataclass — `jira_project`, `repo`, `gitlab_project_id`, `clone_url`, `target_branch`, `credential_ref`, `token` (masked in repr)
-- `ProjectRegistry`: Registry with `from_rendered_map()` async factory, `get_by_jira()`, `jira_keys()`
+- `ResolvedProject`: Frozen Pydantic model — `jira_project` (optional), `repo`, `gitlab_project_id`, `clone_url`, `target_branch`, `credential_ref`, `token` (masked in repr)
+- `ProjectRegistry`: Registry with `from_rendered_map()` (v1) and `from_config()` (v2) async factories, `get_by_jira()`, `get_by_project_id()`, `jira_keys()`
 
 **Depended On By**: `jira_poller.py`, `coding_orchestrator.py`, `main.py`
 

--- a/docs/wiki/module-reference.md
+++ b/docs/wiki/module-reference.md
@@ -10,7 +10,7 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 **Purpose**: FastAPI application entrypoint, lifespan management, poller startup.
 
 **Key Functions**:
-- `lifespan(app: FastAPI) -> AsyncIterator[None]`: Initialize telemetry, load settings, build `AppContext` container, start pollers, graceful shutdown
+- `lifespan(app: FastAPI) -> AsyncIterator[None]`: Initialize telemetry, load settings, build `AppContext`, start pollers, graceful shutdown
 - `health() -> dict[str, object]`: Health check endpoint, includes GitLab poller status if enabled
 - `config_reload(body: RenderedMap, request: Request) -> dict`: Hot-reload project registry from new mapping JSON (requires `X-Gitlab-Token` auth)
 - `_cleanup_stale_repos(clone_dir: str | None) -> None`: Remove leftover `mr-review-*` dirs on startup
@@ -19,7 +19,7 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 **Key Globals**:
 - `app: FastAPI`: FastAPI application instance with lifespan and webhook router
 
-**Internal Imports**: `config`, `container`, `telemetry`, `gitlab_client`, `gitlab_poller`, `jira_client`, `jira_poller`, `webhook`, `concurrency`, `state`, `task_executor`, `coding_orchestrator`, `git_operations`, `mapping_models`, `credential_registry`, `project_registry`
+**Internal Imports**: `config`, `app_context`, `telemetry`, `gitlab_client`, `gitlab_poller`, `jira_client`, `jira_poller`, `webhook`, `concurrency`, `state`, `task_executor`, `coding_orchestrator`, `git_operations`, `mapping_models`, `credential_registry`, `project_registry`
 
 **Depended On By**: Deployed as uvicorn entrypoint
 
@@ -38,7 +38,7 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 **Key Constants**:
 - `HANDLED_ACTIONS = frozenset({"open", "update", "reopen"})`: MR actions that trigger review
 
-**Internal Imports**: `models`, `orchestrator`, `discussion_orchestrator`, `discussion_models`, `metrics`, `container`, `project_registry`
+**Internal Imports**: `models`, `orchestrator`, `discussion_orchestrator`, `discussion_models`, `metrics`, `app_context`, `project_registry`
 
 **Depended On By**: `main.py` (includes router)
 
@@ -638,7 +638,7 @@ All use `frozen=True` config.
 
 ---
 
-### `container.py`
+### `app_context.py`
 **Purpose**: Frozen `AppContext` dataclass replacing `app.state` service locator. Provides typed dependency injection.
 
 **Key Types**:

--- a/docs/wiki/module-reference.md
+++ b/docs/wiki/module-reference.md
@@ -31,9 +31,9 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 **Key Functions**:
 - `webhook(request: Request, background_tasks: BackgroundTasks, x_gitlab_token: str | None) -> dict[str, str]`: POST endpoint, validates HMAC, dispatches to background handlers
 - `_validate_webhook_token(received: str | None, expected: str) -> None`: HMAC comparison using `hmac.compare_digest`
-- `_process_review(request: Request, payload: MergeRequestWebhookPayload) -> None`: Background task for MR review. Uses `get_services()` for typed access to settings, executor, credential_registry. Resolves per-project `resolution_behavior` from project registry.
+- `_process_review(request: Request, payload: MergeRequestWebhookPayload) -> None`: Background task for MR review. Uses `get_app_context()` for typed access to settings, executor, credential_registry. Resolves per-project `resolution_behavior` from project registry.
 - `_is_agent_directed(payload: NoteWebhookPayload, agent_identity: AgentIdentity, request: Request) -> bool`: Check if note @mentions the agent
-- `_process_discussion(request: Request, payload: NoteWebhookPayload, agent_identity: AgentIdentity) -> None`: Background task for discussion interactions. Uses `get_services()` for typed access. Resolves per-project `resolution_behavior` from project registry.
+- `_process_discussion(request: Request, payload: NoteWebhookPayload, agent_identity: AgentIdentity) -> None`: Background task for discussion interactions. Uses `get_app_context()` for typed access. Resolves per-project `resolution_behavior` from project registry.
 
 **Key Constants**:
 - `HANDLED_ACTIONS = frozenset({"open", "update", "reopen"})`: MR actions that trigger review
@@ -645,7 +645,7 @@ All use `frozen=True` config.
 - `AppContext`: Frozen dataclass holding `settings`, `executor`, `repo_locks`, `dedup_store`, `review_tracker`, `credential_registry`, `allowed_project_ids`
 
 **Key Functions**:
-- `get_services(request: Request) -> AppContext`: FastAPI `Depends()` accessor
+- `get_app_context(request: Request) -> AppContext`: FastAPI `Depends()` accessor
 
 **Depended On By**: `webhook.py`, `main.py`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,4 +114,5 @@ dev = [
     "azure-storage-blob==12.28.0",
     "azure-data-tables==12.7.0",
     "aiohttp==3.13.5",
+    "check-jsonschema==0.37.1",
 ]

--- a/src/gitlab_copilot_agent/app_context.py
+++ b/src/gitlab_copilot_agent/app_context.py
@@ -1,7 +1,7 @@
 """Typed application context — replaces app.state service locator.
 
-Created once during app lifespan and stashed on ``app.state.ctx``.
-Consumers access via ``get_services(request)`` FastAPI dependency.
+Created once during app lifespan and stashed on ``app.state.app_context``.
+Consumers access via ``get_app_context(request)`` FastAPI dependency.
 
 See ADR-0011.
 """
@@ -42,21 +42,21 @@ class AppContext:
     allowed_project_ids: frozenset[int] | None = field(default=None)
 
 
-def get_services(request: Request) -> AppContext:
+def get_app_context(request: Request) -> AppContext:
     """FastAPI dependency — retrieve the AppContext from app.state.
 
     Usage::
 
         @router.post("/webhook")
-        async def webhook(ctx: AppContext = Depends(get_services)):
+        async def webhook(app_context: AppContext = Depends(get_app_context)):
             ...
 
     Raises:
         RuntimeError: If the AppContext hasn't been initialized (lifespan bug
             or missing test fixture setup).
     """
-    ctx: AppContext | None = getattr(request.app.state, "ctx", None)
-    if ctx is None:
+    app_context: AppContext | None = getattr(request.app.state, "app_context", None)
+    if app_context is None:
         msg = "AppContext not initialized — check lifespan or test fixture setup"
         raise RuntimeError(msg)
-    return ctx
+    return app_context

--- a/src/gitlab_copilot_agent/app_context.py
+++ b/src/gitlab_copilot_agent/app_context.py
@@ -1,6 +1,6 @@
-"""Typed service container — replaces app.state service locator.
+"""Typed application context — replaces app.state service locator.
 
-Created once during app lifespan and stashed on ``app.state.container``.
+Created once during app lifespan and stashed on ``app.state.ctx``.
 Consumers access via ``get_services(request)`` FastAPI dependency.
 
 See ADR-0011.
@@ -48,15 +48,15 @@ def get_services(request: Request) -> AppContext:
     Usage::
 
         @router.post("/webhook")
-        async def webhook(services: AppContext = Depends(get_services)):
+        async def webhook(ctx: AppContext = Depends(get_services)):
             ...
 
     Raises:
-        RuntimeError: If the container hasn't been initialized (lifespan bug
+        RuntimeError: If the AppContext hasn't been initialized (lifespan bug
             or missing test fixture setup).
     """
-    container: AppContext | None = getattr(request.app.state, "container", None)
-    if container is None:
+    ctx: AppContext | None = getattr(request.app.state, "ctx", None)
+    if ctx is None:
         msg = "AppContext not initialized — check lifespan or test fixture setup"
         raise RuntimeError(msg)
-    return container
+    return ctx

--- a/src/gitlab_copilot_agent/config_v2.py
+++ b/src/gitlab_copilot_agent/config_v2.py
@@ -1,0 +1,324 @@
+"""Config v2 models — GitLab-project-centric YAML configuration.
+
+Full service configuration: service-level settings, per-project config
+with trigger and copilot overrides, and pluggable integrations.
+Replaces both mapping_models.py (Jira-keyed bindings) and the non-secret
+portions of config.py (Settings).
+
+See architecture plan S4 and ADR-0010.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Literal
+
+import structlog
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+log = structlog.get_logger()
+
+ResolutionBehavior = Literal["auto-resolve", "suggest", "off"]
+
+DEFAULT_CONFIG_PATH = "config.yaml"
+
+
+class GitLabConfig(BaseModel):
+    """GitLab instance configuration."""
+
+    model_config = ConfigDict(strict=True)
+
+    url: str = Field(description="GitLab instance URL")
+
+
+class DispatchConfig(BaseModel):
+    """Task dispatch backend configuration."""
+
+    model_config = ConfigDict(strict=True)
+
+    backend: Literal["local", "k8s", "aca"] = Field(
+        default="local", description="Dispatch backend"
+    )
+    # K8s-specific
+    k8s_namespace: str = Field(default="default", description="K8s namespace for Jobs")
+    k8s_job_image: str = Field(default="", description="Docker image for Job pods")
+    k8s_job_timeout: int = Field(default=600, description="Job timeout in seconds")
+    # ACA-specific
+    aca_subscription_id: str = Field(default="", description="Azure subscription ID")
+    aca_resource_group: str = Field(default="", description="Azure resource group")
+    aca_job_name: str = Field(default="", description="ACA Job resource name")
+    aca_job_timeout: int = Field(default=600, description="ACA Job timeout in seconds")
+
+
+class CopilotConfig(BaseModel):
+    """Copilot/LLM configuration — global defaults, overridable per-project."""
+
+    model_config = ConfigDict(strict=True)
+
+    model: str = Field(default="gpt-4", description="Default model for Copilot sessions")
+    plugins: list[str] = Field(default_factory=list, description="Copilot CLI plugins")
+    marketplaces: list[str] = Field(
+        default_factory=list, description="Custom plugin marketplace URLs"
+    )
+
+
+class ServerConfig(BaseModel):
+    """Server operational configuration."""
+
+    model_config = ConfigDict(strict=True)
+
+    log_level: str = Field(default="info", description="Log level")
+    clone_dir: str | None = Field(default=None, description="Base directory for repo clones")
+    shutdown_timeout: int = Field(
+        default=30, gt=0, description="Graceful shutdown timeout in seconds"
+    )
+    webhook_ip_allowlist: list[str] = Field(
+        default_factory=list,
+        description="CIDR ranges allowed to send webhooks. Empty = allow all. "
+        "GitLab.com ranges: 34.74.90.64/28, 34.74.226.0/24",
+    )
+    trusted_proxies: list[str] = Field(
+        default_factory=list,
+        description="CIDR ranges of trusted reverse proxies for X-Forwarded-For parsing",
+    )
+
+
+class PromptsConfig(BaseModel):
+    """System prompt overrides and suffixes."""
+
+    model_config = ConfigDict(strict=True)
+
+    system: str | None = Field(default=None, description="Global base prompt override")
+    system_suffix: str | None = Field(default=None, description="Appended to global base")
+    review: str | None = Field(default=None, description="Review prompt override")
+    review_suffix: str | None = Field(default=None, description="Appended to review prompt")
+    coding: str | None = Field(default=None, description="Coding prompt override")
+    coding_suffix: str | None = Field(default=None, description="Appended to coding prompt")
+    discussion: str | None = Field(default=None, description="Discussion prompt override")
+    discussion_suffix: str | None = Field(
+        default=None, description="Appended to discussion prompt"
+    )
+
+
+class PollConfig(BaseModel):
+    """GitLab polling configuration."""
+
+    model_config = ConfigDict(strict=True)
+
+    enabled: bool = Field(default=False, description="Enable GitLab API polling")
+    interval: int = Field(default=30, description="Polling interval in seconds")
+    lookback_minutes: int = Field(
+        default=60, description="Minutes to look back on startup for recent MRs"
+    )
+    review_on_push: bool = Field(
+        default=True,
+        description="Re-review MRs on new commits (dedup per commit). "
+        "When false, each MR reviewed once (dedup per MR).",
+    )
+
+
+class ConfigDefaults(BaseModel):
+    """Default values applied to every project unless overridden."""
+
+    model_config = ConfigDict(strict=True)
+
+    target_branch: str = Field(default="main", description="Default MR target branch")
+    credential_ref: str = Field(default="default", description="Default credential alias")
+    resolution_behavior: ResolutionBehavior = Field(
+        default="suggest", description="Default resolution behavior"
+    )
+    webhook: bool = Field(default=True, description="Default webhook trigger enabled")
+    poll: PollConfig = Field(
+        default_factory=PollConfig, description="Default polling configuration"
+    )
+
+
+class ProjectConfig(BaseModel):
+    """A single GitLab project entry."""
+
+    model_config = ConfigDict(strict=True)
+
+    repo: str = Field(description="GitLab repo path_with_namespace (e.g. group/repo)")
+    credential_ref: str | None = Field(
+        default=None, description="Credential alias; falls back to defaults"
+    )
+    target_branch: str | None = Field(
+        default=None, description="Target branch; falls back to defaults"
+    )
+    resolution_behavior: ResolutionBehavior | None = Field(
+        default=None, description="Resolution behavior; falls back to defaults"
+    )
+    webhook: bool | None = Field(
+        default=None, description="Webhook trigger; falls back to defaults"
+    )
+    poll: PollConfig | None = Field(
+        default=None, description="Polling config; falls back to defaults"
+    )
+    copilot: CopilotConfig | None = Field(
+        default=None, description="Per-project Copilot overrides"
+    )
+    integrations: list[str] = Field(
+        default_factory=list,
+        description="Integration names from the integrations list",
+    )
+
+
+class JiraIntegrationConfig(BaseModel):
+    """Jira integration block."""
+
+    model_config = ConfigDict(strict=True)
+
+    name: str = Field(description="Unique integration name, referenced by projects")
+    type: Literal["jira"] = Field(description="Integration type discriminator")
+    project_key: str = Field(description="Jira project key (e.g. PROJ)")
+    trigger_status: str = Field(
+        default="AI Ready", description="Jira status that triggers the agent"
+    )
+    in_progress_status: str = Field(default="In Progress", description="Status after agent pickup")
+    in_review_status: str = Field(default="In Review", description="Status after MR creation")
+
+
+IntegrationConfig = JiraIntegrationConfig  # Union when more types added
+
+
+class ConfigFile(BaseModel):
+    """Root config file model (version 2).
+
+    The YAML file is the primary non-secret config source. Secrets
+    (tokens, connection strings) stay as env vars. A few operational
+    env vars (LOG_LEVEL, DISPATCH_BACKEND) can override YAML values.
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    version: Literal[2] = Field(description="Schema version — must be 2")
+    gitlab: GitLabConfig = Field(description="GitLab instance configuration")
+    dispatch: DispatchConfig = Field(
+        default_factory=DispatchConfig, description="Dispatch backend config"
+    )
+    copilot: CopilotConfig = Field(
+        default_factory=CopilotConfig, description="Global Copilot defaults"
+    )
+    server: ServerConfig = Field(
+        default_factory=ServerConfig, description="Server operational config"
+    )
+    prompts: PromptsConfig = Field(default_factory=PromptsConfig, description="Prompt overrides")
+    defaults: ConfigDefaults = Field(
+        default_factory=ConfigDefaults, description="Project defaults"
+    )
+    projects: list[ProjectConfig] = Field(
+        default_factory=lambda: [], description="GitLab project definitions"
+    )
+    integrations: list[IntegrationConfig] = Field(
+        default_factory=lambda: [], description="Named integration configurations"
+    )
+
+    @model_validator(mode="after")
+    def _validate_integration_refs(self) -> ConfigFile:
+        """Ensure every project.integrations ref points to a defined integration."""
+        known = {i.name for i in self.integrations}
+        for proj in self.projects:
+            for ref in proj.integrations:
+                if ref not in known:
+                    msg = (
+                        f"Project '{proj.repo}' references unknown integration '{ref}'. "
+                        f"Known: {sorted(known)}"
+                    )
+                    raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
+    def _validate_unique_repos(self) -> ConfigFile:
+        """Ensure no duplicate project repos."""
+        seen: dict[str, int] = {}
+        for idx, proj in enumerate(self.projects):
+            if proj.repo in seen:
+                msg = f"Duplicate project repo '{proj.repo}' at index {seen[proj.repo]} and {idx}"
+                raise ValueError(msg)
+            seen[proj.repo] = idx
+        return self
+
+    def resolve_project(self, project: ProjectConfig) -> dict[str, object]:
+        """Apply defaults to a project and return resolved values.
+
+        Args:
+            project: A project config entry to resolve against defaults.
+
+        Returns:
+            Dict with fully resolved values for all project fields.
+        """
+        return {
+            "repo": project.repo,
+            "credential_ref": project.credential_ref or self.defaults.credential_ref,
+            "target_branch": project.target_branch or self.defaults.target_branch,
+            "resolution_behavior": (
+                project.resolution_behavior or self.defaults.resolution_behavior
+            ),
+            "webhook": (project.webhook if project.webhook is not None else self.defaults.webhook),
+            "poll": project.poll or self.defaults.poll,
+            "copilot": project.copilot or self.copilot,
+            "integrations": [self.get_integration(name) for name in project.integrations],
+        }
+
+    def get_integration(self, name: str) -> IntegrationConfig | None:
+        """Look up an integration by name.
+
+        Args:
+            name: Integration name as referenced in project configs.
+
+        Returns:
+            The matching IntegrationConfig, or None if not found.
+        """
+        for i in self.integrations:
+            if i.name == name:
+                return i
+        return None
+
+
+def load_config_file(path: Path | None = None) -> ConfigFile:
+    """Load and validate a v2 config YAML file.
+
+    Args:
+        path: Path to the YAML config file. If None, reads from
+            CONFIG_FILE env var (default: config.yaml).
+
+    Returns:
+        Validated ConfigFile model.
+
+    Raises:
+        FileNotFoundError: If the config file does not exist.
+        ValueError: If the file is not valid YAML or fails validation.
+    """
+    if path is None:
+        path = Path(os.environ.get("CONFIG_FILE", DEFAULT_CONFIG_PATH))
+    raw = yaml.safe_load(path.read_text())
+    if not isinstance(raw, dict):
+        msg = f"{path}: expected a YAML mapping, got {type(raw).__name__}"
+        raise ValueError(msg)
+    config = ConfigFile.model_validate(raw)
+    _audit_log_marketplaces(config)
+    return config
+
+
+def _audit_log_marketplaces(config: ConfigFile) -> None:
+    """S10: Emit structured audit logs for configured marketplace URLs.
+
+    Marketplace URLs are external trust boundaries — operators must be aware
+    of any configured custom marketplaces at startup and on reload.
+    """
+    if config.copilot.marketplaces:
+        log.info(
+            "marketplace_urls_configured",
+            scope="global",
+            urls=config.copilot.marketplaces,
+        )
+    for proj in config.projects:
+        if proj.copilot and proj.copilot.marketplaces:
+            log.info(
+                "marketplace_urls_configured",
+                scope="project",
+                repo=proj.repo,
+                urls=proj.copilot.marketplaces,
+            )

--- a/src/gitlab_copilot_agent/container.py
+++ b/src/gitlab_copilot_agent/container.py
@@ -1,0 +1,62 @@
+"""Typed service container — replaces app.state service locator.
+
+Created once during app lifespan and stashed on ``app.state.container``.
+Consumers access via ``get_services(request)`` FastAPI dependency.
+
+See ADR-0011.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from fastapi import Request  # noqa: TC002 — runtime import required for FastAPI Depends()
+
+if TYPE_CHECKING:
+    from gitlab_copilot_agent.concurrency import (
+        DeduplicationStore,
+        DistributedLock,
+        ReviewedMRTracker,
+    )
+    from gitlab_copilot_agent.config import Settings
+    from gitlab_copilot_agent.credential_registry import CredentialRegistry
+    from gitlab_copilot_agent.task_executor import TaskExecutor
+
+
+@dataclass(frozen=True)
+class AppContext:
+    """All injected services in one typed object.
+
+    Holds immutable service references created during app lifespan.
+    Mutable state (project_registry, pollers) lives on ``app.state``
+    directly — see ``/config/reload`` endpoint for hot-swap rationale.
+    """
+
+    settings: Settings
+    executor: TaskExecutor
+    repo_locks: DistributedLock
+    dedup_store: DeduplicationStore
+    review_tracker: ReviewedMRTracker
+    credential_registry: CredentialRegistry
+    allowed_project_ids: frozenset[int] | None = field(default=None)
+
+
+def get_services(request: Request) -> AppContext:
+    """FastAPI dependency — retrieve the AppContext from app.state.
+
+    Usage::
+
+        @router.post("/webhook")
+        async def webhook(services: AppContext = Depends(get_services)):
+            ...
+
+    Raises:
+        RuntimeError: If the container hasn't been initialized (lifespan bug
+            or missing test fixture setup).
+    """
+    container: AppContext | None = getattr(request.app.state, "container", None)
+    if container is None:
+        msg = "AppContext not initialized — check lifespan or test fixture setup"
+        raise RuntimeError(msg)
+    return container

--- a/src/gitlab_copilot_agent/credential_registry.py
+++ b/src/gitlab_copilot_agent/credential_registry.py
@@ -4,8 +4,8 @@ Reads ``GITLAB_TOKEN`` (the default) and ``GITLAB_TOKEN__<ALIAS>`` env vars
 at construction time.  A binding's ``credential_ref`` is resolved to the
 matching token via :meth:`resolve`.
 
-Also provides lazy identity caching: each credential can be resolved to the
-GitLab user it authenticates as via :meth:`resolve_identity`.
+Also provides TTL-cached identity resolution: each credential can be resolved
+to the GitLab user it authenticates as via :meth:`resolve_identity`.
 
 No raw secrets are ever logged.
 """
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import os
 import re
+import time
 
 import gitlab
 import structlog
@@ -24,16 +25,24 @@ from gitlab_copilot_agent.discussion_models import AgentIdentity
 log = structlog.get_logger()
 
 _ALIAS_PATTERN = re.compile(r"^GITLAB_TOKEN__(.+)$")
+_DEFAULT_IDENTITY_TTL = 3600
 
 
 class CredentialRegistry:
     """Startup-loaded registry mapping credential aliases to tokens."""
 
-    def __init__(self, *, default_token: str, named_tokens: dict[str, str] | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        default_token: str,
+        named_tokens: dict[str, str] | None = None,
+        identity_cache_ttl: int = _DEFAULT_IDENTITY_TTL,
+    ) -> None:
         self._tokens: dict[str, str] = {"default": default_token}
         for alias, token in (named_tokens or {}).items():
             self._tokens[alias.lower()] = token
-        self._identities: dict[str, AgentIdentity] = {}
+        self._identities: dict[str, tuple[AgentIdentity, float]] = {}
+        self._identity_cache_ttl = identity_cache_ttl
         self._identity_lock = asyncio.Lock()
 
     @classmethod
@@ -74,28 +83,35 @@ class CredentialRegistry:
             raise KeyError(msg) from None
 
     async def resolve_identity(self, credential_ref: str, gitlab_url: str) -> AgentIdentity:
-        """Return the :class:`AgentIdentity` for *credential_ref*, with caching.
+        """Return the :class:`AgentIdentity` for *credential_ref*, with TTL caching.
 
-        On the first call for a given *credential_ref* this authenticates
-        against the GitLab API; subsequent calls return the cached result.
+        On the first call (or after TTL expiry) for a given *credential_ref*
+        this authenticates against the GitLab API; otherwise returns cached.
 
         Uses an asyncio lock to prevent thundering-herd duplicate API calls
         when multiple coroutines resolve the same credential concurrently.
+
+        Args:
+            credential_ref: Credential alias to resolve.
+            gitlab_url: GitLab instance URL for API authentication.
+
+        Returns:
+            The AgentIdentity (user_id + username) for the credential.
         """
         ref = credential_ref.lower()
-        cached = self._identities.get(ref)
+        cached = self._get_cached_identity(ref)
         if cached is not None:
             return cached
 
         async with self._identity_lock:
             # Double-check after acquiring the lock
-            cached = self._identities.get(ref)
+            cached = self._get_cached_identity(ref)
             if cached is not None:
                 return cached
 
             token = self.resolve(credential_ref)
             identity = await _fetch_identity(gitlab_url, token)
-            self._identities[ref] = identity
+            self._identities[ref] = (identity, time.monotonic())
             log.info(
                 "agent_identity_resolved",
                 credential_ref=ref,
@@ -103,6 +119,17 @@ class CredentialRegistry:
                 username=identity.username,
             )
             return identity
+
+    def _get_cached_identity(self, ref: str) -> AgentIdentity | None:
+        """Return cached identity if present and not expired."""
+        entry = self._identities.get(ref)
+        if entry is None:
+            return None
+        identity, cached_at = entry
+        if time.monotonic() - cached_at > self._identity_cache_ttl:
+            del self._identities[ref]
+            return None
+        return identity
 
     def aliases(self) -> set[str]:
         """Return all registered credential aliases."""

--- a/src/gitlab_copilot_agent/gitlab_poller.py
+++ b/src/gitlab_copilot_agent/gitlab_poller.py
@@ -82,10 +82,28 @@ class GitLabPoller:
         self._task = asyncio.create_task(self._poll_loop())
 
     async def stop(self) -> None:
+        """Cancel the polling loop."""
         if self._task:
             self._task.cancel()
             with suppress(asyncio.CancelledError):
                 await self._task
+
+    def update_project_registry(self, registry: ProjectRegistry | None) -> None:
+        """Swap the project registry and clear cached per-project clients.
+
+        Called by ``/config/reload`` to hot-swap the registry without
+        restarting the poller.
+        """
+        self._project_registry = registry
+        self._project_clients.clear()
+
+    def status(self) -> dict[str, object]:
+        """Return health-check status for the poller."""
+        return {
+            "running": self._task is not None and not self._task.done(),
+            "failures": self._failures,
+            "watermark": self._watermark,
+        }
 
     async def _poll_loop(self) -> None:
         while True:

--- a/src/gitlab_copilot_agent/gitlab_poller.py
+++ b/src/gitlab_copilot_agent/gitlab_poller.py
@@ -53,6 +53,8 @@ class GitLabPoller:
         repo_locks: DistributedLock | None = None,
         project_registry: ProjectRegistry | None = None,
         credential_registry: CredentialRegistry | None = None,
+        *,
+        poll_interval: int = 30,
     ) -> None:
         self._client = gl_client
         self._settings = settings
@@ -63,8 +65,7 @@ class GitLabPoller:
         self._project_registry = project_registry
         self._credential_registry = credential_registry
         self._project_clients: dict[str, GitLabClientProtocol] = {}
-        self._identity_cache: dict[str, AgentIdentity] = {}
-        self._interval: int = 30
+        self._interval: int = poll_interval
         self._task: asyncio.Task[None] | None = None
         self._watermark: str | None = None
         self._note_watermark: str | None = None
@@ -222,7 +223,10 @@ class GitLabPoller:
         await self._dedup.mark_seen(key, ttl_seconds=_DEDUP_TTL)
 
     async def _resolve_agent_identity(self, project_id: int) -> AgentIdentity | None:
-        """Resolve the agent identity for the credential used by this project."""
+        """Resolve the agent identity for the credential used by this project.
+
+        Delegates to CredentialRegistry which owns the TTL-based cache.
+        """
         if self._credential_registry is None:
             return None
         ref = "default"
@@ -230,15 +234,8 @@ class GitLabPoller:
             resolved = self._project_registry.get_by_project_id(project_id)
             if resolved is not None:
                 ref = resolved.credential_ref
-        # Cache per credential_ref
-        if ref in self._identity_cache:
-            return self._identity_cache[ref]
         try:
-            identity = await self._credential_registry.resolve_identity(
-                ref, self._settings.gitlab_url
-            )
-            self._identity_cache[ref] = identity
-            return identity
+            return await self._credential_registry.resolve_identity(ref, self._settings.gitlab_url)
         except Exception:
             await log.awarning(
                 "poller_identity_resolution_failed", credential_ref=ref, exc_info=True

--- a/src/gitlab_copilot_agent/main.py
+++ b/src/gitlab_copilot_agent/main.py
@@ -22,6 +22,7 @@ from gitlab_copilot_agent.concurrency import (
     ReviewedMRTracker,
 )
 from gitlab_copilot_agent.config import Settings
+from gitlab_copilot_agent.container import AppContext
 from gitlab_copilot_agent.credential_registry import CredentialRegistry
 from gitlab_copilot_agent.git_operations import CLONE_DIR_PREFIX
 from gitlab_copilot_agent.gitlab_client import GitLabClient
@@ -123,6 +124,7 @@ def _print_config_errors(exc: ValidationError) -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """Application lifespan — create services, stash in AppContext."""
     init_telemetry()
     try:
         settings = Settings()  # pyright: ignore[reportCallIssue]
@@ -130,8 +132,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         _print_config_errors(exc)
         sys.exit(1)
     _cleanup_stale_repos(settings.clone_dir)
-    app.state.settings = settings
-    app.state.executor = _create_executor(settings.task_executor, settings)
+    executor = _create_executor(settings.task_executor, settings)
 
     # Resolve project allowlist
     allowed_project_ids: set[int] | None = None
@@ -148,22 +149,32 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             except Exception as exc:
                 raise ValueError(f"Cannot resolve GitLab project: {entry!r}") from exc
         await log.ainfo("project_allowlist_resolved", project_ids=sorted(allowed_project_ids))
-    app.state.allowed_project_ids = allowed_project_ids
 
-    # Shared lock manager for both webhook and Jira flows
+    # Shared concurrency primitives
     repo_locks = create_lock()
-    app.state.repo_locks = repo_locks
     dedup_store = create_dedup(
         azure_storage_account_url=settings.azure_storage_account_url,
         azure_storage_connection_string=settings.azure_storage_connection_string,
     )
-    app.state.dedup_store = dedup_store
-    app.state.review_tracker = ReviewedMRTracker()
-
-    # Credential registry — always available for identity resolution
+    review_tracker = ReviewedMRTracker()
     creds = CredentialRegistry.from_env()
-    app.state.credential_registry = creds
 
+    # Build typed AppContext (immutable services)
+    container = AppContext(
+        settings=settings,
+        executor=executor,
+        repo_locks=repo_locks,
+        dedup_store=dedup_store,
+        review_tracker=review_tracker,
+        credential_registry=creds,
+        allowed_project_ids=(
+            frozenset(allowed_project_ids) if allowed_project_ids is not None else None
+        ),
+    )
+    app.state.container = container
+
+    # Mutable state: project_registry and pollers stay on app.state
+    # directly for hot-reload support (see /config/reload endpoint).
     poller: JiraPoller | None = None
     gl_poller: GitLabPoller | None = None
     jira_client: JiraClient | None = None
@@ -196,7 +207,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         gl_client = GitLabClient(settings.gitlab_url, settings.gitlab_token)
         tracker = ProcessedIssueTracker()
         handler = CodingOrchestrator(
-            settings, gl_client, jira_client, app.state.executor, repo_locks, tracker
+            settings, gl_client, jira_client, executor, repo_locks, tracker
         )
         poller = JiraPoller(
             jira_client, settings.jira, project_registry, handler, allowed_project_ids
@@ -214,12 +225,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             settings=settings,
             project_ids=allowed_project_ids,
             dedup=dedup_store,
-            executor=app.state.executor,
+            executor=executor,
             repo_locks=repo_locks,
             project_registry=project_registry,
             credential_registry=creds,
+            poll_interval=settings.gitlab_poll_interval,
         )
-        gl_poller._interval = settings.gitlab_poll_interval  # pyright: ignore[reportPrivateUsage]
         await gl_poller.start()
         app.state.gl_poller = gl_poller
         await log.ainfo(
@@ -291,7 +302,8 @@ async def config_reload(
 
     Requires the same webhook secret used for GitLab webhook auth.
     """
-    settings: Settings = request.app.state.settings
+    container: AppContext = request.app.state.container
+    settings = container.settings
     secret = settings.gitlab_webhook_secret
     received = request.headers.get("X-Gitlab-Token")
     if secret is None:

--- a/src/gitlab_copilot_agent/main.py
+++ b/src/gitlab_copilot_agent/main.py
@@ -160,7 +160,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     creds = CredentialRegistry.from_env()
 
     # Build typed AppContext (immutable services)
-    ctx = AppContext(
+    app_context = AppContext(
         settings=settings,
         executor=executor,
         repo_locks=repo_locks,
@@ -171,7 +171,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             frozenset(allowed_project_ids) if allowed_project_ids is not None else None
         ),
     )
-    app.state.ctx = ctx
+    app.state.app_context = app_context
 
     # Mutable state: project_registry and pollers stay on app.state
     # directly for hot-reload support (see /config/reload endpoint).
@@ -301,8 +301,8 @@ async def config_reload(
 
     Requires the same webhook secret used for GitLab webhook auth.
     """
-    ctx: AppContext = request.app.state.ctx
-    settings = ctx.settings
+    app_context: AppContext = request.app.state.app_context
+    settings = app_context.settings
     secret = settings.gitlab_webhook_secret
     received = request.headers.get("X-Gitlab-Token")
     if secret is None:

--- a/src/gitlab_copilot_agent/main.py
+++ b/src/gitlab_copilot_agent/main.py
@@ -213,10 +213,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             jira_client, settings.jira, project_registry, handler, allowed_project_ids
         )
         await poller.start()
-        app.state.jira_poller = poller
         await log.ainfo("jira_poller_started", interval=settings.jira.poll_interval)
-
-    app.state.project_registry = project_registry
 
     if settings.gitlab_poll and allowed_project_ids:
         gl_client_poll = GitLabClient(settings.gitlab_url, settings.gitlab_token)
@@ -232,12 +229,17 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             poll_interval=settings.gitlab_poll_interval,
         )
         await gl_poller.start()
-        app.state.gl_poller = gl_poller
         await log.ainfo(
             "gitlab_poller_started",
             interval=settings.gitlab_poll_interval,
             projects=sorted(allowed_project_ids),
         )
+
+    # Always set mutable state — even None — so direct attribute access
+    # works without getattr() fallbacks in webhook.py and config_reload.
+    app.state.project_registry = project_registry
+    app.state.jira_poller = poller
+    app.state.gl_poller = gl_poller
 
     await log.ainfo("service started", gitlab_url=settings.gitlab_url)
     yield
@@ -282,14 +284,11 @@ FastAPIInstrumentor.instrument_app(app)
 
 @app.get("/health")
 async def health() -> dict[str, object]:
+    """Health check endpoint."""
     result: dict[str, object] = {"status": "ok"}
-    gl_poller = getattr(app.state, "gl_poller", None)
+    gl_poller: GitLabPoller | None = app.state.gl_poller
     if gl_poller is not None:
-        result["gitlab_poller"] = {
-            "running": gl_poller._task is not None and not gl_poller._task.done(),
-            "failures": gl_poller._failures,
-            "watermark": gl_poller._watermark,
-        }
+        result["gitlab_poller"] = gl_poller.status()
     return result
 
 
@@ -311,7 +310,7 @@ async def config_reload(
     if received is None or not hmac.compare_digest(received, secret):
         raise HTTPException(status_code=401, detail="Invalid token")
 
-    poller: JiraPoller | None = getattr(app.state, "jira_poller", None)
+    poller: JiraPoller | None = app.state.jira_poller
     if poller is None:
         return {"status": "error", "detail": "Jira poller not active"}
     creds = CredentialRegistry.from_env()
@@ -322,10 +321,9 @@ async def config_reload(
         return {"status": "error", "detail": "Invalid configuration — check server logs"}
     await poller.reload_registry(registry)
     app.state.project_registry = registry
-    gl_poller: GitLabPoller | None = getattr(app.state, "gl_poller", None)
+    gl_poller: GitLabPoller | None = app.state.gl_poller
     if gl_poller is not None:
-        gl_poller._project_registry = registry  # pyright: ignore[reportPrivateUsage]
-        gl_poller._project_clients.clear()  # pyright: ignore[reportPrivateUsage]
+        gl_poller.update_project_registry(registry)
     return {
         "status": "ok",
         "jira_keys": sorted(registry.jira_keys()),

--- a/src/gitlab_copilot_agent/main.py
+++ b/src/gitlab_copilot_agent/main.py
@@ -16,13 +16,13 @@ from fastapi import FastAPI, HTTPException, Request
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from pydantic import ValidationError
 
+from gitlab_copilot_agent.app_context import AppContext
 from gitlab_copilot_agent.coding_orchestrator import CodingOrchestrator
 from gitlab_copilot_agent.concurrency import (
     ProcessedIssueTracker,
     ReviewedMRTracker,
 )
 from gitlab_copilot_agent.config import Settings
-from gitlab_copilot_agent.container import AppContext
 from gitlab_copilot_agent.credential_registry import CredentialRegistry
 from gitlab_copilot_agent.git_operations import CLONE_DIR_PREFIX
 from gitlab_copilot_agent.gitlab_client import GitLabClient
@@ -160,7 +160,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     creds = CredentialRegistry.from_env()
 
     # Build typed AppContext (immutable services)
-    container = AppContext(
+    ctx = AppContext(
         settings=settings,
         executor=executor,
         repo_locks=repo_locks,
@@ -171,7 +171,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             frozenset(allowed_project_ids) if allowed_project_ids is not None else None
         ),
     )
-    app.state.container = container
+    app.state.ctx = ctx
 
     # Mutable state: project_registry and pollers stay on app.state
     # directly for hot-reload support (see /config/reload endpoint).
@@ -302,8 +302,8 @@ async def config_reload(
 
     Requires the same webhook secret used for GitLab webhook auth.
     """
-    container: AppContext = request.app.state.container
-    settings = container.settings
+    ctx: AppContext = request.app.state.ctx
+    settings = ctx.settings
     secret = settings.gitlab_webhook_secret
     received = request.headers.get("X-Gitlab-Token")
     if secret is None:

--- a/src/gitlab_copilot_agent/mapping_cli.py
+++ b/src/gitlab_copilot_agent/mapping_cli.py
@@ -5,6 +5,8 @@ Usage::
     mapping-helper validate mappings.yaml
     mapping-helper show     mappings.yaml
     mapping-helper render-json mappings.yaml
+    mapping-helper schema
+    mapping-helper validate-v2 config.yaml
 """
 
 from __future__ import annotations
@@ -17,6 +19,7 @@ from pathlib import Path
 import yaml
 from pydantic import ValidationError
 
+from gitlab_copilot_agent.config_v2 import ConfigFile, load_config_file
 from gitlab_copilot_agent.mapping_models import MappingFile
 
 
@@ -101,6 +104,36 @@ def _print_validation_errors(exc: Exception) -> None:
         print(f"  {exc}", file=sys.stderr)
 
 
+def _cmd_schema(_args: argparse.Namespace) -> int:
+    """Emit the v2 config JSON Schema to stdout.
+
+    Pipe to a file to commit::
+
+        mapping-helper schema > config.schema.json
+    """
+    schema = ConfigFile.model_json_schema()
+    print(json.dumps(schema, indent=2))
+    return 0
+
+
+def _cmd_validate_v2(args: argparse.Namespace) -> int:
+    """Validate a v2 config file."""
+    path = Path(args.path)
+    if not path.is_file():
+        print(f"Error: {path} is not a file", file=sys.stderr)
+        return 1
+    try:
+        config = load_config_file(path)
+        print(
+            f"✅ Valid v2 config: {len(config.projects)} projects, "
+            f"{len(config.integrations)} integrations"
+        )
+    except (ValidationError, ValueError, yaml.YAMLError, FileNotFoundError) as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     """Entry point for the mapping-helper CLI."""
     parser = argparse.ArgumentParser(
@@ -109,6 +142,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     sub = parser.add_subparsers(dest="command", required=True)
 
+    # v1 subcommands (YAML mapping files)
     for name, help_text in [
         ("validate", "Validate a YAML mapping file"),
         ("show", "Show a human-readable summary"),
@@ -117,9 +151,22 @@ def main(argv: list[str] | None = None) -> int:
         p = sub.add_parser(name, help=help_text)
         p.add_argument("path", type=Path, help="Path to the YAML mapping file")
 
-    args = parser.parse_args(argv)
-    path: Path = args.path
+    # v2 subcommands (config v2)
+    sub.add_parser("schema", help="Emit v2 config JSON Schema to stdout")
 
+    v2_validate = sub.add_parser("validate-v2", help="Validate a v2 config file")
+    v2_validate.add_argument("path", type=Path, help="Path to v2 config YAML file")
+
+    args = parser.parse_args(argv)
+
+    # v2 commands don't need the file-existence check
+    if args.command == "schema":
+        return _cmd_schema(args)
+    if args.command == "validate-v2":
+        return _cmd_validate_v2(args)
+
+    # v1 commands require a file path
+    path: Path = args.path
     if not path.is_file():
         print(f"Error: {path} is not a file", file=sys.stderr)
         return 1

--- a/src/gitlab_copilot_agent/project_registry.py
+++ b/src/gitlab_copilot_agent/project_registry.py
@@ -1,6 +1,8 @@
-"""Project registry — resolves Jira→GitLab project context at startup."""
+"""Project registry — resolves project context at startup."""
 
 from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import structlog
 from pydantic import BaseModel, ConfigDict, Field
@@ -8,6 +10,9 @@ from pydantic import BaseModel, ConfigDict, Field
 from gitlab_copilot_agent.credential_registry import CredentialRegistry
 from gitlab_copilot_agent.gitlab_client import GitLabClient
 from gitlab_copilot_agent.mapping_models import RenderedMap, ResolutionBehavior
+
+if TYPE_CHECKING:
+    from gitlab_copilot_agent.config_v2 import ConfigFile
 
 log = structlog.get_logger()
 
@@ -17,7 +22,9 @@ class ResolvedProject(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    jira_project: str = Field(description="Jira project key")
+    jira_project: str | None = Field(
+        default=None, description="Jira project key (None for review-only projects)"
+    )
     repo: str = Field(description="GitLab repo path_with_namespace")
     gitlab_project_id: int = Field(description="Numeric GitLab project ID")
     clone_url: str = Field(description="Git HTTP clone URL")
@@ -37,7 +44,10 @@ class ProjectRegistry:
     """Immutable lookup of Jira key or GitLab project ID → ResolvedProject."""
 
     def __init__(self, projects: list[ResolvedProject]) -> None:
-        self._by_jira = {p.jira_project: p for p in projects}
+        self._by_jira: dict[str, ResolvedProject] = {}
+        for p in projects:
+            if p.jira_project is not None:
+                self._by_jira[p.jira_project] = p
         self._by_project_id: dict[int, ResolvedProject] = {}
         for p in projects:
             if p.gitlab_project_id in self._by_project_id:
@@ -88,4 +98,59 @@ class ProjectRegistry:
             )
         registry = cls(projects)
         await log.ainfo("project_registry_loaded", count=len(projects))
+        return registry
+
+    @classmethod
+    async def from_config(
+        cls,
+        config: ConfigFile,
+        credentials: CredentialRegistry,
+        gitlab_url: str,
+    ) -> ProjectRegistry:
+        """Build registry from v2 config file.
+
+        Args:
+            config: Validated v2 config file.
+            credentials: Credential registry for token resolution.
+            gitlab_url: Base GitLab URL for clone URL construction.
+
+        Returns:
+            Populated ProjectRegistry keyed by GitLab project ID.
+        """
+        projects: list[ResolvedProject] = []
+        base_url = gitlab_url.rstrip("/")
+        for proj_config in config.projects:
+            resolved = config.resolve_project(proj_config)
+            cred_ref = str(resolved["credential_ref"])
+            token = credentials.resolve(cred_ref)
+            client = GitLabClient(gitlab_url, token)
+            pid = await client.resolve_project(proj_config.repo)
+
+            # Find Jira integration if any
+            jira_project: str | None = None
+            raw_integrations = resolved["integrations"]
+            if isinstance(raw_integrations, list):
+                from gitlab_copilot_agent.config_v2 import JiraIntegrationConfig
+
+                for item in raw_integrations:  # type: ignore[reportUnknownVariableType]
+                    if isinstance(item, JiraIntegrationConfig):
+                        jira_project = item.project_key
+                        break
+
+            resolution = str(resolved["resolution_behavior"])
+
+            projects.append(
+                ResolvedProject(
+                    jira_project=jira_project,
+                    repo=proj_config.repo,
+                    gitlab_project_id=pid,
+                    clone_url=f"{base_url}/{proj_config.repo}.git",
+                    target_branch=str(resolved["target_branch"]),
+                    credential_ref=cred_ref,
+                    token=token,
+                    resolution_behavior=str(resolution),  # type: ignore[arg-type]
+                )
+            )
+        registry = cls(projects)
+        await log.ainfo("project_registry_loaded", count=len(projects), source="config_v2")
         return registry

--- a/src/gitlab_copilot_agent/webhook.py
+++ b/src/gitlab_copilot_agent/webhook.py
@@ -8,7 +8,7 @@ import re
 import structlog
 from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, Request
 
-from gitlab_copilot_agent.container import get_services
+from gitlab_copilot_agent.app_context import get_services
 from gitlab_copilot_agent.discussion_models import AgentIdentity
 from gitlab_copilot_agent.discussion_orchestrator import handle_discussion_interaction
 from gitlab_copilot_agent.gitlab_client import GitLabClient

--- a/src/gitlab_copilot_agent/webhook.py
+++ b/src/gitlab_copilot_agent/webhook.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import hmac
 import re
-from typing import TYPE_CHECKING
 
 import structlog
 from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, Request
 
-from gitlab_copilot_agent.concurrency import ReviewedMRTracker
+from gitlab_copilot_agent.container import get_services
 from gitlab_copilot_agent.discussion_models import AgentIdentity
 from gitlab_copilot_agent.discussion_orchestrator import handle_discussion_interaction
 from gitlab_copilot_agent.gitlab_client import GitLabClient
@@ -17,9 +16,6 @@ from gitlab_copilot_agent.metrics import webhook_errors_total, webhook_received_
 from gitlab_copilot_agent.models import MergeRequestWebhookPayload, NoteWebhookPayload
 from gitlab_copilot_agent.orchestrator import handle_review
 from gitlab_copilot_agent.project_registry import ProjectRegistry
-
-if TYPE_CHECKING:
-    from gitlab_copilot_agent.credential_registry import CredentialRegistry
 
 log = structlog.get_logger()
 
@@ -57,17 +53,16 @@ def _validate_webhook_token(received: str | None, expected: str | None) -> None:
 
 async def _process_review(request: Request, payload: MergeRequestWebhookPayload) -> None:
     """Run review in background task; marks head SHA as reviewed on success."""
-    settings = request.app.state.settings
-    executor = request.app.state.executor
-    review_tracker: ReviewedMRTracker = request.app.state.review_tracker
+    svc = get_services(request)
+    settings = svc.settings
+    executor = svc.executor
+    review_tracker = svc.review_tracker
+    credential_registry = svc.credential_registry
     registry: ProjectRegistry | None = getattr(request.app.state, "project_registry", None)
     mr = payload.object_attributes
     project_id = payload.project.id
     head_sha = mr.last_commit.id
     project_token = _resolve_project_token(project_id, registry, settings.gitlab_token)
-    credential_registry: CredentialRegistry | None = getattr(
-        request.app.state, "credential_registry", None
-    )
     resolution_behavior = settings.resolution_behavior
     credential_ref = "default"
     if registry is not None:
@@ -90,10 +85,8 @@ async def _process_review(request: Request, payload: MergeRequestWebhookPayload)
         )
         review_tracker.mark(project_id, mr.iid, head_sha)
         # Also mark in shared dedup store so the poller won't re-review
-        dedup_store = getattr(request.app.state, "dedup_store", None)
-        if dedup_store is not None:
-            review_key = f"review:{project_id}:{mr.iid}:{head_sha}"
-            await dedup_store.mark_seen(review_key, ttl_seconds=86400)
+        review_key = f"review:{project_id}:{mr.iid}:{head_sha}"
+        await svc.dedup_store.mark_seen(review_key, ttl_seconds=86400)
         bound.info("background_review_completed")
     except Exception:
         webhook_errors_total.add(1, {"handler": "review"})
@@ -121,7 +114,8 @@ async def _is_agent_directed(
     # fetch the discussion and check if the agent has a prior note in it
     discussion_id = payload.object_attributes.discussion_id
     if discussion_id and payload.merge_request:
-        settings = request.app.state.settings
+        svc = get_services(request)
+        settings = svc.settings
         registry: ProjectRegistry | None = getattr(request.app.state, "project_registry", None)
         token = _resolve_project_token(payload.project.id, registry, settings.gitlab_token)
         try:
@@ -148,9 +142,10 @@ async def _process_discussion(
     note_key: str = "",
 ) -> None:
     """Process a discussion interaction in the background."""
-    settings = request.app.state.settings
-    executor = request.app.state.executor
-    repo_locks = request.app.state.repo_locks
+    svc = get_services(request)
+    settings = svc.settings
+    executor = svc.executor
+    repo_locks = svc.repo_locks
     registry: ProjectRegistry | None = getattr(request.app.state, "project_registry", None)
     project_token = _resolve_project_token(payload.project.id, registry, settings.gitlab_token)
 
@@ -183,9 +178,7 @@ async def _process_discussion(
         bound.exception("background_discussion_failed")
     finally:
         if note_key:
-            dedup_store = getattr(request.app.state, "dedup_store", None)
-            if dedup_store is not None:
-                await dedup_store.mark_seen(note_key, ttl_seconds=86400)
+            await svc.dedup_store.mark_seen(note_key, ttl_seconds=86400)
 
 
 @router.post("/webhook", status_code=200)
@@ -194,17 +187,18 @@ async def webhook(
     background_tasks: BackgroundTasks,
     x_gitlab_token: str | None = Header(default=None),
 ) -> dict[str, str]:
-    settings = request.app.state.settings
+    """Handle GitLab webhook events (MR and note)."""
+    svc = get_services(request)
+    settings = svc.settings
 
     _validate_webhook_token(x_gitlab_token, settings.gitlab_webhook_secret)
 
     body = await request.json()
 
     # Project allowlist check
-    allowed = request.app.state.allowed_project_ids
-    if allowed is not None:
+    if svc.allowed_project_ids is not None:
         project_id = body.get("project", {}).get("id")
-        if project_id not in allowed:
+        if project_id not in svc.allowed_project_ids:
             return {"status": "ignored", "reason": "project not in allowlist"}
 
     object_kind = body.get("object_kind")
@@ -224,7 +218,7 @@ async def webhook(
             return {"status": "ignored", "reason": "no new commits"}
 
         # Deduplicate by (project_id, mr_iid, head_sha)
-        review_tracker: ReviewedMRTracker = request.app.state.review_tracker
+        review_tracker = svc.review_tracker
         head_sha = mr.last_commit.id
         if review_tracker.is_reviewed(payload.project.id, mr.iid, head_sha):
             await log.ainfo(
@@ -245,11 +239,7 @@ async def webhook(
             return {"status": "ignored", "reason": "not an MR note"}
 
         # Self-comment detection via agent identity (per-project credential)
-        credential_registry: CredentialRegistry | None = getattr(
-            request.app.state, "credential_registry", None
-        )
-        if credential_registry is None:
-            return {"status": "ignored", "reason": "no credential registry"}
+        credential_registry = svc.credential_registry
 
         # Resolve the credential_ref for this project (not always "default")
         registry: ProjectRegistry | None = getattr(request.app.state, "project_registry", None)
@@ -275,11 +265,10 @@ async def webhook(
             return {"status": "ignored", "reason": "not directed at agent"}
 
         # Deduplicate — prevents reprocessing on duplicate webhook deliveries
-        dedup_store = getattr(request.app.state, "dedup_store", None)
         note_id = note_payload.object_attributes.id
         mr_iid = note_payload.merge_request.iid if note_payload.merge_request else 0
         note_key = f"note:{note_payload.project.id}:{mr_iid}:{note_id}"
-        if dedup_store is not None and await dedup_store.is_seen(note_key):
+        if await svc.dedup_store.is_seen(note_key):
             return {"status": "skipped", "reason": "already processed"}
 
         background_tasks.add_task(

--- a/src/gitlab_copilot_agent/webhook.py
+++ b/src/gitlab_copilot_agent/webhook.py
@@ -58,7 +58,7 @@ async def _process_review(request: Request, payload: MergeRequestWebhookPayload)
     executor = svc.executor
     review_tracker = svc.review_tracker
     credential_registry = svc.credential_registry
-    registry: ProjectRegistry | None = getattr(request.app.state, "project_registry", None)
+    registry: ProjectRegistry | None = request.app.state.project_registry
     mr = payload.object_attributes
     project_id = payload.project.id
     head_sha = mr.last_commit.id
@@ -116,7 +116,7 @@ async def _is_agent_directed(
     if discussion_id and payload.merge_request:
         svc = get_services(request)
         settings = svc.settings
-        registry: ProjectRegistry | None = getattr(request.app.state, "project_registry", None)
+        registry: ProjectRegistry | None = request.app.state.project_registry
         token = _resolve_project_token(payload.project.id, registry, settings.gitlab_token)
         try:
             gl_client = GitLabClient(settings.gitlab_url, token)
@@ -146,7 +146,7 @@ async def _process_discussion(
     settings = svc.settings
     executor = svc.executor
     repo_locks = svc.repo_locks
-    registry: ProjectRegistry | None = getattr(request.app.state, "project_registry", None)
+    registry: ProjectRegistry | None = request.app.state.project_registry
     project_token = _resolve_project_token(payload.project.id, registry, settings.gitlab_token)
 
     # Resolve resolution behavior from project registry or global settings
@@ -242,7 +242,7 @@ async def webhook(
         credential_registry = svc.credential_registry
 
         # Resolve the credential_ref for this project (not always "default")
-        registry: ProjectRegistry | None = getattr(request.app.state, "project_registry", None)
+        registry: ProjectRegistry | None = request.app.state.project_registry
         credential_ref = "default"
         if registry is not None:
             resolved = registry.get_by_project_id(note_payload.project.id)

--- a/src/gitlab_copilot_agent/webhook.py
+++ b/src/gitlab_copilot_agent/webhook.py
@@ -8,7 +8,7 @@ import re
 import structlog
 from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, Request
 
-from gitlab_copilot_agent.app_context import get_services
+from gitlab_copilot_agent.app_context import get_app_context
 from gitlab_copilot_agent.discussion_models import AgentIdentity
 from gitlab_copilot_agent.discussion_orchestrator import handle_discussion_interaction
 from gitlab_copilot_agent.gitlab_client import GitLabClient
@@ -53,11 +53,11 @@ def _validate_webhook_token(received: str | None, expected: str | None) -> None:
 
 async def _process_review(request: Request, payload: MergeRequestWebhookPayload) -> None:
     """Run review in background task; marks head SHA as reviewed on success."""
-    svc = get_services(request)
-    settings = svc.settings
-    executor = svc.executor
-    review_tracker = svc.review_tracker
-    credential_registry = svc.credential_registry
+    app_context = get_app_context(request)
+    settings = app_context.settings
+    executor = app_context.executor
+    review_tracker = app_context.review_tracker
+    credential_registry = app_context.credential_registry
     registry: ProjectRegistry | None = request.app.state.project_registry
     mr = payload.object_attributes
     project_id = payload.project.id
@@ -86,7 +86,7 @@ async def _process_review(request: Request, payload: MergeRequestWebhookPayload)
         review_tracker.mark(project_id, mr.iid, head_sha)
         # Also mark in shared dedup store so the poller won't re-review
         review_key = f"review:{project_id}:{mr.iid}:{head_sha}"
-        await svc.dedup_store.mark_seen(review_key, ttl_seconds=86400)
+        await app_context.dedup_store.mark_seen(review_key, ttl_seconds=86400)
         bound.info("background_review_completed")
     except Exception:
         webhook_errors_total.add(1, {"handler": "review"})
@@ -114,8 +114,8 @@ async def _is_agent_directed(
     # fetch the discussion and check if the agent has a prior note in it
     discussion_id = payload.object_attributes.discussion_id
     if discussion_id and payload.merge_request:
-        svc = get_services(request)
-        settings = svc.settings
+        app_context = get_app_context(request)
+        settings = app_context.settings
         registry: ProjectRegistry | None = request.app.state.project_registry
         token = _resolve_project_token(payload.project.id, registry, settings.gitlab_token)
         try:
@@ -142,10 +142,10 @@ async def _process_discussion(
     note_key: str = "",
 ) -> None:
     """Process a discussion interaction in the background."""
-    svc = get_services(request)
-    settings = svc.settings
-    executor = svc.executor
-    repo_locks = svc.repo_locks
+    app_context = get_app_context(request)
+    settings = app_context.settings
+    executor = app_context.executor
+    repo_locks = app_context.repo_locks
     registry: ProjectRegistry | None = request.app.state.project_registry
     project_token = _resolve_project_token(payload.project.id, registry, settings.gitlab_token)
 
@@ -178,7 +178,7 @@ async def _process_discussion(
         bound.exception("background_discussion_failed")
     finally:
         if note_key:
-            await svc.dedup_store.mark_seen(note_key, ttl_seconds=86400)
+            await app_context.dedup_store.mark_seen(note_key, ttl_seconds=86400)
 
 
 @router.post("/webhook", status_code=200)
@@ -188,17 +188,17 @@ async def webhook(
     x_gitlab_token: str | None = Header(default=None),
 ) -> dict[str, str]:
     """Handle GitLab webhook events (MR and note)."""
-    svc = get_services(request)
-    settings = svc.settings
+    app_context = get_app_context(request)
+    settings = app_context.settings
 
     _validate_webhook_token(x_gitlab_token, settings.gitlab_webhook_secret)
 
     body = await request.json()
 
     # Project allowlist check
-    if svc.allowed_project_ids is not None:
+    if app_context.allowed_project_ids is not None:
         project_id = body.get("project", {}).get("id")
-        if project_id not in svc.allowed_project_ids:
+        if project_id not in app_context.allowed_project_ids:
             return {"status": "ignored", "reason": "project not in allowlist"}
 
     object_kind = body.get("object_kind")
@@ -218,7 +218,7 @@ async def webhook(
             return {"status": "ignored", "reason": "no new commits"}
 
         # Deduplicate by (project_id, mr_iid, head_sha)
-        review_tracker = svc.review_tracker
+        review_tracker = app_context.review_tracker
         head_sha = mr.last_commit.id
         if review_tracker.is_reviewed(payload.project.id, mr.iid, head_sha):
             await log.ainfo(
@@ -239,7 +239,7 @@ async def webhook(
             return {"status": "ignored", "reason": "not an MR note"}
 
         # Self-comment detection via agent identity (per-project credential)
-        credential_registry = svc.credential_registry
+        credential_registry = app_context.credential_registry
 
         # Resolve the credential_ref for this project (not always "default")
         registry: ProjectRegistry | None = request.app.state.project_registry
@@ -268,7 +268,7 @@ async def webhook(
         note_id = note_payload.object_attributes.id
         mr_iid = note_payload.merge_request.iid if note_payload.merge_request else 0
         note_key = f"note:{note_payload.project.id}:{mr_iid}:{note_id}"
-        if await svc.dedup_store.is_seen(note_key):
+        if await app_context.dedup_store.is_seen(note_key):
             return {"status": "skipped", "reason": "already processed"}
 
         background_tasks.add_task(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,7 +174,7 @@ def env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
 async def client(env_vars: None) -> AsyncIterator[AsyncClient]:
     """AsyncClient wired to the FastAPI app with test settings."""
     ctx = make_app_context()
-    app.state.ctx = ctx
+    app.state.app_context = ctx
     app.state.project_registry = None
     app.state.jira_poller = None
     app.state.gl_poller = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,8 @@ from typing import Any
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from gitlab_copilot_agent.app_context import AppContext
 from gitlab_copilot_agent.config import Settings
-from gitlab_copilot_agent.container import AppContext
 from gitlab_copilot_agent.gitlab_client import MRChange, MRDiffRef
 from gitlab_copilot_agent.main import app
 from gitlab_copilot_agent.models import (
@@ -107,7 +107,7 @@ def make_settings(**overrides: Any) -> Settings:
     return Settings(**(defaults | overrides))
 
 
-def make_container(**overrides: Any) -> AppContext:
+def make_app_context(**overrides: Any) -> AppContext:
     """Create an AppContext with test defaults. Override any field."""
     from gitlab_copilot_agent.concurrency import MemoryDedup, RepoLockManager, ReviewedMRTracker
     from gitlab_copilot_agent.credential_registry import CredentialRegistry
@@ -173,8 +173,8 @@ def env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture
 async def client(env_vars: None) -> AsyncIterator[AsyncClient]:
     """AsyncClient wired to the FastAPI app with test settings."""
-    container = make_container()
-    app.state.container = container
+    ctx = make_app_context()
+    app.state.ctx = ctx
     app.state.project_registry = None
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from gitlab_copilot_agent.config import Settings
+from gitlab_copilot_agent.container import AppContext
 from gitlab_copilot_agent.gitlab_client import MRChange, MRDiffRef
 from gitlab_copilot_agent.main import app
 from gitlab_copilot_agent.models import (
@@ -106,6 +107,23 @@ def make_settings(**overrides: Any) -> Settings:
     return Settings(**(defaults | overrides))
 
 
+def make_container(**overrides: Any) -> AppContext:
+    """Create an AppContext with test defaults. Override any field."""
+    from gitlab_copilot_agent.concurrency import MemoryDedup, RepoLockManager, ReviewedMRTracker
+    from gitlab_copilot_agent.credential_registry import CredentialRegistry
+
+    settings = overrides.pop("settings", None) or make_settings()
+    defaults: dict[str, Any] = {
+        "settings": settings,
+        "executor": LocalTaskExecutor(),
+        "repo_locks": RepoLockManager(),
+        "dedup_store": MemoryDedup(),
+        "review_tracker": ReviewedMRTracker(),
+        "credential_registry": CredentialRegistry(default_token=GITLAB_TOKEN),
+    }
+    return AppContext(**(defaults | overrides))
+
+
 def make_mr_payload(**attr_overrides: Any) -> dict[str, Any]:
     """Create an MR webhook payload. Override object_attributes fields."""
     payload: dict[str, Any] = {**MR_PAYLOAD}
@@ -155,14 +173,8 @@ def env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture
 async def client(env_vars: None) -> AsyncIterator[AsyncClient]:
     """AsyncClient wired to the FastAPI app with test settings."""
-    from gitlab_copilot_agent.concurrency import MemoryDedup, RepoLockManager, ReviewedMRTracker
-
-    app.state.settings = make_settings()
-    app.state.executor = LocalTaskExecutor()
-    app.state.repo_locks = RepoLockManager()
-    app.state.dedup_store = MemoryDedup()
-    app.state.review_tracker = ReviewedMRTracker()
-    app.state.allowed_project_ids = None
+    container = make_container()
+    app.state.container = container
     app.state.project_registry = None
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,6 +176,8 @@ async def client(env_vars: None) -> AsyncIterator[AsyncClient]:
     ctx = make_app_context()
     app.state.ctx = ctx
     app.state.project_registry = None
+    app.state.jira_poller = None
+    app.state.gl_poller = None
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         yield c

--- a/tests/test_app_context.py
+++ b/tests/test_app_context.py
@@ -1,4 +1,4 @@
-"""Tests for app_context — AppContext dataclass and get_services dependency."""
+"""Tests for app_context — AppContext dataclass and get_app_context dependency."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ import pytest
 from fastapi import FastAPI, Request
 from starlette.datastructures import State
 
-from gitlab_copilot_agent.app_context import AppContext, get_services
+from gitlab_copilot_agent.app_context import AppContext, get_app_context
 
 
 def _make_context(**overrides: object) -> AppContext:
@@ -51,13 +51,13 @@ class TestGetServices:
     def test_returns_ctx(self) -> None:
         app = FastAPI()
         ctx = _make_context()
-        app.state.ctx = ctx
+        app.state.app_context = ctx
         request = _make_request(app)
-        assert get_services(request) is ctx
+        assert get_app_context(request) is ctx
 
     def test_raises_when_no_ctx(self) -> None:
         app = FastAPI()
         app.state = State()
         request = _make_request(app)
         with pytest.raises(RuntimeError, match="AppContext not initialized"):
-            get_services(request)
+            get_app_context(request)

--- a/tests/test_app_context.py
+++ b/tests/test_app_context.py
@@ -1,4 +1,4 @@
-"""Tests for container — AppContext dataclass and get_services dependency."""
+"""Tests for app_context — AppContext dataclass and get_services dependency."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ import pytest
 from fastapi import FastAPI, Request
 from starlette.datastructures import State
 
-from gitlab_copilot_agent.container import AppContext, get_services
+from gitlab_copilot_agent.app_context import AppContext, get_services
 
 
 def _make_context(**overrides: object) -> AppContext:
@@ -48,14 +48,14 @@ class TestAppContext:
 
 
 class TestGetServices:
-    def test_returns_container(self) -> None:
+    def test_returns_ctx(self) -> None:
         app = FastAPI()
         ctx = _make_context()
-        app.state.container = ctx
+        app.state.ctx = ctx
         request = _make_request(app)
         assert get_services(request) is ctx
 
-    def test_raises_when_no_container(self) -> None:
+    def test_raises_when_no_ctx(self) -> None:
         app = FastAPI()
         app.state = State()
         request = _make_request(app)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -184,8 +184,9 @@ class TestPrintConfigErrors:
             _print_config_errors(exc)
 
         err = capsys.readouterr().err
+        # pydantic-settings reports the first missing required field;
+        # gitlab_token is caught later by _check_auth model validator
         assert "GITLAB_URL" in err
-        assert "GITLAB_TOKEN" in err
         assert "configuration-reference.md" in err
 
     def test_value_error_shown_as_message(self, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_config_v2.py
+++ b/tests/test_config_v2.py
@@ -1,0 +1,372 @@
+"""Tests for config_v2 — GitLab-centric v2 configuration models."""
+
+from __future__ import annotations
+
+import textwrap
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from gitlab_copilot_agent.config_v2 import (
+    ConfigDefaults,
+    ConfigFile,
+    CopilotConfig,
+    DispatchConfig,
+    GitLabConfig,
+    JiraIntegrationConfig,
+    PollConfig,
+    ProjectConfig,
+    ServerConfig,
+    load_config_file,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# -- Constants --
+
+GITLAB_URL = "https://gitlab.example.com"
+
+MINIMAL_CONFIG: dict[str, Any] = {
+    "version": 2,
+    "gitlab": {"url": GITLAB_URL},
+}
+
+FULL_CONFIG_YAML = textwrap.dedent("""\
+    version: 2
+
+    gitlab:
+      url: https://gitlab.example.com
+
+    dispatch:
+      backend: aca
+      aca_subscription_id: sub-123
+      aca_resource_group: rg-test
+      aca_job_name: copilot-task
+      aca_job_timeout: 900
+
+    copilot:
+      model: gpt-4o
+      plugins:
+        - "@some/plugin"
+      marketplaces:
+        - https://private.marketplace.example.com
+
+    server:
+      log_level: debug
+      shutdown_timeout: 60
+      webhook_ip_allowlist:
+        - "34.74.90.64/28"
+      trusted_proxies:
+        - "10.0.0.0/8"
+
+    prompts:
+      system: "You are a helpful assistant."
+      review_suffix: "Be concise."
+
+    defaults:
+      target_branch: develop
+      credential_ref: platform
+      resolution_behavior: auto-resolve
+      webhook: false
+      poll:
+        enabled: true
+        interval: 45
+        lookback_minutes: 120
+        review_on_push: false
+
+    projects:
+      - repo: group/service-a
+        credential_ref: default
+        integrations:
+          - my-jira
+        copilot:
+          model: gpt-4o
+          plugins:
+            - "@some/plugin"
+          marketplaces:
+            - https://private.marketplace.example.com
+
+      - repo: group/internal-tool
+        credential_ref: platform
+        webhook: true
+        poll:
+          enabled: false
+
+    integrations:
+      - name: my-jira
+        type: jira
+        project_key: PROJ
+        trigger_status: "AI Ready"
+        in_progress_status: "In Progress"
+        in_review_status: "In Review"
+""")
+
+
+def _full_config_dict() -> dict[str, Any]:
+    """Return the full config as a parsed dict."""
+    return yaml.safe_load(FULL_CONFIG_YAML)
+
+
+# -- Model unit tests --
+
+
+class TestGitLabConfig:
+    def test_requires_url(self) -> None:
+        with pytest.raises(ValidationError):
+            GitLabConfig.model_validate({})
+
+    def test_valid(self) -> None:
+        cfg = GitLabConfig(url=GITLAB_URL)
+        assert cfg.url == GITLAB_URL
+
+
+class TestDispatchConfig:
+    def test_defaults(self) -> None:
+        cfg = DispatchConfig()
+        assert cfg.backend == "local"
+        assert cfg.k8s_namespace == "default"
+        assert cfg.aca_job_timeout == 600
+
+    def test_backend_validation(self) -> None:
+        with pytest.raises(ValidationError):
+            DispatchConfig.model_validate({"backend": "invalid"})
+
+
+class TestCopilotConfig:
+    def test_defaults(self) -> None:
+        cfg = CopilotConfig()
+        assert cfg.model == "gpt-4"
+        assert cfg.plugins == []
+        assert cfg.marketplaces == []
+
+
+class TestServerConfig:
+    def test_defaults(self) -> None:
+        cfg = ServerConfig()
+        assert cfg.log_level == "info"
+        assert cfg.clone_dir is None
+        assert cfg.shutdown_timeout == 30
+        assert cfg.webhook_ip_allowlist == []
+        assert cfg.trusted_proxies == []
+
+    def test_shutdown_timeout_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            ServerConfig(shutdown_timeout=0)
+
+
+class TestPollConfig:
+    def test_defaults(self) -> None:
+        cfg = PollConfig()
+        assert cfg.enabled is False
+        assert cfg.interval == 30
+        assert cfg.lookback_minutes == 60
+        assert cfg.review_on_push is True
+
+
+class TestConfigDefaults:
+    def test_defaults(self) -> None:
+        cfg = ConfigDefaults()
+        assert cfg.target_branch == "main"
+        assert cfg.credential_ref == "default"
+        assert cfg.resolution_behavior == "suggest"
+        assert cfg.webhook is True
+        assert cfg.poll.enabled is False
+
+
+class TestProjectConfig:
+    def test_minimal(self) -> None:
+        proj = ProjectConfig(repo="group/project")
+        assert proj.repo == "group/project"
+        assert proj.credential_ref is None
+        assert proj.integrations == []
+
+    def test_all_fields(self) -> None:
+        proj = ProjectConfig(
+            repo="group/project",
+            credential_ref="custom",
+            target_branch="develop",
+            resolution_behavior="auto-resolve",
+            webhook=False,
+            poll=PollConfig(enabled=True, interval=60),
+            copilot=CopilotConfig(model="gpt-4o"),
+            integrations=["my-jira"],
+        )
+        assert proj.credential_ref == "custom"
+        assert proj.poll is not None
+        assert proj.poll.interval == 60
+
+
+class TestJiraIntegrationConfig:
+    def test_valid(self) -> None:
+        cfg = JiraIntegrationConfig(
+            name="my-jira",
+            type="jira",
+            project_key="PROJ",
+        )
+        assert cfg.trigger_status == "AI Ready"
+
+    def test_requires_name_and_key(self) -> None:
+        with pytest.raises(ValidationError):
+            JiraIntegrationConfig.model_validate({"type": "jira"})
+
+
+# -- ConfigFile tests --
+
+
+class TestConfigFile:
+    def test_minimal_config(self) -> None:
+        cfg = ConfigFile.model_validate(MINIMAL_CONFIG)
+        assert cfg.version == 2
+        assert cfg.gitlab.url == GITLAB_URL
+        assert cfg.dispatch.backend == "local"
+        assert cfg.projects == []
+
+    def test_full_config_yaml(self) -> None:
+        cfg = ConfigFile.model_validate(_full_config_dict())
+        assert cfg.version == 2
+        assert len(cfg.projects) == 2
+        assert len(cfg.integrations) == 1
+        assert cfg.dispatch.backend == "aca"
+        assert cfg.copilot.model == "gpt-4o"
+        assert cfg.defaults.target_branch == "develop"
+
+    def test_rejects_unknown_integration_ref(self) -> None:
+        data = {
+            **MINIMAL_CONFIG,
+            "projects": [{"repo": "g/p", "integrations": ["nonexistent"]}],
+        }
+        with pytest.raises(ValueError, match="unknown integration 'nonexistent'"):
+            ConfigFile.model_validate(data)
+
+    def test_rejects_duplicate_repos(self) -> None:
+        data = {
+            **MINIMAL_CONFIG,
+            "projects": [{"repo": "g/p"}, {"repo": "g/p"}],
+        }
+        with pytest.raises(ValueError, match="Duplicate project repo"):
+            ConfigFile.model_validate(data)
+
+    def test_rejects_wrong_version(self) -> None:
+        with pytest.raises(ValidationError):
+            ConfigFile.model_validate({"version": 1, "gitlab": {"url": GITLAB_URL}})
+
+    def test_json_schema_generation(self) -> None:
+        schema = ConfigFile.model_json_schema()
+        assert schema["title"] == "ConfigFile"
+        assert "properties" in schema
+        assert "version" in schema["properties"]
+
+    def test_get_integration(self) -> None:
+        cfg = ConfigFile.model_validate(_full_config_dict())
+        jira = cfg.get_integration("my-jira")
+        assert jira is not None
+        assert jira.project_key == "PROJ"
+
+    def test_get_integration_missing(self) -> None:
+        cfg = ConfigFile.model_validate(MINIMAL_CONFIG)
+        assert cfg.get_integration("nonexistent") is None
+
+
+class TestResolveProject:
+    def test_applies_defaults_for_omitted_fields(self) -> None:
+        cfg = ConfigFile.model_validate(
+            {
+                **MINIMAL_CONFIG,
+                "defaults": {"target_branch": "develop", "credential_ref": "team"},
+                "projects": [{"repo": "g/p"}],
+            }
+        )
+        resolved = cfg.resolve_project(cfg.projects[0])
+        assert resolved["credential_ref"] == "team"
+        assert resolved["target_branch"] == "develop"
+        assert resolved["resolution_behavior"] == "suggest"
+        assert resolved["webhook"] is True
+
+    def test_project_overrides_defaults(self) -> None:
+        cfg = ConfigFile.model_validate(
+            {
+                **MINIMAL_CONFIG,
+                "projects": [
+                    {
+                        "repo": "g/p",
+                        "credential_ref": "custom",
+                        "target_branch": "release",
+                        "resolution_behavior": "auto-resolve",
+                        "webhook": False,
+                    }
+                ],
+            }
+        )
+        resolved = cfg.resolve_project(cfg.projects[0])
+        assert resolved["credential_ref"] == "custom"
+        assert resolved["target_branch"] == "release"
+        assert resolved["resolution_behavior"] == "auto-resolve"
+        assert resolved["webhook"] is False
+
+    def test_resolves_integrations(self) -> None:
+        cfg = ConfigFile.model_validate(_full_config_dict())
+        proj = cfg.projects[0]
+        resolved = cfg.resolve_project(proj)
+        integrations = resolved["integrations"]
+        assert len(integrations) == 1
+        assert integrations[0].project_key == "PROJ"
+
+    def test_copilot_override(self) -> None:
+        cfg = ConfigFile.model_validate(_full_config_dict())
+        # project 0 has copilot override
+        resolved = cfg.resolve_project(cfg.projects[0])
+        assert resolved["copilot"].model == "gpt-4o"
+        # project 1 falls back to global
+        resolved2 = cfg.resolve_project(cfg.projects[1])
+        assert resolved2["copilot"].model == "gpt-4o"  # global copilot
+
+
+# -- load_config_file tests --
+
+
+class TestLoadConfigFile:
+    def test_loads_valid_yaml(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(yaml.dump(MINIMAL_CONFIG))
+        cfg = load_config_file(config_file)
+        assert cfg.version == 2
+        assert cfg.gitlab.url == GITLAB_URL
+
+    def test_loads_full_yaml(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(FULL_CONFIG_YAML)
+        cfg = load_config_file(config_file)
+        assert len(cfg.projects) == 2
+
+    def test_file_not_found(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_config_file(tmp_path / "nonexistent.yaml")
+
+    def test_invalid_yaml_content(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("just a string")
+        with pytest.raises(ValueError, match="expected a YAML mapping"):
+            load_config_file(config_file)
+
+    def test_reads_config_file_env_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_file = tmp_path / "custom.yaml"
+        config_file.write_text(yaml.dump(MINIMAL_CONFIG))
+        monkeypatch.setenv("CONFIG_FILE", str(config_file))
+        cfg = load_config_file()
+        assert cfg.gitlab.url == GITLAB_URL
+
+    def test_audit_logs_marketplace_urls(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(FULL_CONFIG_YAML)
+        load_config_file(config_file)
+        captured = capsys.readouterr().out
+        assert "marketplace_urls_configured" in captured
+        assert "scope=global" in captured
+        assert "scope=project" in captured

--- a/tests/test_config_v2.py
+++ b/tests/test_config_v2.py
@@ -110,107 +110,69 @@ def _full_config_dict() -> dict[str, Any]:
     return yaml.safe_load(FULL_CONFIG_YAML)
 
 
-# -- Model unit tests --
+# -- Sub-model tests (parameterized) --
 
 
-class TestGitLabConfig:
-    def test_requires_url(self) -> None:
-        with pytest.raises(ValidationError):
-            GitLabConfig.model_validate({})
-
-    def test_valid(self) -> None:
-        cfg = GitLabConfig(url=GITLAB_URL)
-        assert cfg.url == GITLAB_URL
-
-
-class TestDispatchConfig:
-    def test_defaults(self) -> None:
-        cfg = DispatchConfig()
-        assert cfg.backend == "local"
-        assert cfg.k8s_namespace == "default"
-        assert cfg.aca_job_timeout == 600
-
-    def test_backend_validation(self) -> None:
-        with pytest.raises(ValidationError):
-            DispatchConfig.model_validate({"backend": "invalid"})
-
-
-class TestCopilotConfig:
-    def test_defaults(self) -> None:
-        cfg = CopilotConfig()
-        assert cfg.model == "gpt-4"
-        assert cfg.plugins == []
-        assert cfg.marketplaces == []
-
-
-class TestServerConfig:
-    def test_defaults(self) -> None:
-        cfg = ServerConfig()
-        assert cfg.log_level == "info"
-        assert cfg.clone_dir is None
-        assert cfg.shutdown_timeout == 30
-        assert cfg.webhook_ip_allowlist == []
-        assert cfg.trusted_proxies == []
-
-    def test_shutdown_timeout_must_be_positive(self) -> None:
-        with pytest.raises(ValidationError):
-            ServerConfig(shutdown_timeout=0)
+@pytest.mark.parametrize(
+    ("model_cls", "field", "expected"),
+    [
+        (DispatchConfig, "backend", "local"),
+        (DispatchConfig, "k8s_namespace", "default"),
+        (DispatchConfig, "aca_job_timeout", 600),
+        (CopilotConfig, "model", "gpt-4"),
+        (CopilotConfig, "plugins", []),
+        (CopilotConfig, "marketplaces", []),
+        (ServerConfig, "log_level", "info"),
+        (ServerConfig, "clone_dir", None),
+        (ServerConfig, "shutdown_timeout", 30),
+        (ServerConfig, "webhook_ip_allowlist", []),
+        (ServerConfig, "trusted_proxies", []),
+        (PollConfig, "enabled", False),
+        (PollConfig, "interval", 30),
+        (PollConfig, "lookback_minutes", 60),
+        (PollConfig, "review_on_push", True),
+        (ConfigDefaults, "target_branch", "main"),
+        (ConfigDefaults, "credential_ref", "default"),
+        (ConfigDefaults, "resolution_behavior", "suggest"),
+        (ConfigDefaults, "webhook", True),
+    ],
+)
+def test_model_defaults(model_cls: type[Any], field: str, expected: object) -> None:
+    """Each sub-model field has the documented default value."""
+    instance = model_cls()
+    assert getattr(instance, field) == expected
 
 
-class TestPollConfig:
-    def test_defaults(self) -> None:
-        cfg = PollConfig()
-        assert cfg.enabled is False
-        assert cfg.interval == 30
-        assert cfg.lookback_minutes == 60
-        assert cfg.review_on_push is True
+@pytest.mark.parametrize(
+    ("model_cls", "data", "match"),
+    [
+        (GitLabConfig, {}, "url"),
+        (DispatchConfig, {"backend": "invalid"}, "backend"),
+        (ServerConfig, {"shutdown_timeout": 0}, "shutdown_timeout"),
+        (JiraIntegrationConfig, {"type": "jira"}, "name"),
+    ],
+    ids=["gitlab-missing-url", "dispatch-bad-backend", "server-zero-timeout", "jira-missing-name"],
+)
+def test_model_rejects_invalid(model_cls: type[Any], data: dict[str, Any], match: str) -> None:
+    """Models reject invalid or missing required fields."""
+    with pytest.raises(ValidationError, match=match):
+        model_cls.model_validate(data)
 
 
-class TestConfigDefaults:
-    def test_defaults(self) -> None:
-        cfg = ConfigDefaults()
-        assert cfg.target_branch == "main"
-        assert cfg.credential_ref == "default"
-        assert cfg.resolution_behavior == "suggest"
-        assert cfg.webhook is True
-        assert cfg.poll.enabled is False
+def test_project_config_minimal() -> None:
+    """ProjectConfig only requires repo; everything else falls back to defaults."""
+    proj = ProjectConfig(repo="group/project")
+    assert proj.repo == "group/project"
+    assert proj.credential_ref is None
+    assert proj.integrations == []
 
 
-class TestProjectConfig:
-    def test_minimal(self) -> None:
-        proj = ProjectConfig(repo="group/project")
-        assert proj.repo == "group/project"
-        assert proj.credential_ref is None
-        assert proj.integrations == []
-
-    def test_all_fields(self) -> None:
-        proj = ProjectConfig(
-            repo="group/project",
-            credential_ref="custom",
-            target_branch="develop",
-            resolution_behavior="auto-resolve",
-            webhook=False,
-            poll=PollConfig(enabled=True, interval=60),
-            copilot=CopilotConfig(model="gpt-4o"),
-            integrations=["my-jira"],
-        )
-        assert proj.credential_ref == "custom"
-        assert proj.poll is not None
-        assert proj.poll.interval == 60
-
-
-class TestJiraIntegrationConfig:
-    def test_valid(self) -> None:
-        cfg = JiraIntegrationConfig(
-            name="my-jira",
-            type="jira",
-            project_key="PROJ",
-        )
-        assert cfg.trigger_status == "AI Ready"
-
-    def test_requires_name_and_key(self) -> None:
-        with pytest.raises(ValidationError):
-            JiraIntegrationConfig.model_validate({"type": "jira"})
+def test_jira_integration_defaults() -> None:
+    """JiraIntegrationConfig populates Jira status defaults."""
+    cfg = JiraIntegrationConfig(name="j", type="jira", project_key="P")
+    assert cfg.trigger_status == "AI Ready"
+    assert cfg.in_progress_status == "In Progress"
+    assert cfg.in_review_status == "In Review"
 
 
 # -- ConfigFile tests --
@@ -328,18 +290,20 @@ class TestResolveProject:
 
 
 class TestLoadConfigFile:
-    def test_loads_valid_yaml(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize(
+        ("content", "expected_projects"),
+        [
+            (yaml.dump(MINIMAL_CONFIG), 0),
+            (FULL_CONFIG_YAML, 2),
+        ],
+        ids=["minimal", "full"],
+    )
+    def test_loads_valid_yaml(self, tmp_path: Path, content: str, expected_projects: int) -> None:
         config_file = tmp_path / "config.yaml"
-        config_file.write_text(yaml.dump(MINIMAL_CONFIG))
+        config_file.write_text(content)
         cfg = load_config_file(config_file)
         assert cfg.version == 2
-        assert cfg.gitlab.url == GITLAB_URL
-
-    def test_loads_full_yaml(self, tmp_path: Path) -> None:
-        config_file = tmp_path / "config.yaml"
-        config_file.write_text(FULL_CONFIG_YAML)
-        cfg = load_config_file(config_file)
-        assert len(cfg.projects) == 2
+        assert len(cfg.projects) == expected_projects
 
     def test_file_not_found(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError):

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,0 +1,63 @@
+"""Tests for container — AppContext dataclass and get_services dependency."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI, Request
+from starlette.datastructures import State
+
+from gitlab_copilot_agent.container import AppContext, get_services
+
+
+def _make_context(**overrides: object) -> AppContext:
+    """Create an AppContext with mock services for testing."""
+    defaults = {
+        "settings": MagicMock(),
+        "executor": MagicMock(),
+        "repo_locks": MagicMock(),
+        "dedup_store": MagicMock(),
+        "review_tracker": MagicMock(),
+        "credential_registry": MagicMock(),
+    }
+    return AppContext(**(defaults | overrides))
+
+
+def _make_request(app: FastAPI) -> Request:
+    """Create a minimal Request object for testing."""
+    scope = {"type": "http", "app": app}
+    return Request(scope)
+
+
+class TestAppContext:
+    def test_creates_with_required_fields(self) -> None:
+        ctx = _make_context()
+        assert ctx.settings is not None
+        assert ctx.executor is not None
+        assert ctx.allowed_project_ids is None
+
+    def test_frozen(self) -> None:
+        ctx = _make_context()
+        with pytest.raises(AttributeError):
+            ctx.settings = MagicMock()  # type: ignore[misc]
+
+    def test_allowed_project_ids_frozenset(self) -> None:
+        ctx = _make_context(allowed_project_ids=frozenset({1, 2, 3}))
+        assert ctx.allowed_project_ids == frozenset({1, 2, 3})
+
+
+class TestGetServices:
+    def test_returns_container(self) -> None:
+        app = FastAPI()
+        ctx = _make_context()
+        app.state.container = ctx
+        request = _make_request(app)
+        assert get_services(request) is ctx
+
+    def test_raises_when_no_container(self) -> None:
+        app = FastAPI()
+        app.state = State()
+        request = _make_request(app)
+        with pytest.raises(RuntimeError, match="AppContext not initialized"):
+            get_services(request)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -51,12 +51,12 @@ async def test_lifespan_without_jira_starts_and_stops(env_vars: None) -> None:
     """Test that lifespan completes successfully when Jira is not enabled."""
     test_app = FastAPI()
     async with lifespan(test_app):
-        assert test_app.state.container is not None
-        assert test_app.state.container.settings.jira is None
-        assert test_app.state.container.repo_locks is not None
-        assert isinstance(test_app.state.container.repo_locks, RepoLockManager)
-        assert isinstance(test_app.state.container.dedup_store, DeduplicationStore)
-        assert isinstance(test_app.state.container.executor, LocalTaskExecutor)
+        assert test_app.state.ctx is not None
+        assert test_app.state.ctx.settings.jira is None
+        assert test_app.state.ctx.repo_locks is not None
+        assert isinstance(test_app.state.ctx.repo_locks, RepoLockManager)
+        assert isinstance(test_app.state.ctx.dedup_store, DeduplicationStore)
+        assert isinstance(test_app.state.ctx.executor, LocalTaskExecutor)
         assert test_app.state.project_registry is None
 
 
@@ -97,13 +97,13 @@ async def test_lifespan_with_jira_creates_shared_lock_manager(
         mock_registry_cls.from_rendered_map = AsyncMock(return_value=mock_registry)
         async with lifespan(test_app):
             mock_poller.start.assert_called_once()
-            assert test_app.state.container.repo_locks is not None
-            assert isinstance(test_app.state.container.repo_locks, RepoLockManager)
+            assert test_app.state.ctx.repo_locks is not None
+            assert isinstance(test_app.state.ctx.repo_locks, RepoLockManager)
             assert test_app.state.project_registry is mock_registry
             mock_orch_class.assert_called_once()
             args, _kwargs = mock_orch_class.call_args
             assert isinstance(args[3], LocalTaskExecutor)
-            assert args[4] is test_app.state.container.repo_locks
+            assert args[4] is test_app.state.ctx.repo_locks
 
         mock_poller.stop.assert_called_once()
 
@@ -254,9 +254,7 @@ async def test_lifespan_resolves_allowlist(
     mock_client.resolve_project = AsyncMock(side_effect=[RESOLVED_PROJECT_ID, 99])
     with patch("gitlab_copilot_agent.main.GitLabClient", return_value=mock_client):
         async with lifespan(test_app):
-            assert test_app.state.container.allowed_project_ids == frozenset(
-                {RESOLVED_PROJECT_ID, 99}
-            )
+            assert test_app.state.ctx.allowed_project_ids == frozenset({RESOLVED_PROJECT_ID, 99})
 
 
 @pytest.mark.asyncio
@@ -264,7 +262,7 @@ async def test_lifespan_allowlist_none_when_unset(env_vars: None) -> None:
     """When GITLAB_PROJECTS is not set, allowed_project_ids is None."""
     test_app = FastAPI()
     async with lifespan(test_app):
-        assert test_app.state.container.allowed_project_ids is None
+        assert test_app.state.ctx.allowed_project_ids is None
 
 
 # -- GitLab poller wiring tests --

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -308,7 +308,7 @@ async def test_lifespan_no_poller_when_poll_disabled(env_vars: None) -> None:
     """When GITLAB_POLL is not set, no poller is created."""
     test_app = FastAPI()
     async with lifespan(test_app):
-        assert not hasattr(test_app.state, "gl_poller")
+        assert test_app.state.gl_poller is None
 
 
 def test_config_poll_requires_projects(
@@ -348,13 +348,12 @@ async def test_health_with_poller(client: AsyncClient) -> None:
 
     from gitlab_copilot_agent.main import app
 
-    mock_task = MagicMock()
-    mock_task.done.return_value = False
-
     mock_poller = MagicMock()
-    mock_poller._task = mock_task
-    mock_poller._failures = 0
-    mock_poller._watermark = "2026-01-01T00:00:00Z"
+    mock_poller.status.return_value = {
+        "running": True,
+        "failures": 0,
+        "watermark": "2026-01-01T00:00:00Z",
+    }
     app.state.gl_poller = mock_poller
 
     resp = await client.get("/health")
@@ -364,7 +363,7 @@ async def test_health_with_poller(client: AsyncClient) -> None:
     assert data["gitlab_poller"]["failures"] == 0
     assert data["gitlab_poller"]["watermark"] == "2026-01-01T00:00:00Z"
 
-    del app.state.gl_poller
+    app.state.gl_poller = None
 
 
 @pytest.mark.asyncio

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -51,12 +51,12 @@ async def test_lifespan_without_jira_starts_and_stops(env_vars: None) -> None:
     """Test that lifespan completes successfully when Jira is not enabled."""
     test_app = FastAPI()
     async with lifespan(test_app):
-        assert test_app.state.ctx is not None
-        assert test_app.state.ctx.settings.jira is None
-        assert test_app.state.ctx.repo_locks is not None
-        assert isinstance(test_app.state.ctx.repo_locks, RepoLockManager)
-        assert isinstance(test_app.state.ctx.dedup_store, DeduplicationStore)
-        assert isinstance(test_app.state.ctx.executor, LocalTaskExecutor)
+        assert test_app.state.app_context is not None
+        assert test_app.state.app_context.settings.jira is None
+        assert test_app.state.app_context.repo_locks is not None
+        assert isinstance(test_app.state.app_context.repo_locks, RepoLockManager)
+        assert isinstance(test_app.state.app_context.dedup_store, DeduplicationStore)
+        assert isinstance(test_app.state.app_context.executor, LocalTaskExecutor)
         assert test_app.state.project_registry is None
 
 
@@ -97,13 +97,13 @@ async def test_lifespan_with_jira_creates_shared_lock_manager(
         mock_registry_cls.from_rendered_map = AsyncMock(return_value=mock_registry)
         async with lifespan(test_app):
             mock_poller.start.assert_called_once()
-            assert test_app.state.ctx.repo_locks is not None
-            assert isinstance(test_app.state.ctx.repo_locks, RepoLockManager)
+            assert test_app.state.app_context.repo_locks is not None
+            assert isinstance(test_app.state.app_context.repo_locks, RepoLockManager)
             assert test_app.state.project_registry is mock_registry
             mock_orch_class.assert_called_once()
             args, _kwargs = mock_orch_class.call_args
             assert isinstance(args[3], LocalTaskExecutor)
-            assert args[4] is test_app.state.ctx.repo_locks
+            assert args[4] is test_app.state.app_context.repo_locks
 
         mock_poller.stop.assert_called_once()
 
@@ -254,7 +254,9 @@ async def test_lifespan_resolves_allowlist(
     mock_client.resolve_project = AsyncMock(side_effect=[RESOLVED_PROJECT_ID, 99])
     with patch("gitlab_copilot_agent.main.GitLabClient", return_value=mock_client):
         async with lifespan(test_app):
-            assert test_app.state.ctx.allowed_project_ids == frozenset({RESOLVED_PROJECT_ID, 99})
+            assert test_app.state.app_context.allowed_project_ids == frozenset(
+                {RESOLVED_PROJECT_ID, 99}
+            )
 
 
 @pytest.mark.asyncio
@@ -262,7 +264,7 @@ async def test_lifespan_allowlist_none_when_unset(env_vars: None) -> None:
     """When GITLAB_PROJECTS is not set, allowed_project_ids is None."""
     test_app = FastAPI()
     async with lifespan(test_app):
-        assert test_app.state.ctx.allowed_project_ids is None
+        assert test_app.state.app_context.allowed_project_ids is None
 
 
 # -- GitLab poller wiring tests --

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -51,12 +51,12 @@ async def test_lifespan_without_jira_starts_and_stops(env_vars: None) -> None:
     """Test that lifespan completes successfully when Jira is not enabled."""
     test_app = FastAPI()
     async with lifespan(test_app):
-        assert test_app.state.settings is not None
-        assert test_app.state.settings.jira is None
-        assert test_app.state.repo_locks is not None
-        assert isinstance(test_app.state.repo_locks, RepoLockManager)
-        assert isinstance(test_app.state.dedup_store, DeduplicationStore)
-        assert isinstance(test_app.state.executor, LocalTaskExecutor)
+        assert test_app.state.container is not None
+        assert test_app.state.container.settings.jira is None
+        assert test_app.state.container.repo_locks is not None
+        assert isinstance(test_app.state.container.repo_locks, RepoLockManager)
+        assert isinstance(test_app.state.container.dedup_store, DeduplicationStore)
+        assert isinstance(test_app.state.container.executor, LocalTaskExecutor)
         assert test_app.state.project_registry is None
 
 
@@ -97,13 +97,13 @@ async def test_lifespan_with_jira_creates_shared_lock_manager(
         mock_registry_cls.from_rendered_map = AsyncMock(return_value=mock_registry)
         async with lifespan(test_app):
             mock_poller.start.assert_called_once()
-            assert test_app.state.repo_locks is not None
-            assert isinstance(test_app.state.repo_locks, RepoLockManager)
+            assert test_app.state.container.repo_locks is not None
+            assert isinstance(test_app.state.container.repo_locks, RepoLockManager)
             assert test_app.state.project_registry is mock_registry
             mock_orch_class.assert_called_once()
             args, _kwargs = mock_orch_class.call_args
             assert isinstance(args[3], LocalTaskExecutor)
-            assert args[4] is test_app.state.repo_locks
+            assert args[4] is test_app.state.container.repo_locks
 
         mock_poller.stop.assert_called_once()
 
@@ -254,7 +254,9 @@ async def test_lifespan_resolves_allowlist(
     mock_client.resolve_project = AsyncMock(side_effect=[RESOLVED_PROJECT_ID, 99])
     with patch("gitlab_copilot_agent.main.GitLabClient", return_value=mock_client):
         async with lifespan(test_app):
-            assert test_app.state.allowed_project_ids == {RESOLVED_PROJECT_ID, 99}
+            assert test_app.state.container.allowed_project_ids == frozenset(
+                {RESOLVED_PROJECT_ID, 99}
+            )
 
 
 @pytest.mark.asyncio
@@ -262,7 +264,7 @@ async def test_lifespan_allowlist_none_when_unset(env_vars: None) -> None:
     """When GITLAB_PROJECTS is not set, allowed_project_ids is None."""
     test_app = FastAPI()
     async with lifespan(test_app):
-        assert test_app.state.allowed_project_ids is None
+        assert test_app.state.container.allowed_project_ids is None
 
 
 # -- GitLab poller wiring tests --

--- a/tests/test_mapping_cli.py
+++ b/tests/test_mapping_cli.py
@@ -181,3 +181,71 @@ class TestRenderJson:
     ) -> None:
         rc = main(["render-json", str(invalid_yaml_file)])
         assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# schema command (v2)
+# ---------------------------------------------------------------------------
+
+V2_MINIMAL_CONFIG = {"version": 2, "gitlab": {"url": "https://gitlab.example.com"}}
+
+
+class TestSchema:
+    def test_outputs_valid_json_schema(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main(["schema"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        schema = json.loads(out)
+        assert schema["title"] == "ConfigFile"
+        assert "properties" in schema
+
+    def test_schema_contains_key_fields(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main(["schema"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        schema = json.loads(out)
+        props = schema["properties"]
+        assert "version" in props
+        assert "gitlab" in props
+        assert "projects" in props
+
+
+# ---------------------------------------------------------------------------
+# validate-v2 command
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def valid_v2_file(tmp_path: Path) -> Path:
+    p = tmp_path / "config.yaml"
+    p.write_text(yaml.dump(V2_MINIMAL_CONFIG))
+    return p
+
+
+@pytest.fixture()
+def invalid_v2_file(tmp_path: Path) -> Path:
+    p = tmp_path / "bad_config.yaml"
+    p.write_text(yaml.dump({"version": 1}))
+    return p
+
+
+class TestValidateV2:
+    def test_valid_config(self, valid_v2_file: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main(["validate-v2", str(valid_v2_file)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Valid v2 config" in out
+
+    def test_invalid_config(
+        self, invalid_v2_file: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = main(["validate-v2", str(invalid_v2_file)])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert err  # some error printed
+
+    def test_missing_file(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main(["validate-v2", "/nonexistent/config.yaml"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "not a file" in err

--- a/tests/test_multi_credential_integration.py
+++ b/tests/test_multi_credential_integration.py
@@ -187,7 +187,7 @@ async def test_note_webhook_multi_project_token_isolation(
     )
     import dataclasses
 
-    app.state.container = dataclasses.replace(app.state.container, credential_registry=mock_cred)
+    app.state.ctx = dataclasses.replace(app.state.ctx, credential_registry=mock_cred)
 
     note_payload = {
         "object_kind": "note",

--- a/tests/test_multi_credential_integration.py
+++ b/tests/test_multi_credential_integration.py
@@ -187,7 +187,9 @@ async def test_note_webhook_multi_project_token_isolation(
     )
     import dataclasses
 
-    app.state.ctx = dataclasses.replace(app.state.ctx, credential_registry=mock_cred)
+    app.state.app_context = dataclasses.replace(
+        app.state.app_context, credential_registry=mock_cred
+    )
 
     note_payload = {
         "object_kind": "note",

--- a/tests/test_multi_credential_integration.py
+++ b/tests/test_multi_credential_integration.py
@@ -20,7 +20,6 @@ from tests.conftest import (
     FAKE_REVIEW_OUTPUT,
     GITLAB_URL,
     HEADERS,
-    make_settings,
 )
 
 # -- Two projects with distinct credentials --
@@ -123,7 +122,6 @@ async def test_multi_project_webhooks_use_distinct_tokens(
 
     registry = _make_multi_project_registry()
     app.state.project_registry = registry
-    app.state.settings = make_settings()
 
     try:
         # Send webhook for project Alpha
@@ -187,7 +185,9 @@ async def test_note_webhook_multi_project_token_isolation(
     mock_cred.resolve_identity = AsyncMock(
         return_value=AgentIdentity(user_id=AGENT_USER_ID, username=AGENT_USERNAME)
     )
-    app.state.credential_registry = mock_cred
+    import dataclasses
+
+    app.state.container = dataclasses.replace(app.state.container, credential_registry=mock_cred)
 
     note_payload = {
         "object_kind": "note",
@@ -222,4 +222,3 @@ async def test_note_webhook_multi_project_token_isolation(
             assert kwargs["project_token"] == PROJECT_BETA_TOKEN
     finally:
         app.state.project_registry = None
-        del app.state.credential_registry

--- a/tests/test_project_registry.py
+++ b/tests/test_project_registry.py
@@ -96,8 +96,8 @@ class TestFromRenderedMap:
             default_token=DEFAULT_TOKEN,
             named_tokens={"platform_team": PLATFORM_TOKEN},
         )
-        with patch("gitlab_copilot_agent.project_registry.GitLabClient") as MC:
-            MC.return_value = AsyncMock(
+        with patch("gitlab_copilot_agent.project_registry.GitLabClient") as mock_client_cls:
+            mock_client_cls.return_value = AsyncMock(
                 resolve_project=AsyncMock(side_effect=[PID_A, PID_B]),
             )
             reg = await ProjectRegistry.from_rendered_map(rendered, creds, GITLAB_URL)
@@ -112,3 +112,95 @@ class TestFromRenderedMap:
         creds = CredentialRegistry(default_token=DEFAULT_TOKEN)
         with pytest.raises(KeyError, match="Unknown credential_ref"):
             await ProjectRegistry.from_rendered_map(rendered, creds, GITLAB_URL)
+
+
+class TestOptionalJiraProject:
+    """Tests for optional jira_project (review-only projects)."""
+
+    def test_none_jira_project_not_indexed(self) -> None:
+        proj = _proj(jira="PROJ")
+        no_jira = ResolvedProject(
+            repo="group/review-only",
+            gitlab_project_id=200,
+            clone_url=f"{GITLAB_URL}/group/review-only.git",
+            target_branch="main",
+            credential_ref="default",
+            token=DEFAULT_TOKEN,
+        )
+        reg = ProjectRegistry([proj, no_jira])
+        assert reg.jira_keys() == {JIRA_PROJ}
+        assert reg.get_by_project_id(200) is not None
+        assert reg.get_by_jira("PROJ") is not None
+
+    def test_all_none_jira_produces_empty_jira_keys(self) -> None:
+        no_jira = ResolvedProject(
+            repo="group/review-only",
+            gitlab_project_id=200,
+            clone_url=f"{GITLAB_URL}/group/review-only.git",
+            target_branch="main",
+            credential_ref="default",
+            token=DEFAULT_TOKEN,
+        )
+        reg = ProjectRegistry([no_jira])
+        assert reg.jira_keys() == set()
+        assert reg.get_by_project_id(200) is not None
+
+
+class TestFromConfig:
+    """Tests for ProjectRegistry.from_config() with v2 ConfigFile."""
+
+    async def test_builds_from_v2_config(self) -> None:
+        from gitlab_copilot_agent.config_v2 import ConfigFile
+
+        config = ConfigFile.model_validate(
+            {
+                "version": 2,
+                "gitlab": {"url": GITLAB_URL},
+                "projects": [
+                    {"repo": REPO_A},
+                    {"repo": REPO_B, "credential_ref": "platform_team"},
+                ],
+            }
+        )
+        creds = CredentialRegistry(
+            default_token=DEFAULT_TOKEN,
+            named_tokens={"platform_team": PLATFORM_TOKEN},
+        )
+        with patch("gitlab_copilot_agent.project_registry.GitLabClient") as mock_client_cls:
+            mock_client_cls.return_value = AsyncMock(
+                resolve_project=AsyncMock(side_effect=[PID_A, PID_B]),
+            )
+            reg = await ProjectRegistry.from_config(config, creds, GITLAB_URL)
+
+        assert reg.get_by_project_id(PID_A) is not None
+        assert reg.get_by_project_id(PID_B) is not None
+        # No jira integrations → jira_project should be None
+        assert reg.get_by_project_id(PID_A).jira_project is None
+        assert reg.jira_keys() == set()
+
+    async def test_resolves_jira_integration(self) -> None:
+        from gitlab_copilot_agent.config_v2 import ConfigFile
+
+        config = ConfigFile.model_validate(
+            {
+                "version": 2,
+                "gitlab": {"url": GITLAB_URL},
+                "projects": [
+                    {"repo": REPO_A, "integrations": ["my-jira"]},
+                ],
+                "integrations": [
+                    {"name": "my-jira", "type": "jira", "project_key": "PROJ"},
+                ],
+            }
+        )
+        creds = CredentialRegistry(default_token=DEFAULT_TOKEN)
+        with patch("gitlab_copilot_agent.project_registry.GitLabClient") as mock_client_cls:
+            mock_client_cls.return_value = AsyncMock(
+                resolve_project=AsyncMock(return_value=PID_A),
+            )
+            reg = await ProjectRegistry.from_config(config, creds, GITLAB_URL)
+
+        p = reg.get_by_project_id(PID_A)
+        assert p is not None
+        assert p.jira_project == "PROJ"
+        assert reg.jira_keys() == {"PROJ"}

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,6 +1,7 @@
 """Tests for the webhook endpoint."""
 
 import asyncio
+import dataclasses
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -17,6 +18,7 @@ from tests.conftest import (
     MR_IID,
     MR_PAYLOAD,
     PROJECT_ID,
+    make_container,
     make_mr_payload,
     make_settings,
 )
@@ -41,8 +43,10 @@ async def test_webhook_rejects_bad_token(client: AsyncClient, token: str | None)
 
 async def test_webhook_returns_403_when_secret_not_configured(client: AsyncClient) -> None:
     """Polling-only mode: no webhook secret configured → 403."""
-    app.state.settings = make_settings(
-        gitlab_webhook_secret=None, gitlab_poll=True, gitlab_projects="group/project"
+    app.state.container = make_container(
+        settings=make_settings(
+            gitlab_webhook_secret=None, gitlab_poll=True, gitlab_projects="group/project"
+        )
     )
     resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
     assert resp.status_code == 403
@@ -95,54 +99,39 @@ def _note_body(note: str = f"@{AGENT_USERNAME} fix the bug") -> dict[str, object
 
 
 def _setup_credential_registry() -> MagicMock:
-    """Wire a credential registry into app.state and return the mock."""
+    """Wire a mock credential registry into the container and return it."""
     mock = _make_credential_registry_mock()
-    app.state.credential_registry = mock
+    app.state.container = dataclasses.replace(app.state.container, credential_registry=mock)
     return mock
 
 
 async def test_note_webhook_queues_mention(client: AsyncClient) -> None:
     """Note with @mention of agent is queued for processing."""
     _setup_credential_registry()
-    try:
-        with patch("gitlab_copilot_agent.webhook.handle_discussion_interaction"):
-            resp = await client.post("/webhook", json=_note_body(), headers=HEADERS)
-        assert resp.json()["status"] == "queued"
-    finally:
-        del app.state.credential_registry
+    with patch("gitlab_copilot_agent.webhook.handle_discussion_interaction"):
+        resp = await client.post("/webhook", json=_note_body(), headers=HEADERS)
+    assert resp.json()["status"] == "queued"
 
 
 async def test_note_webhook_ignores_no_mention(client: AsyncClient) -> None:
     """Note without @mention is ignored."""
     _setup_credential_registry()
-    try:
-        resp = await client.post("/webhook", json=_note_body("just a comment"), headers=HEADERS)
-        assert resp.json() == {"status": "ignored", "reason": "not directed at agent"}
-    finally:
-        del app.state.credential_registry
-
-
-async def test_note_webhook_ignores_without_credential_registry(client: AsyncClient) -> None:
-    """Note is ignored when no credential_registry is configured."""
-    resp = await client.post("/webhook", json=_note_body(), headers=HEADERS)
-    assert resp.json() == {"status": "ignored", "reason": "no credential registry"}
+    resp = await client.post("/webhook", json=_note_body("just a comment"), headers=HEADERS)
+    assert resp.json() == {"status": "ignored", "reason": "not directed at agent"}
 
 
 async def test_note_webhook_uses_shared_lock_manager(client: AsyncClient) -> None:
-    """Verify that the discussion handler receives repo_locks from app.state."""
+    """Verify that the discussion handler receives repo_locks from container."""
     _setup_credential_registry()
     mock_handle = AsyncMock()
-    try:
-        with patch("gitlab_copilot_agent.webhook.handle_discussion_interaction", mock_handle):
-            resp = await client.post("/webhook", json=_note_body(), headers=HEADERS)
-            assert resp.json()["status"] == "queued"
-            await asyncio.sleep(0.1)
+    with patch("gitlab_copilot_agent.webhook.handle_discussion_interaction", mock_handle):
+        resp = await client.post("/webhook", json=_note_body(), headers=HEADERS)
+        assert resp.json()["status"] == "queued"
+        await asyncio.sleep(0.1)
 
-            mock_handle.assert_awaited_once()
-            _, kwargs = mock_handle.call_args
-            assert kwargs["repo_locks"] is app.state.repo_locks
-    finally:
-        del app.state.credential_registry
+        mock_handle.assert_awaited_once()
+        _, kwargs = mock_handle.call_args
+        assert kwargs["repo_locks"] is app.state.container.repo_locks
 
 
 # -- Deduplication tests --
@@ -150,10 +139,8 @@ async def test_note_webhook_uses_shared_lock_manager(client: AsyncClient) -> Non
 
 async def test_webhook_skips_duplicate_head_sha(client: AsyncClient) -> None:
     """Second webhook with same project/MR/SHA is skipped."""
-    from gitlab_copilot_agent.main import app
-
     # Pre-mark this SHA as reviewed
-    app.state.review_tracker.mark(PROJECT_ID, MR_IID, "abc123")
+    app.state.container.review_tracker.mark(PROJECT_ID, MR_IID, "abc123")
 
     resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
     assert resp.status_code == 200
@@ -162,9 +149,7 @@ async def test_webhook_skips_duplicate_head_sha(client: AsyncClient) -> None:
 
 async def test_webhook_queues_new_head_sha(client: AsyncClient) -> None:
     """New SHA on same MR is NOT skipped."""
-    from gitlab_copilot_agent.main import app
-
-    app.state.review_tracker.mark(PROJECT_ID, MR_IID, "old_sha")
+    app.state.container.review_tracker.mark(PROJECT_ID, MR_IID, "old_sha")
 
     payload = make_mr_payload(last_commit={"id": "new_sha", "message": "new commit"})
     resp = await client.post("/webhook", json=payload, headers=HEADERS)
@@ -173,9 +158,7 @@ async def test_webhook_queues_new_head_sha(client: AsyncClient) -> None:
 
 async def test_webhook_marks_sha_after_successful_review(client: AsyncClient) -> None:
     """SHA is marked as reviewed only after handle_review succeeds."""
-    from gitlab_copilot_agent.main import app
-
-    tracker = app.state.review_tracker
+    tracker = app.state.container.review_tracker
     assert not tracker.is_reviewed(PROJECT_ID, MR_IID, "abc123")
 
     with patch("gitlab_copilot_agent.webhook.handle_review", new_callable=AsyncMock):
@@ -188,9 +171,7 @@ async def test_webhook_marks_sha_after_successful_review(client: AsyncClient) ->
 
 async def test_webhook_does_not_mark_sha_on_review_failure(client: AsyncClient) -> None:
     """SHA is NOT marked if handle_review raises."""
-    from gitlab_copilot_agent.main import app
-
-    tracker = app.state.review_tracker
+    tracker = app.state.container.review_tracker
 
     with patch(
         "gitlab_copilot_agent.webhook.handle_review",
@@ -224,29 +205,27 @@ async def test_webhook_queues_update_with_new_commits(client: AsyncClient) -> No
 
 async def test_webhook_accepts_when_allowlist_is_none(client: AsyncClient) -> None:
     """Backward compat: no allowlist configured means all projects pass."""
-    assert app.state.allowed_project_ids is None
+    assert app.state.container.allowed_project_ids is None
     resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
     assert resp.json()["status"] == "queued"
 
 
 async def test_webhook_accepts_when_project_in_allowlist(client: AsyncClient) -> None:
     """Events from allowed projects are processed normally."""
-    app.state.allowed_project_ids = {PROJECT_ID}
-    try:
-        resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
-        assert resp.json()["status"] == "queued"
-    finally:
-        app.state.allowed_project_ids = None
+    app.state.container = dataclasses.replace(
+        app.state.container, allowed_project_ids=frozenset({PROJECT_ID})
+    )
+    resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
+    assert resp.json()["status"] == "queued"
 
 
 async def test_webhook_rejects_when_project_not_in_allowlist(client: AsyncClient) -> None:
     """Events from non-allowed projects are ignored."""
-    app.state.allowed_project_ids = {NON_ALLOWED_PROJECT_ID}
-    try:
-        resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
-        assert resp.json() == {"status": "ignored", "reason": "project not in allowlist"}
-    finally:
-        app.state.allowed_project_ids = None
+    app.state.container = dataclasses.replace(
+        app.state.container, allowed_project_ids=frozenset({NON_ALLOWED_PROJECT_ID})
+    )
+    resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
+    assert resp.json() == {"status": "ignored", "reason": "project not in allowlist"}
 
 
 # -- Per-project credential tests --
@@ -305,7 +284,9 @@ async def test_webhook_review_falls_back_to_global_token(client: AsyncClient) ->
 async def test_webhook_discussion_uses_per_project_token(client: AsyncClient) -> None:
     """Discussion handler resolves per-project token from registry."""
     app.state.project_registry = _make_project_registry()
-    app.state.credential_registry = _make_credential_registry_mock()
+    app.state.container = dataclasses.replace(
+        app.state.container, credential_registry=_make_credential_registry_mock()
+    )
     mock_handle = AsyncMock()
     try:
         with patch("gitlab_copilot_agent.webhook.handle_discussion_interaction", mock_handle):
@@ -318,7 +299,6 @@ async def test_webhook_discussion_uses_per_project_token(client: AsyncClient) ->
         assert kwargs["project_token"] == PER_PROJECT_TOKEN
     finally:
         app.state.project_registry = None
-        del app.state.credential_registry
 
 
 async def test_webhook_review_works_without_registry(client: AsyncClient) -> None:
@@ -336,21 +316,20 @@ async def test_webhook_review_works_without_registry(client: AsyncClient) -> Non
 
 
 async def test_webhook_review_passes_credential_registry(client: AsyncClient) -> None:
-    """MR review forwards credential_registry from app.state."""
+    """MR review forwards credential_registry from container."""
     mock_registry = MagicMock()
-    app.state.credential_registry = mock_registry
+    app.state.container = dataclasses.replace(
+        app.state.container, credential_registry=mock_registry
+    )
     mock_handle = AsyncMock()
-    try:
-        with patch("gitlab_copilot_agent.webhook.handle_review", mock_handle):
-            resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
-            assert resp.json() == {"status": "queued"}
-            await asyncio.sleep(0.1)
+    with patch("gitlab_copilot_agent.webhook.handle_review", mock_handle):
+        resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
+        assert resp.json() == {"status": "queued"}
+        await asyncio.sleep(0.1)
 
-        mock_handle.assert_awaited_once()
-        _, kwargs = mock_handle.call_args
-        assert kwargs["credential_registry"] is mock_registry
-    finally:
-        del app.state.credential_registry
+    mock_handle.assert_awaited_once()
+    _, kwargs = mock_handle.call_args
+    assert kwargs["credential_registry"] is mock_registry
 
 
 # -- Self-comment detection tests --
@@ -399,36 +378,36 @@ def _note_body_with_user(
 
 async def test_self_comment_detected_via_user_id(client: AsyncClient) -> None:
     """Note from the agent (matched by user_id) is ignored."""
-    app.state.credential_registry = _make_credential_registry_mock(user_id=AGENT_USER_ID)
-    try:
-        body = _note_body_with_user(user_id=AGENT_USER_ID, username="someone-else")
-        resp = await client.post("/webhook", json=body, headers=HEADERS)
-        assert resp.json() == {"status": "ignored", "reason": "self-comment"}
-    finally:
-        del app.state.credential_registry
+    app.state.container = dataclasses.replace(
+        app.state.container,
+        credential_registry=_make_credential_registry_mock(user_id=AGENT_USER_ID),
+    )
+    body = _note_body_with_user(user_id=AGENT_USER_ID, username="someone-else")
+    resp = await client.post("/webhook", json=body, headers=HEADERS)
+    assert resp.json() == {"status": "ignored", "reason": "self-comment"}
 
 
 async def test_no_self_comment_when_ids_differ(client: AsyncClient) -> None:
     """Note from a different user with @mention proceeds to queue."""
-    app.state.credential_registry = _make_credential_registry_mock(user_id=AGENT_USER_ID)
-    try:
-        with patch("gitlab_copilot_agent.webhook.handle_discussion_interaction"):
-            body = _note_body_with_user(user_id=NOTE_AUTHOR_USER_ID)
-            resp = await client.post("/webhook", json=body, headers=HEADERS)
-            assert resp.json() == {"status": "queued"}
-    finally:
-        del app.state.credential_registry
+    app.state.container = dataclasses.replace(
+        app.state.container,
+        credential_registry=_make_credential_registry_mock(user_id=AGENT_USER_ID),
+    )
+    with patch("gitlab_copilot_agent.webhook.handle_discussion_interaction"):
+        body = _note_body_with_user(user_id=NOTE_AUTHOR_USER_ID)
+        resp = await client.post("/webhook", json=body, headers=HEADERS)
+        assert resp.json() == {"status": "queued"}
 
 
 async def test_identity_resolution_failure_returns_ignored(client: AsyncClient) -> None:
     """When resolve_identity raises, note is ignored."""
-    app.state.credential_registry = _make_credential_registry_mock(raise_on_resolve=True)
-    try:
-        body = _note_body_with_user(user_id=NOTE_AUTHOR_USER_ID, username=AGENT_USERNAME)
-        resp = await client.post("/webhook", json=body, headers=HEADERS)
-        assert resp.json() == {"status": "ignored", "reason": "identity resolution failed"}
-    finally:
-        del app.state.credential_registry
+    app.state.container = dataclasses.replace(
+        app.state.container,
+        credential_registry=_make_credential_registry_mock(raise_on_resolve=True),
+    )
+    body = _note_body_with_user(user_id=NOTE_AUTHOR_USER_ID, username=AGENT_USERNAME)
+    resp = await client.post("/webhook", json=body, headers=HEADERS)
+    assert resp.json() == {"status": "ignored", "reason": "identity resolution failed"}
 
 
 # -- _is_agent_directed tests --

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -43,7 +43,7 @@ async def test_webhook_rejects_bad_token(client: AsyncClient, token: str | None)
 
 async def test_webhook_returns_403_when_secret_not_configured(client: AsyncClient) -> None:
     """Polling-only mode: no webhook secret configured → 403."""
-    app.state.ctx = make_app_context(
+    app.state.app_context = make_app_context(
         settings=make_settings(
             gitlab_webhook_secret=None, gitlab_poll=True, gitlab_projects="group/project"
         )
@@ -101,7 +101,7 @@ def _note_body(note: str = f"@{AGENT_USERNAME} fix the bug") -> dict[str, object
 def _setup_credential_registry() -> MagicMock:
     """Wire a mock credential registry into the app context and return it."""
     mock = _make_credential_registry_mock()
-    app.state.ctx = dataclasses.replace(app.state.ctx, credential_registry=mock)
+    app.state.app_context = dataclasses.replace(app.state.app_context, credential_registry=mock)
     return mock
 
 
@@ -131,7 +131,7 @@ async def test_note_webhook_uses_shared_lock_manager(client: AsyncClient) -> Non
 
         mock_handle.assert_awaited_once()
         _, kwargs = mock_handle.call_args
-        assert kwargs["repo_locks"] is app.state.ctx.repo_locks
+        assert kwargs["repo_locks"] is app.state.app_context.repo_locks
 
 
 # -- Deduplication tests --
@@ -140,7 +140,7 @@ async def test_note_webhook_uses_shared_lock_manager(client: AsyncClient) -> Non
 async def test_webhook_skips_duplicate_head_sha(client: AsyncClient) -> None:
     """Second webhook with same project/MR/SHA is skipped."""
     # Pre-mark this SHA as reviewed
-    app.state.ctx.review_tracker.mark(PROJECT_ID, MR_IID, "abc123")
+    app.state.app_context.review_tracker.mark(PROJECT_ID, MR_IID, "abc123")
 
     resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
     assert resp.status_code == 200
@@ -149,7 +149,7 @@ async def test_webhook_skips_duplicate_head_sha(client: AsyncClient) -> None:
 
 async def test_webhook_queues_new_head_sha(client: AsyncClient) -> None:
     """New SHA on same MR is NOT skipped."""
-    app.state.ctx.review_tracker.mark(PROJECT_ID, MR_IID, "old_sha")
+    app.state.app_context.review_tracker.mark(PROJECT_ID, MR_IID, "old_sha")
 
     payload = make_mr_payload(last_commit={"id": "new_sha", "message": "new commit"})
     resp = await client.post("/webhook", json=payload, headers=HEADERS)
@@ -158,7 +158,7 @@ async def test_webhook_queues_new_head_sha(client: AsyncClient) -> None:
 
 async def test_webhook_marks_sha_after_successful_review(client: AsyncClient) -> None:
     """SHA is marked as reviewed only after handle_review succeeds."""
-    tracker = app.state.ctx.review_tracker
+    tracker = app.state.app_context.review_tracker
     assert not tracker.is_reviewed(PROJECT_ID, MR_IID, "abc123")
 
     with patch("gitlab_copilot_agent.webhook.handle_review", new_callable=AsyncMock):
@@ -171,7 +171,7 @@ async def test_webhook_marks_sha_after_successful_review(client: AsyncClient) ->
 
 async def test_webhook_does_not_mark_sha_on_review_failure(client: AsyncClient) -> None:
     """SHA is NOT marked if handle_review raises."""
-    tracker = app.state.ctx.review_tracker
+    tracker = app.state.app_context.review_tracker
 
     with patch(
         "gitlab_copilot_agent.webhook.handle_review",
@@ -205,22 +205,24 @@ async def test_webhook_queues_update_with_new_commits(client: AsyncClient) -> No
 
 async def test_webhook_accepts_when_allowlist_is_none(client: AsyncClient) -> None:
     """Backward compat: no allowlist configured means all projects pass."""
-    assert app.state.ctx.allowed_project_ids is None
+    assert app.state.app_context.allowed_project_ids is None
     resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
     assert resp.json()["status"] == "queued"
 
 
 async def test_webhook_accepts_when_project_in_allowlist(client: AsyncClient) -> None:
     """Events from allowed projects are processed normally."""
-    app.state.ctx = dataclasses.replace(app.state.ctx, allowed_project_ids=frozenset({PROJECT_ID}))
+    app.state.app_context = dataclasses.replace(
+        app.state.app_context, allowed_project_ids=frozenset({PROJECT_ID})
+    )
     resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
     assert resp.json()["status"] == "queued"
 
 
 async def test_webhook_rejects_when_project_not_in_allowlist(client: AsyncClient) -> None:
     """Events from non-allowed projects are ignored."""
-    app.state.ctx = dataclasses.replace(
-        app.state.ctx, allowed_project_ids=frozenset({NON_ALLOWED_PROJECT_ID})
+    app.state.app_context = dataclasses.replace(
+        app.state.app_context, allowed_project_ids=frozenset({NON_ALLOWED_PROJECT_ID})
     )
     resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
     assert resp.json() == {"status": "ignored", "reason": "project not in allowlist"}
@@ -282,8 +284,8 @@ async def test_webhook_review_falls_back_to_global_token(client: AsyncClient) ->
 async def test_webhook_discussion_uses_per_project_token(client: AsyncClient) -> None:
     """Discussion handler resolves per-project token from registry."""
     app.state.project_registry = _make_project_registry()
-    app.state.ctx = dataclasses.replace(
-        app.state.ctx, credential_registry=_make_credential_registry_mock()
+    app.state.app_context = dataclasses.replace(
+        app.state.app_context, credential_registry=_make_credential_registry_mock()
     )
     mock_handle = AsyncMock()
     try:
@@ -316,7 +318,9 @@ async def test_webhook_review_works_without_registry(client: AsyncClient) -> Non
 async def test_webhook_review_passes_credential_registry(client: AsyncClient) -> None:
     """MR review forwards credential_registry from app context."""
     mock_registry = MagicMock()
-    app.state.ctx = dataclasses.replace(app.state.ctx, credential_registry=mock_registry)
+    app.state.app_context = dataclasses.replace(
+        app.state.app_context, credential_registry=mock_registry
+    )
     mock_handle = AsyncMock()
     with patch("gitlab_copilot_agent.webhook.handle_review", mock_handle):
         resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
@@ -374,8 +378,8 @@ def _note_body_with_user(
 
 async def test_self_comment_detected_via_user_id(client: AsyncClient) -> None:
     """Note from the agent (matched by user_id) is ignored."""
-    app.state.ctx = dataclasses.replace(
-        app.state.ctx,
+    app.state.app_context = dataclasses.replace(
+        app.state.app_context,
         credential_registry=_make_credential_registry_mock(user_id=AGENT_USER_ID),
     )
     body = _note_body_with_user(user_id=AGENT_USER_ID, username="someone-else")
@@ -385,8 +389,8 @@ async def test_self_comment_detected_via_user_id(client: AsyncClient) -> None:
 
 async def test_no_self_comment_when_ids_differ(client: AsyncClient) -> None:
     """Note from a different user with @mention proceeds to queue."""
-    app.state.ctx = dataclasses.replace(
-        app.state.ctx,
+    app.state.app_context = dataclasses.replace(
+        app.state.app_context,
         credential_registry=_make_credential_registry_mock(user_id=AGENT_USER_ID),
     )
     with patch("gitlab_copilot_agent.webhook.handle_discussion_interaction"):
@@ -397,8 +401,8 @@ async def test_no_self_comment_when_ids_differ(client: AsyncClient) -> None:
 
 async def test_identity_resolution_failure_returns_ignored(client: AsyncClient) -> None:
     """When resolve_identity raises, note is ignored."""
-    app.state.ctx = dataclasses.replace(
-        app.state.ctx,
+    app.state.app_context = dataclasses.replace(
+        app.state.app_context,
         credential_registry=_make_credential_registry_mock(raise_on_resolve=True),
     )
     body = _note_body_with_user(user_id=NOTE_AUTHOR_USER_ID, username=AGENT_USERNAME)

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -18,7 +18,7 @@ from tests.conftest import (
     MR_IID,
     MR_PAYLOAD,
     PROJECT_ID,
-    make_container,
+    make_app_context,
     make_mr_payload,
     make_settings,
 )
@@ -43,7 +43,7 @@ async def test_webhook_rejects_bad_token(client: AsyncClient, token: str | None)
 
 async def test_webhook_returns_403_when_secret_not_configured(client: AsyncClient) -> None:
     """Polling-only mode: no webhook secret configured → 403."""
-    app.state.container = make_container(
+    app.state.ctx = make_app_context(
         settings=make_settings(
             gitlab_webhook_secret=None, gitlab_poll=True, gitlab_projects="group/project"
         )
@@ -99,9 +99,9 @@ def _note_body(note: str = f"@{AGENT_USERNAME} fix the bug") -> dict[str, object
 
 
 def _setup_credential_registry() -> MagicMock:
-    """Wire a mock credential registry into the container and return it."""
+    """Wire a mock credential registry into the app context and return it."""
     mock = _make_credential_registry_mock()
-    app.state.container = dataclasses.replace(app.state.container, credential_registry=mock)
+    app.state.ctx = dataclasses.replace(app.state.ctx, credential_registry=mock)
     return mock
 
 
@@ -121,7 +121,7 @@ async def test_note_webhook_ignores_no_mention(client: AsyncClient) -> None:
 
 
 async def test_note_webhook_uses_shared_lock_manager(client: AsyncClient) -> None:
-    """Verify that the discussion handler receives repo_locks from container."""
+    """Verify that the discussion handler receives repo_locks from app context."""
     _setup_credential_registry()
     mock_handle = AsyncMock()
     with patch("gitlab_copilot_agent.webhook.handle_discussion_interaction", mock_handle):
@@ -131,7 +131,7 @@ async def test_note_webhook_uses_shared_lock_manager(client: AsyncClient) -> Non
 
         mock_handle.assert_awaited_once()
         _, kwargs = mock_handle.call_args
-        assert kwargs["repo_locks"] is app.state.container.repo_locks
+        assert kwargs["repo_locks"] is app.state.ctx.repo_locks
 
 
 # -- Deduplication tests --
@@ -140,7 +140,7 @@ async def test_note_webhook_uses_shared_lock_manager(client: AsyncClient) -> Non
 async def test_webhook_skips_duplicate_head_sha(client: AsyncClient) -> None:
     """Second webhook with same project/MR/SHA is skipped."""
     # Pre-mark this SHA as reviewed
-    app.state.container.review_tracker.mark(PROJECT_ID, MR_IID, "abc123")
+    app.state.ctx.review_tracker.mark(PROJECT_ID, MR_IID, "abc123")
 
     resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
     assert resp.status_code == 200
@@ -149,7 +149,7 @@ async def test_webhook_skips_duplicate_head_sha(client: AsyncClient) -> None:
 
 async def test_webhook_queues_new_head_sha(client: AsyncClient) -> None:
     """New SHA on same MR is NOT skipped."""
-    app.state.container.review_tracker.mark(PROJECT_ID, MR_IID, "old_sha")
+    app.state.ctx.review_tracker.mark(PROJECT_ID, MR_IID, "old_sha")
 
     payload = make_mr_payload(last_commit={"id": "new_sha", "message": "new commit"})
     resp = await client.post("/webhook", json=payload, headers=HEADERS)
@@ -158,7 +158,7 @@ async def test_webhook_queues_new_head_sha(client: AsyncClient) -> None:
 
 async def test_webhook_marks_sha_after_successful_review(client: AsyncClient) -> None:
     """SHA is marked as reviewed only after handle_review succeeds."""
-    tracker = app.state.container.review_tracker
+    tracker = app.state.ctx.review_tracker
     assert not tracker.is_reviewed(PROJECT_ID, MR_IID, "abc123")
 
     with patch("gitlab_copilot_agent.webhook.handle_review", new_callable=AsyncMock):
@@ -171,7 +171,7 @@ async def test_webhook_marks_sha_after_successful_review(client: AsyncClient) ->
 
 async def test_webhook_does_not_mark_sha_on_review_failure(client: AsyncClient) -> None:
     """SHA is NOT marked if handle_review raises."""
-    tracker = app.state.container.review_tracker
+    tracker = app.state.ctx.review_tracker
 
     with patch(
         "gitlab_copilot_agent.webhook.handle_review",
@@ -205,24 +205,22 @@ async def test_webhook_queues_update_with_new_commits(client: AsyncClient) -> No
 
 async def test_webhook_accepts_when_allowlist_is_none(client: AsyncClient) -> None:
     """Backward compat: no allowlist configured means all projects pass."""
-    assert app.state.container.allowed_project_ids is None
+    assert app.state.ctx.allowed_project_ids is None
     resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
     assert resp.json()["status"] == "queued"
 
 
 async def test_webhook_accepts_when_project_in_allowlist(client: AsyncClient) -> None:
     """Events from allowed projects are processed normally."""
-    app.state.container = dataclasses.replace(
-        app.state.container, allowed_project_ids=frozenset({PROJECT_ID})
-    )
+    app.state.ctx = dataclasses.replace(app.state.ctx, allowed_project_ids=frozenset({PROJECT_ID}))
     resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
     assert resp.json()["status"] == "queued"
 
 
 async def test_webhook_rejects_when_project_not_in_allowlist(client: AsyncClient) -> None:
     """Events from non-allowed projects are ignored."""
-    app.state.container = dataclasses.replace(
-        app.state.container, allowed_project_ids=frozenset({NON_ALLOWED_PROJECT_ID})
+    app.state.ctx = dataclasses.replace(
+        app.state.ctx, allowed_project_ids=frozenset({NON_ALLOWED_PROJECT_ID})
     )
     resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
     assert resp.json() == {"status": "ignored", "reason": "project not in allowlist"}
@@ -284,8 +282,8 @@ async def test_webhook_review_falls_back_to_global_token(client: AsyncClient) ->
 async def test_webhook_discussion_uses_per_project_token(client: AsyncClient) -> None:
     """Discussion handler resolves per-project token from registry."""
     app.state.project_registry = _make_project_registry()
-    app.state.container = dataclasses.replace(
-        app.state.container, credential_registry=_make_credential_registry_mock()
+    app.state.ctx = dataclasses.replace(
+        app.state.ctx, credential_registry=_make_credential_registry_mock()
     )
     mock_handle = AsyncMock()
     try:
@@ -316,11 +314,9 @@ async def test_webhook_review_works_without_registry(client: AsyncClient) -> Non
 
 
 async def test_webhook_review_passes_credential_registry(client: AsyncClient) -> None:
-    """MR review forwards credential_registry from container."""
+    """MR review forwards credential_registry from app context."""
     mock_registry = MagicMock()
-    app.state.container = dataclasses.replace(
-        app.state.container, credential_registry=mock_registry
-    )
+    app.state.ctx = dataclasses.replace(app.state.ctx, credential_registry=mock_registry)
     mock_handle = AsyncMock()
     with patch("gitlab_copilot_agent.webhook.handle_review", mock_handle):
         resp = await client.post("/webhook", json=MR_PAYLOAD, headers=HEADERS)
@@ -378,8 +374,8 @@ def _note_body_with_user(
 
 async def test_self_comment_detected_via_user_id(client: AsyncClient) -> None:
     """Note from the agent (matched by user_id) is ignored."""
-    app.state.container = dataclasses.replace(
-        app.state.container,
+    app.state.ctx = dataclasses.replace(
+        app.state.ctx,
         credential_registry=_make_credential_registry_mock(user_id=AGENT_USER_ID),
     )
     body = _note_body_with_user(user_id=AGENT_USER_ID, username="someone-else")
@@ -389,8 +385,8 @@ async def test_self_comment_detected_via_user_id(client: AsyncClient) -> None:
 
 async def test_no_self_comment_when_ids_differ(client: AsyncClient) -> None:
     """Note from a different user with @mention proceeds to queue."""
-    app.state.container = dataclasses.replace(
-        app.state.container,
+    app.state.ctx = dataclasses.replace(
+        app.state.ctx,
         credential_registry=_make_credential_registry_mock(user_id=AGENT_USER_ID),
     )
     with patch("gitlab_copilot_agent.webhook.handle_discussion_interaction"):
@@ -401,8 +397,8 @@ async def test_no_self_comment_when_ids_differ(client: AsyncClient) -> None:
 
 async def test_identity_resolution_failure_returns_ignored(client: AsyncClient) -> None:
     """When resolve_identity raises, note is ignored."""
-    app.state.container = dataclasses.replace(
-        app.state.container,
+    app.state.ctx = dataclasses.replace(
+        app.state.ctx,
         credential_registry=_make_credential_registry_mock(raise_on_resolve=True),
     )
     body = _note_body_with_user(user_id=NOTE_AUTHOR_USER_ID, username=AGENT_USERNAME)

--- a/uv.lock
+++ b/uv.lock
@@ -361,6 +361,22 @@ wheels = [
 ]
 
 [[package]]
+name = "check-jsonschema"
+version = "0.37.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "jsonschema" },
+    { name = "regress" },
+    { name = "requests" },
+    { name = "ruamel-yaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/d4/46468808fcda2bdb824e1f5617095a14cac60f9bcefc954fbfee55712d1b/check_jsonschema-0.37.1.tar.gz", hash = "sha256:00a2ba5cdc95006e0d07e3743f4f23d80b7f30a690706c018c83578610c2e0a0", size = 408161, upload-time = "2026-03-26T02:49:59.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/cc/bfa3f5c4b8fdc05956a9426f4d7a9a85c6d6d68c8096722f612bf4db5d08/check_jsonschema-0.37.1-py3-none-any.whl", hash = "sha256:cf672ef4ccd62f9512ac40d28dde135108799ee8d749095ac72b62ecdb796d2e", size = 392983, upload-time = "2026-03-26T02:49:57.808Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -699,6 +715,7 @@ dev = [
     { name = "azure-identity" },
     { name = "azure-storage-blob" },
     { name = "azure-storage-queue" },
+    { name = "check-jsonschema" },
     { name = "pyright" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -745,6 +762,7 @@ dev = [
     { name = "azure-identity", specifier = "==1.25.3" },
     { name = "azure-storage-blob", specifier = "==12.28.0" },
     { name = "azure-storage-queue", specifier = "==12.15.0" },
+    { name = "check-jsonschema", specifier = "==0.37.1" },
     { name = "pyright", specifier = "==1.1.408" },
     { name = "pytest-asyncio", specifier = "==1.3.0" },
     { name = "pytest-cov", specifier = "==7.1.0" },
@@ -950,6 +968,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -1715,6 +1760,96 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "regress"
+version = "2025.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/bf/faa406189856f9b566fa1c42d173188d3e86cd5116484a663922365e0004/regress-2025.10.1.tar.gz", hash = "sha256:dcc0a8af0cdbc3d6e0d4725f113335d0a5ffbba86ae3ca18d2b5b352c5f2c8ed", size = 11567, upload-time = "2025-10-09T07:09:48.397Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/82/68b78d093656628ded54d3e947024058f4c86f18d195174b48d370e468fd/regress-2025.10.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:45695cd7ddc6a919863f243a09a9e737257f958c0d2af0e71e349c9d0f3048ad", size = 445523, upload-time = "2025-10-09T07:08:01.16Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/aa/9c42061860892def750a5f5eb0a1894999db370f441a73a52b8b22ce8ea0/regress-2025.10.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:63503a8f601a10e5d9d72ea6efb415a2838a4766736775322578ce5fe18cb233", size = 434820, upload-time = "2025-10-09T07:08:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/4d/e460b2a8d2fe5bfe03658b0fa7b34fb2a4f38fe699b7d818838950b0377c/regress-2025.10.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28941c80252119ef051ad67195fa8d155a0c8dc9ecb801786d94eeea6738e4c3", size = 514909, upload-time = "2025-10-09T07:08:03.696Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e2/fa4fa358b4958fc9bcdd4037e04af26878a2dadd2be6fd21e8d78ecf0ea7/regress-2025.10.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6d26daee7d46905c8d4232f44c39ea788f10d39c166735177f603783b4ace4e8", size = 497159, upload-time = "2025-10-09T07:08:05.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6a/5f084ab9ceade680d3a55cc195fd8aa2f458e1e7b310ba79a937e31a8511/regress-2025.10.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f0599f9cb12722300b6d4fcd6bd9b2be5bf233bc567c3ca503d8e392de23798a", size = 674601, upload-time = "2025-10-09T07:08:05.946Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/80/87f041edee9ecd50867789f053efa4888eefaab6d5c3996d6b8257dfd18b/regress-2025.10.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:46b92e1ec6092e6e989e4ad5f52f0a358e88355f70cf4dba9abce84f3cd513cf", size = 575664, upload-time = "2025-10-09T07:08:06.942Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/66/312bd179376c6cf9aab285a0c709eb3241c649a1d7ec256d34c4e7a453e7/regress-2025.10.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ac0e197c7f1b5ffca42341518b6a03e2ea3cdd66516af9278492d2d2bfc9ce2", size = 508055, upload-time = "2025-10-09T07:08:07.91Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/68/c69c6fb053de81c8f0f5d702706c4237bd021c67be977ba03f770db2579f/regress-2025.10.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:05e6c68021dff89fee7bcdab25e0819cff4c7f0761dc41f0fb609b0e9ebb6272", size = 520794, upload-time = "2025-10-09T07:08:08.973Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/47/66845b8f71a3cbdc545a324bf2083fbc84fee728690f561dd85ba9dedb25/regress-2025.10.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:39600db4e404155168d6f75c3dbb2ae03ef3e288b4a57c7a6562a1144bf07682", size = 695537, upload-time = "2025-10-09T07:08:09.946Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a4/c389c1b0ab16d33755f3b58c34ba92c9991e1fca31e5e3e608baa04b2f47/regress-2025.10.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d48e91d14a366570685f76adaf9d108e3abc5522572e7e1d0d78c3cc3ebf0833", size = 695148, upload-time = "2025-10-09T07:08:11.668Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ec/ae94eb4dd93a18be022fa72a88ca73f5f3cfd78f077afdb40b66e2139db9/regress-2025.10.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ce4e38ada2a39159d8a2523084e2b5ed94b3f7f7b196ba6b99c2d6c4ff634a87", size = 690997, upload-time = "2025-10-09T07:08:12.812Z" },
+    { url = "https://files.pythonhosted.org/packages/42/1f/669280d98640568d1012e1b77178eb75b3ceb468c9bc50058529a90f42f5/regress-2025.10.1-cp312-cp312-win32.whl", hash = "sha256:c35c8cd42900d9195e5bf48d701dda28c204854fba7cc27d18f309745f57b8b5", size = 282521, upload-time = "2025-10-09T07:08:13.922Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/d77a57e89ace8fd0b6acb124dfefd536e8e696103cba21956050f09b69a4/regress-2025.10.1-cp312-cp312-win_amd64.whl", hash = "sha256:089b6c5f0965962e8046493e5a1222a24e88d6f235fa8fe2424ec869e6ff613c", size = 301556, upload-time = "2025-10-09T07:08:14.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ce/a0e08ff0f36d6106152b33148a087c77f6cbb649863440447b1cdfd393d1/regress-2025.10.1-cp312-cp312-win_arm64.whl", hash = "sha256:469b03b1deffb6d20ea4f95aa44ef0e0e5a9b47d56f709276b06a96338b570a0", size = 288571, upload-time = "2025-10-09T07:08:15.772Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/bd/f7ff13577c688efec36488554489635c135ab7c2b3652c00aaa3d74bd761/regress-2025.10.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9100da34f69e18ad6d545f5d74f8ee729e42ce200a73752dd6d94f8a373d0e71", size = 445469, upload-time = "2025-10-09T07:08:16.825Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3d/e8fc72e7424c168dfc4cdf3a864f189f6d3afbb6e3ed66455774d1f5e2ba/regress-2025.10.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9e25096697b034848d8fc7910cdb38b7abc2bd2d7ade8767893359918ed4efd0", size = 434712, upload-time = "2025-10-09T07:08:17.817Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d0/a18cc39008765d2b964bc2eba423416545d97b4f2623b99549c5e97e4d37/regress-2025.10.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c4c40a8c9f3e0119d2384a52b55dcc770461e1ead6ae7b41314999223116a15", size = 514752, upload-time = "2025-10-09T07:08:19.148Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/11/57e64ba417867b39ad9ca55feaea80d3176735dba36e6a92ff21b8224fcb/regress-2025.10.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25d8518285aa3ce67ddbede90a1a9ca6a5d23a1b8275dd5a9722af0c64b37b2a", size = 497412, upload-time = "2025-10-09T07:08:20.448Z" },
+    { url = "https://files.pythonhosted.org/packages/72/6c/2fd3d3877c1957408548f7a380580f0b64ef8aff69f7fc2cc182a79b0b0b/regress-2025.10.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8051fac3696730bb84d7675c62c7073792a0e105233d4f8e1055f2cab9b04fce", size = 676998, upload-time = "2025-10-09T07:08:21.881Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/54/acde146473453f3acb5dd29e5be0fb627d87ad020ec5674ee133cde24261/regress-2025.10.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8e337ce3b150ca0ff599b1150b995ff6a2e32b5940e17ac3f30a29133960709e", size = 576129, upload-time = "2025-10-09T07:08:23.354Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b0/8007436b33496ec8f10d7b7a67a7a669569c82fc2a182d4f928ab4fd11da/regress-2025.10.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:290a15652c3fafe387db02061d4ed9a100804ed5a162d069b5a0ac28b5df162a", size = 507510, upload-time = "2025-10-09T07:08:24.34Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9e/6ac6cd1de7e34e34cb492df627847de0d01cee982c7dd7d100e67cf1aa93/regress-2025.10.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b4bc2008b59e5124c1672d7fd9f203e5d4a4ff88ebaf4666e3281141e2d8db20", size = 520595, upload-time = "2025-10-09T07:08:25.35Z" },
+    { url = "https://files.pythonhosted.org/packages/11/26/35556d1dd6f64122a16166db7651d1a5804edebea9835cbcd452d9b7c2ff/regress-2025.10.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:56ef2f8ef9a102a7d42cbbc2f3c0c5e1b186bd8eaa78d564da566b0bf20653dc", size = 695584, upload-time = "2025-10-09T07:08:26.52Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/33/07650dfc042b55270fc269276112c592d458cdfb8d31c85447ff743dcf10/regress-2025.10.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:0680ac0b0a0058acb55b64aa56956732cf56b0baa84ea95e3fa124ab16da58aa", size = 695277, upload-time = "2025-10-09T07:08:27.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6b/80f446103df39fc1ce6e271e7c274687bb830402de23e68795ba2ab13214/regress-2025.10.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47c03bfd853651241fc11436fb14ef7c9b312bb9a9c2828aa5c93943e945f1ef", size = 690951, upload-time = "2025-10-09T07:08:29.295Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/10/43cd990934ddb2be3318380fa380f7ca19e0eda0c30793b73e8ab8839367/regress-2025.10.1-cp313-cp313-win32.whl", hash = "sha256:3d12e6a834ed5f6d9dc7e86ea8fd77d37bb13900129930151d87c3261c3a799e", size = 282592, upload-time = "2025-10-09T07:08:30.695Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/22/4855af0447c98793d3a406ddf42680736e700b8c78336d6199dff9a5fd1b/regress-2025.10.1-cp313-cp313-win_amd64.whl", hash = "sha256:ee3b7325ea849097d674020c72b2e6deb8f1018f085a7ecbd22831cd217b7f80", size = 301551, upload-time = "2025-10-09T07:08:31.715Z" },
+    { url = "https://files.pythonhosted.org/packages/82/99/cd16dce5d1cb98970a8d7c577529e5890d938b54ade223d532fad0343221/regress-2025.10.1-cp313-cp313-win_arm64.whl", hash = "sha256:e5f35e04fe6382c236d60c98b3f0a4a22dea75398b99c9c9bf3fb9d386cd7ebb", size = 288909, upload-time = "2025-10-09T07:08:32.605Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/32/35dbbdff29174dcc253bb00b2a0d2aaf3f47a2b1d174ab4ab828feca63f1/regress-2025.10.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:0ee12c4e1c4e6e3609f41dd58065bc241945e912772f7320238d6544f0745950", size = 444440, upload-time = "2025-10-09T07:08:33.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/1b/d97cf19b3de5ff8d78d03e0c470af48f7e8b6814b197014fda3f8a3aaca5/regress-2025.10.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:389c2278848cbfed81753a04ce8ea6c037271179cb9ef4decac7d3c65ae3330b", size = 434626, upload-time = "2025-10-09T07:08:34.75Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f1/c0900448a4fd6248cd05c04c83aebb31f22ba3886965a5667f6ac4edc2b0/regress-2025.10.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf743b00cac20f8e8d271f275df7bc192ebb4faa7aee8fe98484df338786dec6", size = 514470, upload-time = "2025-10-09T07:08:35.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/a1/6346a314230af2859d2f0af5c4534ee497b9b13983ee06489652d7e1895b/regress-2025.10.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5541da1f581377bc20d2f77e017453aa8f2c2f4bfe7679dee00e139ec700abe8", size = 497546, upload-time = "2025-10-09T07:08:36.739Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ff/09605137dff09594c9e12ce555a80d8405a6ad76faa1db702bfba57468d0/regress-2025.10.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a67216efa72bb27db170f637d67eb9acdc167da5d617163b057803de7aed1e6d", size = 676318, upload-time = "2025-10-09T07:08:37.72Z" },
+    { url = "https://files.pythonhosted.org/packages/26/37/4a65635c18844d687f9ad5bdd79b72fac8d15b131264616d6b1bb52614c2/regress-2025.10.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fb61e653a325aea4681cf7b96ba9bbabc1aeb3f3d8fe877a07800024907398b9", size = 576190, upload-time = "2025-10-09T07:08:38.782Z" },
+    { url = "https://files.pythonhosted.org/packages/93/87/90a0a77a0416d7e3255e606f848021949b2f53ca18c9e4e240edb42e0929/regress-2025.10.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2a0a7da1d42fdff8068ab976a66beea572621514a130b37592489ae134a0e27", size = 507768, upload-time = "2025-10-09T07:08:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/82c8147027f0012dd7e743267d60dcf4218b2e061825b89cddddaa7fbe49/regress-2025.10.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:337ef62f785dc6e05c4a09be7a902980cf4d4f15346f4eca9eaf02745485440c", size = 520555, upload-time = "2025-10-09T07:08:40.801Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ce/5dd5dda048173b644a475ae9f4643733b31c3543e861569af4257c60d32a/regress-2025.10.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:aaf5d102e05b109dde13363e705969b3ffdbbfeb880270187eed0871e75f0c8f", size = 695587, upload-time = "2025-10-09T07:08:42.136Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/08/7f6615d8ce3088feb82843ff4d48191600602d624021dbef797d274a043d/regress-2025.10.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:adf331c8938e0d8705fc5d05d08fab09c11cb4bcdf8a64fa21902972c4cd38f4", size = 694933, upload-time = "2025-10-09T07:08:43.171Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/94524b996745f892b30dec6e770701956f7125459c6a6b2c075af4b8f0a6/regress-2025.10.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:287f86b5c0bf3bc9c0abd45bf6745ba9c6a5624c3132b07631bac4403b45143f", size = 691029, upload-time = "2025-10-09T07:08:44.369Z" },
+    { url = "https://files.pythonhosted.org/packages/64/e1/612c3b8afa448747e9133a95b1e18d0ee8f3f5e930f7048d1af03976f883/regress-2025.10.1-cp313-cp313t-win32.whl", hash = "sha256:877e05e7c570ee1e077e8b587cca8a318b7675f3c94c6c4e25d0d145abf7c0b6", size = 282136, upload-time = "2025-10-09T07:08:45.477Z" },
+    { url = "https://files.pythonhosted.org/packages/51/1d/9d5a476a6b16a41e724e864afb834947323bfa4b309978dbdc2bf8dbdb02/regress-2025.10.1-cp313-cp313t-win_amd64.whl", hash = "sha256:97307f87b128389d8b3f385c8e431fc318263281d1a1c0394606bc813aea05fc", size = 301674, upload-time = "2025-10-09T07:08:46.513Z" },
+    { url = "https://files.pythonhosted.org/packages/63/a0/49e86facc015003db16ff9e6ce5086e843b45a19f4e0e34ce59e6d6c2d81/regress-2025.10.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:56123dbe783a2bab04d1a1850605c483d40f36196bc52d249aa245d06f866f78", size = 444793, upload-time = "2025-10-09T07:08:47.867Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3f/2873d64a063d33f721ffa66f2543ef5a5482a0e8d69d700e28e8e40e1ae6/regress-2025.10.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8405a31f0a1475e1c9aa20c4d6e1465ef2f7259581c018a2e273083494ca9a61", size = 434881, upload-time = "2025-10-09T07:08:49.192Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/69/7179ca674432677db0060c49fc79a1816b7585e5ba10cfc546251a362d35/regress-2025.10.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:12430b2c7263a7b359d30dd0f2b179426d489df30da78cd21023376eb2fe2682", size = 514673, upload-time = "2025-10-09T07:08:50.203Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/de/2f35d611ee0223001c2b3ffe80ae4509dc8d082171d60046db179fada84e/regress-2025.10.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7ecba827aff7f951db40be777c32608a1b16bbeb7f02fcc97a2e9fc6702641f", size = 498108, upload-time = "2025-10-09T07:08:51.304Z" },
+    { url = "https://files.pythonhosted.org/packages/97/82/6f1762b94810e55ab179a4ec2f804f5b8af152c3fb8d348fee7642437e29/regress-2025.10.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:293be370961c6887efb82e466a15523ff24a702d444f44917ce318b222ffd229", size = 676532, upload-time = "2025-10-09T07:08:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/06/46/c24aa9299b9706cf39422b48ba6cbba20e2826b3850f3d2a1b6d2865b1b1/regress-2025.10.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:783b9c50760aab988e4d60dcb7c54eba3fe730d80f9a877f1dc52d14263f86b1", size = 576455, upload-time = "2025-10-09T07:08:53.637Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a7/e13517b6388d058406e69387045797d3b4358c44f8dd37a457f4714123eb/regress-2025.10.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ed3b4d0df960aeccb685f8de5001c19f426f1ab09fde715e5abdbf9c59b26a", size = 506859, upload-time = "2025-10-09T07:08:54.557Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/a5/52b57c409586809402595f1b7938826cc84fb9983be1fa7bbdce14026613/regress-2025.10.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:08e99c44e4c3860352400af96b25a4ebb673c16d53c6367153631ec77d5130b8", size = 520546, upload-time = "2025-10-09T07:08:55.56Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/5f/e46311b2452d0419aeca10df5c16ae554f82ba8d21a9cc854ed225ea4a49/regress-2025.10.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6b52096ecbf39f50756e51efa9286f47c598572f6b8bb2119f855de817f38b8e", size = 695829, upload-time = "2025-10-09T07:08:56.543Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/6f/fd52382dcd315594cd5ec74bb436a5ca6a6376e5f205b9711c1e2abc4e4c/regress-2025.10.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:b99a73cfbdc5d99681aeb3aeaa2d88369023c96648cc785433d6a92c8d3a8394", size = 695324, upload-time = "2025-10-09T07:08:57.572Z" },
+    { url = "https://files.pythonhosted.org/packages/75/88/61ad735f401d0b9b043c52e4cea95bff10584894351c878eeb52e34e01e1/regress-2025.10.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:05d02b4d7179b85acf28d7329a488901d6baef5f5b337dcd52f53ea0ff980bc3", size = 691245, upload-time = "2025-10-09T07:08:58.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/10/26f42441c7d3aaa68af23520d298475e19338bf087bae2d687d911869036/regress-2025.10.1-cp314-cp314-win32.whl", hash = "sha256:e7cc153fabb47b6f8dfc2903186934e07aa57ee1debe9b3569ac4779b43708ae", size = 282612, upload-time = "2025-10-09T07:08:59.898Z" },
+    { url = "https://files.pythonhosted.org/packages/66/18/ecbc4b30960988fde96f0e36fdd59d687af734befc013a03395c519ae46b/regress-2025.10.1-cp314-cp314-win_amd64.whl", hash = "sha256:102c4627f026db8d361ab61155e0f1093176555d60ddb1cc4c9b6f5bbe255c1f", size = 301416, upload-time = "2025-10-09T07:09:00.805Z" },
+    { url = "https://files.pythonhosted.org/packages/53/05/0f5b750f65428b00e8b90af33935f667dad267ea0e9493aef993e307b60b/regress-2025.10.1-cp314-cp314-win_arm64.whl", hash = "sha256:e5c441a6017a5a29bb38c573892d882485cc26937cb1ee12da8593723bf6c041", size = 288347, upload-time = "2025-10-09T07:09:02.07Z" },
+    { url = "https://files.pythonhosted.org/packages/88/43/33a2ec3342919ff5516e4eec66ae01fd3dea8ff51c86f8746a8f34211dc9/regress-2025.10.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:77d63b338c2a4e56b4f05632d3fd94061ad47ee2b272b158b9c2e09545a4c6bb", size = 444092, upload-time = "2025-10-09T07:09:03.088Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/30/2f5d12fa93215fe914eaa0ce3bb7f184d9b4460ba9cf4bb6ad17bd40418a/regress-2025.10.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:722c408a3bc92b4904005e68244c28fa6df943290df8d670faf349414c86aabb", size = 434309, upload-time = "2025-10-09T07:09:04.503Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/19/6c76d2a5617c7980c752ea3b6152f070a9c708e789032e3219377743556a/regress-2025.10.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3afe24e6474f5dbc448f865641c29bcbed4eb3b87ac9eb0e6755c4eff4f7111", size = 514890, upload-time = "2025-10-09T07:09:05.488Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/d3/04cede3329ce180477856b56875bdf5c51936584fe1e8717f2f5b80ce5b9/regress-2025.10.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9fdbbea49bf2fe65f7272b0316e1343aff1ccbb85b58fab325778c416d648ed9", size = 496277, upload-time = "2025-10-09T07:09:10.062Z" },
+    { url = "https://files.pythonhosted.org/packages/16/9c/2954a87ea2bd6c75506233242a7b0a1e68553b07772b72d6acc7b08e0f9a/regress-2025.10.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6d451a88292c5a93f57cf754c71b3aa8b570ed159f9fd481554948c467e6105d", size = 677710, upload-time = "2025-10-09T07:09:11.054Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/47/199000108d39b40339532d2e6d9e0188cb747da8478cd697cf57ab7d9411/regress-2025.10.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a97649f21c875b7e95e10a59f0f487a518735f51a7aec7fc95fb2c3d9a3914d5", size = 575255, upload-time = "2025-10-09T07:09:12.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/49/84e96203933feffb1e77f6553e82684501a34e144f64c50113f7c2228fde/regress-2025.10.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a542e38c8bb95f618674a5d2d248f1010547d7ff2e46a6cf4fa4b851459ba440", size = 507535, upload-time = "2025-10-09T07:09:13.408Z" },
+    { url = "https://files.pythonhosted.org/packages/47/0d/e368ef1b8d3d19633d49cf35c48154fd382da643246c3ad58d63a1053f45/regress-2025.10.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:933561ea90b2ac9a826e956a994b8a66635cd96467374281da992ceea8b0de4c", size = 520011, upload-time = "2025-10-09T07:09:14.546Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/25/6a1c13a7a18444cfedcef80a5727d3feae2055214d228e7847a647431e77/regress-2025.10.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b6b5aa9f9408fdf260c73071282a28d29efbb4c30a4b95ab29863bea31987621", size = 695675, upload-time = "2025-10-09T07:09:15.983Z" },
+    { url = "https://files.pythonhosted.org/packages/89/7c/2000eadccfc762da29004b192f1c15e2d026d0b6dd5fb0ff3f5f06cfd216/regress-2025.10.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:afee501f000666afe18531132edcaf0dc0178dd591cccf5b9596563e7456c118", size = 694358, upload-time = "2025-10-09T07:09:16.98Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5a/5743b01774c8c438811e357d79fdce4be7729a59e72f28f4b2df0379784e/regress-2025.10.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4d0bf23a6d996655ed88c822bb0123cc2e92a1df95079ce7408552c35ec05d47", size = 691223, upload-time = "2025-10-09T07:09:18.467Z" },
+    { url = "https://files.pythonhosted.org/packages/47/03/8f99f04fa8fa307c343285f8630537ad493a78754c273de7427c084dc5b1/regress-2025.10.1-cp314-cp314t-win32.whl", hash = "sha256:adaa80c97927d623ff72b920bcc637568f124eabe84559c7927a91253ff55d5e", size = 281997, upload-time = "2025-10-09T07:09:19.51Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/7e/e65462387ffd8f67ffea40482d55655a89b9088f258def3824007e6b7c74/regress-2025.10.1-cp314-cp314t-win_amd64.whl", hash = "sha256:6553c8ba57fa92ab3e9ef5c811d6214c80131bba06496bd5920e6e5a3d53ca8e", size = 301375, upload-time = "2025-10-09T07:09:20.431Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1752,6 +1887,96 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Phase 1 of architecture restructuring (R1, R7): introduces GitLab-centric config v2 schema and typed AppContext replacing the `app.state` service locator pattern.

## Why

- **Config coupling**: Current config is Jira-keyed (`mapping_models.py`) — projects without Jira cannot be configured
- **Service locator antipattern**: 10 untyped `getattr(app.state, ...)` calls across webhook/main with no compile-time safety
- **Stale identity cache**: `credential_registry` cached identities forever; `gitlab_poller` had a duplicate cache

## Changes

### New modules
- **`config_v2.py`** — 12 Pydantic models for GitLab-centric YAML config (`ConfigFile`, `ProjectConfig`, `IntegrationConfig`, etc.), `load_config_file()`, S10 marketplace URL audit logging, I2 `webhook_ip_allowlist`/`trusted_proxies` fields
- **`container.py`** — Frozen `AppContext` dataclass with `get_services()` FastAPI dependency. Immutable services in container; mutable state (`project_registry`, pollers) stays on `app.state` for hot-reload support
- **`config.example.yaml`** — Documented example config

### Refactored modules
- **`main.py`** — Lifespan builds `AppContext`, stashes as `app.state.container`
- **`webhook.py`** — All `getattr(app.state, ...)` replaced with `get_services(request)`
- **`credential_registry.py`** — Added `identity_cache_ttl` (S7, default 1hr, `time.monotonic()`)
- **`gitlab_poller.py`** — Added `poll_interval` constructor param (removes `_interval` private mutation); removed duplicate `_identity_cache` (credential_registry is now single cache owner)
- **`project_registry.py`** — `jira_project` made optional (`str | None`); added `from_config()` classmethod for v2 config; kept `from_rendered_map()` for backward compat
- **`mapping_cli.py`** — Added `schema` and `validate-v2` subcommands

### Tests
- 44 new tests across `test_config_v2.py`, `test_container.py`, `test_mapping_cli.py`, `test_project_registry.py`
- Updated `conftest.py` with `make_container()` factory
- Updated `test_webhook.py`, `test_main.py`, `test_multi_credential_integration.py` for AppContext

## Validation

- **Lint**: ratchet improved 167 → 163 violations; pyright strict clean
- **Tests**: 825 passed, 97% coverage (1 pre-existing failure in `test_config.py`)
- **Code review**: GPT-5.1 cross-vendor — no issues
- **OWASP review**: All 11 categories pass

## Related issues

Closes architectural recommendations R1 (Typed AppContext) and R7 (GitLab-centric config)
