### PR TITLE
refactor(client): rewrite GitLabClient and credential_registry with httpx

### DIFF
--- a/.lint-baseline.json
+++ b/.lint-baseline.json
@@ -19,16 +19,12 @@
     "D105": 4,
     "TC003": 1
   },
-  "src/gitlab_copilot_agent/credential_registry.py": {
-    "RUF003": 1
-  },
   "src/gitlab_copilot_agent/discussion_orchestrator.py": {
     "TC001": 4,
     "TC003": 1
   },
   "src/gitlab_copilot_agent/gitlab_client.py": {
-    "D101": 2,
-    "D102": 17,
+    "D102": 15,
     "TC003": 1
   },
   "src/gitlab_copilot_agent/gitlab_poller.py": {

--- a/docs/wiki/module-reference.md
+++ b/docs/wiki/module-reference.md
@@ -361,7 +361,7 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 ## External Service Clients
 
 ### `gitlab_client.py`
-**Purpose**: GitLab API client for repo cloning, diff fetching, and MR metadata.
+**Purpose**: Async GitLab REST API client using httpx — fully typed, with retry and pagination.
 
 **Key Models**:
 - `MRAuthor`: id, username
@@ -377,23 +377,28 @@ All modules in `src/gitlab_copilot_agent/`, organized by architectural layer.
 
 **Key Classes**:
 - `GitLabClient`:
-  - `__init__(url: str, token: str)`: Initialize python-gitlab client
-  - `get_mr_details(project_id: int, mr_iid: int) -> MRDetails`: Fetch MR changes and diff refs
-  - `clone_repo(clone_url: str, branch: str, token: str, clone_dir: str | None) -> Path`: Clone repo via git_operations
-  - `cleanup(repo_path: Path) -> None`: Remove cloned repo
+  - `__init__(url: str, token: str)`: Initialize httpx async client with PRIVATE-TOKEN header
+  - `aclose() -> None`: Close the underlying httpx client
+  - `__aenter__`/`__aexit__`: Async context manager support
+  - `_request(method, path, *, idempotent, **kwargs) -> Response`: HTTP request with retry on 429/5xx for idempotent (GET) requests; respects `Retry-After` header
+  - `_paginate(path, params) -> list[dict]`: Fetch all pages of a paginated endpoint
+  - `get_mr_details(project_id, mr_iid) -> MRDetails`: Fetch MR changes; retries on null diff_refs (GitLab race)
+  - `clone_repo(clone_url, branch, token, clone_dir) -> Path`: Clone repo via git_operations
+  - `cleanup(repo_path) -> None`: Remove cloned repo
   - `create_merge_request(...) -> int`: Create MR, return iid
-  - `post_mr_comment(project_id: int, mr_iid: int, body: str) -> None`: Post MR note
-  - `list_project_mrs(project_id: int, state: str, updated_after: str | None) -> list[MRListItem]`: List MRs
-  - `list_mr_notes(project_id: int, mr_iid: int, created_after: str | None) -> list[NoteListItem]`: List notes
-  - `resolve_project(id_or_path: str | int) -> int`: Resolve project ID
-  - `list_mr_discussions(project_id: int, mr_iid: int) -> list[Discussion]`: List MR discussions with notes and resolution status
-  - `get_current_user() -> AgentIdentity`: Discover authenticated user identity
-  - `resolve_discussion(project_id: int, mr_iid: int, discussion_id: str) -> None`: Resolve a discussion thread (sets resolved=True)
-  - `reply_to_discussion(project_id: int, mr_iid: int, discussion_id: str, body: str) -> None`: Post a reply to an existing discussion thread
-  - `compare_commits(project_id: int, from_sha: str, to_sha: str) -> list[MRChange]`: Compare two commits via the Repository Compare API. Returns file changes between SHAs in MRChange format for incremental diff computation
-  - `get_mr_commits(project_id: int, mr_iid: int) -> list[MRCommit]`: Fetch commits on a merge request for developer intent context
+  - `post_mr_comment(project_id, mr_iid, body) -> None`: Post MR note
+  - `create_mr_discussion(project_id, mr_iid, body, position) -> None`: Create inline discussion on diff
+  - `list_project_mrs(project_id, state, updated_after) -> list[MRListItem]`: List MRs (paginated)
+  - `list_mr_notes(project_id, mr_iid, created_after) -> list[NoteListItem]`: List notes (paginated)
+  - `resolve_project(id_or_path) -> int`: Resolve project ID (URL-encodes paths)
+  - `list_mr_discussions(project_id, mr_iid) -> list[Discussion]`: List discussions (paginated)
+  - `get_current_user() -> AgentIdentity`: GET /user for authenticated identity
+  - `resolve_discussion(project_id, mr_iid, discussion_id) -> None`: PUT to resolve a thread
+  - `reply_to_discussion(project_id, mr_iid, discussion_id, body) -> None`: POST reply to thread
+  - `compare_commits(project_id, from_sha, to_sha) -> list[MRChange]`: Compare two commits
+  - `get_mr_commits(project_id, mr_iid) -> list[MRCommit]`: Fetch MR commits (paginated)
 
-**Internal Imports**: `git_operations`
+**Internal Imports**: `git_operations`, `discussion_models`
 
 **Depended On By**: `orchestrator.py`, `coding_orchestrator.py`, `gitlab_poller.py`, `main.py`
 
@@ -642,12 +647,12 @@ All use `frozen=True` config.
 ---
 
 ### `credential_registry.py`
-**Purpose**: Resolve credential aliases to GitLab tokens from environment. TTL-cached identity resolution.
+**Purpose**: Resolve credential aliases to GitLab tokens from environment. TTL-cached identity resolution via httpx.
 
 **Key Methods**:
 - `from_env() -> CredentialRegistry`: Reads `GITLAB_TOKEN` + `GITLAB_TOKEN__<ALIAS>` env vars
 - `resolve(credential_ref: str) -> str`: Returns token for alias, raises `KeyError` if unknown
-- `resolve_identity(credential_ref: str, gitlab_url: str) -> AgentIdentity`: TTL-cached identity lookup (default 1hr, `time.monotonic()`)
+- `resolve_identity(credential_ref: str, gitlab_url: str) -> AgentIdentity`: TTL-cached identity lookup (default 1hr, `time.monotonic()`). Uses httpx `GET /api/v4/user`.
 
 **Depended On By**: `project_registry.py`, `main.py`, `gitlab_poller.py`
 

--- a/src/gitlab_copilot_agent/credential_registry.py
+++ b/src/gitlab_copilot_agent/credential_registry.py
@@ -17,7 +17,7 @@ import os
 import re
 import time
 
-import gitlab
+import httpx
 import structlog
 
 from gitlab_copilot_agent.discussion_models import AgentIdentity
@@ -139,16 +139,11 @@ class CredentialRegistry:
 async def _fetch_identity(gitlab_url: str, token: str) -> AgentIdentity:
     """Authenticate against GitLab and return the caller's identity.
 
-    Uses :func:`asyncio.to_thread` because python-gitlab is synchronous.
+    Uses a one-shot httpx request to ``GET /api/v4/user``.
     """
-
-    def _sync_auth() -> AgentIdentity:
-        gl = gitlab.Gitlab(gitlab_url, private_token=token)
-        gl.auth()
-        user = gl.user
-        if user is None:  # pragma: no cover – defensive
-            msg = "gl.auth() succeeded but gl.user is None"
-            raise RuntimeError(msg)
-        return AgentIdentity(user_id=user.id, username=user.username)
-
-    return await asyncio.to_thread(_sync_auth)
+    url = f"{gitlab_url.rstrip('/')}/api/v4/user"
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.get(url, headers={"PRIVATE-TOKEN": token})
+        resp.raise_for_status()
+    data = resp.json()
+    return AgentIdentity(user_id=data["id"], username=data["username"])

--- a/src/gitlab_copilot_agent/gitlab_client.py
+++ b/src/gitlab_copilot_agent/gitlab_client.py
@@ -1,18 +1,32 @@
-"""GitLab API client for repo cloning, diff fetching, and MR metadata."""
+"""GitLab API client — async httpx-based, fully typed.
+
+Replaces the previous python-gitlab wrapper.  All API calls are natively
+async via httpx — no ``asyncio.to_thread`` overhead.  Transient failures
+(HTTP 429, 5xx, transport errors) are retried with exponential backoff
+for idempotent (GET) requests only.
+"""
 
 from __future__ import annotations
 
 import asyncio
+import shutil
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol  # Any: unvalidated JSON from resp.json()
+from urllib.parse import quote
 
-import gitlab
+import httpx
 import structlog
 from pydantic import BaseModel, ConfigDict, Field
 
 from gitlab_copilot_agent.discussion_models import AgentIdentity, Discussion, DiscussionNote
 
 log = structlog.get_logger()
+
+_DEFAULT_TIMEOUT = 30.0
+_MAX_RETRIES = 3
+_RETRY_BACKOFF = 1.0
+_DIFF_REFS_MAX_RETRIES = 5
+_PAGE_SIZE = 100
 
 
 class MRAuthor(BaseModel):
@@ -93,6 +107,8 @@ class MRCommit(BaseModel):
 
 
 class GitLabClientProtocol(Protocol):
+    """Protocol for GitLab API operations used throughout the codebase."""
+
     async def get_mr_details(self, project_id: int, mr_iid: int) -> MRDetails: ...
     async def clone_repo(self, clone_url: str, branch: str, token: str) -> Path: ...
     async def cleanup(self, repo_path: Path) -> None: ...
@@ -119,67 +135,275 @@ class GitLabClientProtocol(Protocol):
         self, project_id: int, from_sha: str, to_sha: str
     ) -> list[MRChange]: ...
     async def get_mr_commits(self, project_id: int, mr_iid: int) -> list[MRCommit]: ...
+    async def create_mr_discussion(
+        self, project_id: int, mr_iid: int, body: str, position: dict[str, object]
+    ) -> None: ...
 
 
 class GitLabClient:
+    """Async GitLab REST API client using httpx.
+
+    All API calls use async httpx directly — no python-gitlab dependency.
+    Retries transient failures (429, 5xx) with exponential backoff for
+    idempotent GET requests only.  Mutating calls (POST/PUT) are *not*
+    retried on server errors to avoid duplicate side-effects.
+
+    Args:
+        url: GitLab instance base URL (e.g. ``https://gitlab.example.com``).
+        token: GitLab private access token.
+    """
+
     def __init__(self, url: str, token: str) -> None:
-        self._gl = gitlab.Gitlab(url, private_token=token)
+        self._base_url = url.rstrip("/")
+        self._client = httpx.AsyncClient(
+            base_url=f"{self._base_url}/api/v4",
+            headers={"PRIVATE-TOKEN": token},
+            timeout=_DEFAULT_TIMEOUT,
+        )
         self._token = token
 
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+
+    async def __aenter__(self) -> GitLabClient:
+        """Enter async context manager."""
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        """Exit async context manager and close the HTTP client."""
+        await self.aclose()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        idempotent: bool | None = None,
+        json: object | None = None,
+        params: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        """Make an API request, retrying transient errors for safe methods.
+
+        Args:
+            method: HTTP method (GET, POST, PUT, DELETE).
+            path: API path relative to ``/api/v4``.
+            idempotent: Override retry eligibility.  Defaults to ``True``
+                for GET/HEAD, ``False`` otherwise.
+            json: JSON request body (for POST/PUT).
+            params: Query parameters.
+
+        Returns:
+            The successful ``httpx.Response``.
+
+        Raises:
+            httpx.HTTPStatusError: On non-retryable HTTP errors.
+            httpx.TransportError: When all retries are exhausted.
+        """
+        can_retry = idempotent if idempotent is not None else method.upper() in ("GET", "HEAD")
+        max_attempts = _MAX_RETRIES if can_retry else 1
+        last_exc: Exception | None = None
+
+        for attempt in range(max_attempts):
+            try:
+                resp = await self._client.request(method, path, json=json, params=params)
+                if (
+                    resp.status_code == 429 or resp.status_code >= 500
+                ) and attempt < max_attempts - 1:
+                    delay = _retry_delay(resp, attempt)
+                    log.warning(
+                        "gitlab_api_retry",
+                        status=resp.status_code,
+                        attempt=attempt,
+                        delay=delay,
+                        path=path,
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                resp.raise_for_status()
+                return resp
+            except httpx.TransportError as exc:
+                last_exc = exc
+                if attempt < max_attempts - 1:
+                    delay = _RETRY_BACKOFF * (2**attempt)
+                    log.warning(
+                        "gitlab_transport_retry",
+                        attempt=attempt,
+                        delay=delay,
+                        error=str(exc),
+                    )
+                    await asyncio.sleep(delay)
+        if last_exc is not None:
+            raise last_exc
+        raise RuntimeError("Request failed after retries")  # pragma: no cover
+
+    async def _paginate(
+        self,
+        path: str,
+        params: dict[str, str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Fetch all pages of a paginated GitLab API endpoint.
+
+        Args:
+            path: API path relative to ``/api/v4``.
+            params: Query parameters (``per_page`` is added automatically).
+
+        Returns:
+            Concatenated list of JSON objects from all pages.
+        """
+        all_items: list[dict[str, Any]] = []
+        page_params: dict[str, str] = {**(params or {}), "per_page": str(_PAGE_SIZE)}
+        page = 1
+
+        while True:
+            page_params["page"] = str(page)
+            resp = await self._request("GET", path, params=page_params)
+            items: list[dict[str, Any]] = resp.json()
+            if not items:
+                break
+            all_items.extend(items)
+            if len(items) < _PAGE_SIZE:
+                break
+            page += 1
+
+        return all_items
+
+    # ------------------------------------------------------------------
+    # Project
+    # ------------------------------------------------------------------
+
+    async def resolve_project(self, id_or_path: str | int) -> int:
+        """Resolve a project path or ID to its numeric ID.
+
+        Args:
+            id_or_path: Numeric project ID or ``"group/project"`` path.
+
+        Returns:
+            The numeric project ID.
+        """
+        if isinstance(id_or_path, int):
+            return id_or_path
+        encoded = quote(str(id_or_path), safe="")
+        resp = await self._request("GET", f"/projects/{encoded}")
+        data: dict[str, Any] = resp.json()
+        return int(data["id"])
+
+    # ------------------------------------------------------------------
+    # Merge requests
+    # ------------------------------------------------------------------
+
     async def get_mr_details(self, project_id: int, mr_iid: int) -> MRDetails:
-        def _fetch() -> MRDetails:
-            import time
+        """Fetch MR metadata and file changes.
 
-            project = self._gl.projects.get(project_id)
-            mr = project.mergerequests.get(mr_iid)
+        Retries when ``diff_refs`` is null — a known GitLab race condition
+        on freshly-created MRs where the diff is still being computed.
 
-            # Retry when diff_refs is null (GitLab race on freshly-created MRs)
-            raw_diff_refs: object | None = None
-            changes_data: dict[str, object] = {}
-            for attempt in range(5):
-                changes_data = mr.changes()  # pyright: ignore[reportAssignmentType]
-                raw_diff_refs = changes_data.get("diff_refs")
-                if raw_diff_refs is not None:
-                    break
-                time.sleep(min(2**attempt, 8))
+        Args:
+            project_id: Numeric project ID.
+            mr_iid: Merge request internal ID.
 
-            if raw_diff_refs is None:
-                msg = (
-                    f"diff_refs is null for MR !{mr_iid} in project {project_id} "
-                    f"after retries — GitLab may still be computing the diff"
-                )
-                raise RuntimeError(msg)
-            diff_refs = MRDiffRef.model_validate(raw_diff_refs)
-
-            raw_changes = changes_data.get("changes", [])
-            assert isinstance(raw_changes, list)
-            changes: list[MRChange] = []
-            for c in raw_changes:  # pyright: ignore[reportUnknownVariableType]
-                if isinstance(c, dict):
-                    changes.append(MRChange.model_validate(c))
-
-            raw_desc = changes_data.get("description")
-            return MRDetails(
-                title=str(changes_data.get("title", "")),
-                description=str(raw_desc) if raw_desc is not None else None,
-                diff_refs=diff_refs,
-                changes=changes,
+        Returns:
+            Parsed MR details with diff refs and file changes.
+        """
+        data: dict[str, Any] = {}
+        for attempt in range(_DIFF_REFS_MAX_RETRIES):
+            resp = await self._request(
+                "GET",
+                f"/projects/{project_id}/merge_requests/{mr_iid}/changes",
             )
+            data = resp.json()
+            if data.get("diff_refs") is not None:
+                break
+            if attempt < _DIFF_REFS_MAX_RETRIES - 1:
+                await asyncio.sleep(min(2**attempt, 8))
 
-        return await asyncio.to_thread(_fetch)
+        if data.get("diff_refs") is None:
+            msg = (
+                f"diff_refs is null for MR !{mr_iid} in project {project_id} "
+                f"after retries — GitLab may still be computing the diff"
+            )
+            raise RuntimeError(msg)
 
-    async def clone_repo(
-        self, clone_url: str, branch: str, token: str, *, clone_dir: str | None = None
-    ) -> Path:
-        from gitlab_copilot_agent.git_operations import git_clone
+        diff_refs = MRDiffRef.model_validate(data["diff_refs"])
+        changes = [
+            MRChange.model_validate(c) for c in data.get("changes", []) if isinstance(c, dict)
+        ]
+        raw_desc = data.get("description")
+        return MRDetails(
+            title=str(data.get("title", "")),
+            description=str(raw_desc) if raw_desc is not None else None,
+            diff_refs=diff_refs,
+            changes=changes,
+        )
 
-        return await git_clone(clone_url, branch, token, clone_dir=clone_dir)
+    async def get_mr_commits(self, project_id: int, mr_iid: int) -> list[MRCommit]:
+        """Fetch commits on a merge request for developer intent context.
 
-    async def cleanup(self, repo_path: Path) -> None:
-        import shutil
+        Args:
+            project_id: Numeric project ID.
+            mr_iid: Merge request internal ID.
 
-        await asyncio.to_thread(shutil.rmtree, repo_path, True)
-        await log.ainfo("repo_cleaned", path=str(repo_path))
+        Returns:
+            List of commits on the MR.
+        """
+        items = await self._paginate(
+            f"/projects/{project_id}/merge_requests/{mr_iid}/commits",
+        )
+        return [MRCommit.model_validate(c) for c in items]
+
+    async def list_project_mrs(
+        self,
+        project_id: int,
+        state: str = "opened",
+        updated_after: str | None = None,
+    ) -> list[MRListItem]:
+        """List merge requests for a project.
+
+        Args:
+            project_id: Numeric project ID.
+            state: MR state filter (``opened``, ``merged``, ``closed``, ``all``).
+            updated_after: ISO 8601 timestamp to filter by last update.
+
+        Returns:
+            List of matching merge requests.
+        """
+        params: dict[str, str] = {"state": state}
+        if updated_after is not None:
+            params["updated_after"] = updated_after
+        items = await self._paginate(
+            f"/projects/{project_id}/merge_requests",
+            params=params,
+        )
+        return [MRListItem.model_validate(mr) for mr in items]
+
+    async def list_mr_notes(
+        self,
+        project_id: int,
+        mr_iid: int,
+        created_after: str | None = None,
+    ) -> list[NoteListItem]:
+        """List notes (comments) on a merge request.
+
+        Args:
+            project_id: Numeric project ID.
+            mr_iid: Merge request internal ID.
+            created_after: ISO 8601 timestamp to filter notes.
+
+        Returns:
+            List of notes on the MR.
+        """
+        params: dict[str, str] = {}
+        if created_after is not None:
+            params["created_after"] = created_after
+        items = await self._paginate(
+            f"/projects/{project_id}/merge_requests/{mr_iid}/notes",
+            params=params,
+        )
+        return [NoteListItem.model_validate(n) for n in items]
 
     async def create_merge_request(
         self,
@@ -189,222 +413,279 @@ class GitLabClient:
         title: str,
         description: str,
     ) -> int:
-        """Create a merge request. Returns the MR IID."""
+        """Create a merge request. Returns the MR IID.
 
-        def _create() -> int:
-            project = self._gl.projects.get(project_id)
-            mr = project.mergerequests.create(
-                {
-                    "source_branch": source_branch,
-                    "target_branch": target_branch,
-                    "title": title,
-                    "description": description,
-                }
-            )
-            return mr.iid  # pyright: ignore[reportReturnType]
+        Args:
+            project_id: Numeric project ID.
+            source_branch: Source branch name.
+            target_branch: Target branch name.
+            title: MR title.
+            description: MR description.
 
-        return await asyncio.to_thread(_create)
+        Returns:
+            The IID of the newly created merge request.
+        """
+        resp = await self._request(
+            "POST",
+            f"/projects/{project_id}/merge_requests",
+            json={
+                "source_branch": source_branch,
+                "target_branch": target_branch,
+                "title": title,
+                "description": description,
+            },
+        )
+        data: dict[str, Any] = resp.json()
+        return int(data["iid"])
 
     async def post_mr_comment(self, project_id: int, mr_iid: int, body: str) -> None:
-        """Post a comment on a merge request."""
+        """Post a note (comment) on a merge request.
 
-        def _post() -> None:
-            project = self._gl.projects.get(project_id)
-            mr = project.mergerequests.get(mr_iid)
-            mr.notes.create({"body": body})
+        Args:
+            project_id: Numeric project ID.
+            mr_iid: Merge request internal ID.
+            body: Comment body text.
+        """
+        await self._request(
+            "POST",
+            f"/projects/{project_id}/merge_requests/{mr_iid}/notes",
+            json={"body": body},
+        )
 
-        await asyncio.to_thread(_post)
+    async def create_mr_discussion(
+        self,
+        project_id: int,
+        mr_iid: int,
+        body: str,
+        position: dict[str, object],
+    ) -> None:
+        """Create an inline discussion on a merge request diff.
 
-    async def list_project_mrs(
-        self, project_id: int, state: str = "opened", updated_after: str | None = None
-    ) -> list[MRListItem]:
-        """List merge requests for a project."""
+        Args:
+            project_id: Numeric project ID.
+            mr_iid: Merge request internal ID.
+            body: Discussion body text.
+            position: Diff position dict with ``base_sha``, ``start_sha``,
+                ``head_sha``, ``position_type``, ``old_path``, ``new_path``,
+                ``new_line``.
+        """
+        await self._request(
+            "POST",
+            f"/projects/{project_id}/merge_requests/{mr_iid}/discussions",
+            json={"body": body, "position": position},
+        )
 
-        def _list() -> list[MRListItem]:
-            project = self._gl.projects.get(project_id)
-            if updated_after is not None:
-                mrs = project.mergerequests.list(
-                    state=state, get_all=True, updated_after=updated_after
-                )
-            else:
-                mrs = project.mergerequests.list(state=state, get_all=True)
-            return [MRListItem.model_validate(mr.attributes) for mr in mrs]
-
-        return await asyncio.to_thread(_list)
-
-    async def list_mr_notes(
-        self, project_id: int, mr_iid: int, created_after: str | None = None
-    ) -> list[NoteListItem]:
-        """List notes (comments) on a merge request."""
-
-        def _list() -> list[NoteListItem]:
-            project = self._gl.projects.get(project_id)
-            mr = project.mergerequests.get(mr_iid)
-            if created_after is not None:
-                notes = mr.notes.list(get_all=True, created_after=created_after)
-            else:
-                notes = mr.notes.list(get_all=True)
-            return [NoteListItem.model_validate(n.attributes) for n in notes]
-
-        return await asyncio.to_thread(_list)
-
-    async def resolve_project(self, id_or_path: str | int) -> int:
-        """Resolve a project ID or path to its numeric ID."""
-
-        def _resolve() -> int:
-            project = self._gl.projects.get(id_or_path)
-            return project.id  # pyright: ignore[reportReturnType]
-
-        return await asyncio.to_thread(_resolve)
+    # ------------------------------------------------------------------
+    # Discussions
+    # ------------------------------------------------------------------
 
     async def list_mr_discussions(self, project_id: int, mr_iid: int) -> list[Discussion]:
-        """Fetch all discussions on an MR with thread structure."""
+        """Fetch all discussions on an MR with thread structure.
 
-        def _fetch() -> list[Discussion]:
-            project = self._gl.projects.get(project_id)
-            mr = project.mergerequests.get(mr_iid)
-            raw_discussions = mr.discussions.list(get_all=True)
+        Filters out system notes and extracts inline/position metadata.
 
-            discussions: list[Discussion] = []
-            for raw_disc in raw_discussions:
-                attrs = raw_disc.attributes
-                notes: list[DiscussionNote] = []
-                is_inline = False
+        Args:
+            project_id: Numeric project ID.
+            mr_iid: Merge request internal ID.
 
-                for raw_note in attrs.get("notes", []):
-                    if raw_note.get("system", False):
-                        continue  # Skip system notes
-
-                    note_type = raw_note.get("type")
-                    if note_type == "DiffNote":
-                        is_inline = True
-
-                    position: dict[str, object] | None = None
-                    raw_pos = raw_note.get("position")
-                    if raw_pos and isinstance(raw_pos, dict):
-                        position = {
-                            "new_path": raw_pos.get("new_path"),  # pyright: ignore[reportUnknownMemberType]
-                            "old_path": raw_pos.get("old_path"),  # pyright: ignore[reportUnknownMemberType]
-                            "new_line": raw_pos.get("new_line"),  # pyright: ignore[reportUnknownMemberType]
-                            "old_line": raw_pos.get("old_line"),  # pyright: ignore[reportUnknownMemberType]
-                            "head_sha": raw_pos.get("head_sha"),  # pyright: ignore[reportUnknownMemberType]
-                        }
-
-                    author = raw_note.get("author", {})
-                    raw_resolved_by = raw_note.get("resolved_by")
-                    resolved_by_id: int | None = None
-                    if isinstance(raw_resolved_by, dict):
-                        _rbid = raw_resolved_by.get("id")  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
-                        if isinstance(_rbid, int):
-                            resolved_by_id = _rbid
-                    notes.append(
-                        DiscussionNote(
-                            note_id=raw_note["id"],
-                            author_id=author.get("id", 0),
-                            author_username=author.get("username", ""),
-                            body=raw_note.get("body", ""),
-                            created_at=raw_note.get("created_at", ""),
-                            is_system=False,  # already filtered above
-                            resolved=raw_note.get("resolved"),
-                            resolved_by_id=resolved_by_id,
-                            resolvable=raw_note.get("resolvable", False),
-                            position=position,
-                        )
-                    )
-
-                if not notes:
-                    continue  # All notes were system notes
-
-                # Check resolution at discussion level
-                raw_notes = attrs.get("notes", [])
-                first_note: dict[str, object] = (
-                    raw_notes[0] if raw_notes else {}  # pyright: ignore[reportUnknownMemberType]
-                )
-                is_resolved = bool(first_note.get("resolved", False))
-
-                discussions.append(
-                    Discussion(
-                        discussion_id=attrs["id"],
-                        notes=notes,
-                        is_resolved=is_resolved,
-                        is_inline=is_inline,
-                    )
-                )
-
-            return discussions
-
-        return await asyncio.to_thread(_fetch)
-
-    async def get_current_user(self) -> AgentIdentity:
-        """Discover the identity of the authenticated user."""
-
-        def _fetch() -> AgentIdentity:
-            self._gl.auth()
-            user = self._gl.user
-            assert user is not None, "GitLab auth() did not populate user"
-            return AgentIdentity(
-                user_id=user.id,  # pyright: ignore[reportArgumentType]
-                username=user.username,  # pyright: ignore[reportArgumentType]
-            )
-
-        return await asyncio.to_thread(_fetch)
+        Returns:
+            Parsed discussion threads.
+        """
+        raw_discussions = await self._paginate(
+            f"/projects/{project_id}/merge_requests/{mr_iid}/discussions",
+        )
+        return _parse_discussions(raw_discussions)
 
     async def resolve_discussion(self, project_id: int, mr_iid: int, discussion_id: str) -> None:
-        """Resolve a discussion thread via the GitLab API."""
+        """Resolve a discussion thread via the GitLab API.
 
-        def _resolve() -> None:
-            project = self._gl.projects.get(project_id)
-            mr = project.mergerequests.get(mr_iid)
-            disc = mr.discussions.get(discussion_id)
-            disc.resolved = True
-            disc.save()
-
-        await asyncio.to_thread(_resolve)
+        Args:
+            project_id: Numeric project ID.
+            mr_iid: Merge request internal ID.
+            discussion_id: GitLab discussion ID.
+        """
+        await self._request(
+            "PUT",
+            f"/projects/{project_id}/merge_requests/{mr_iid}/discussions/{discussion_id}",
+            json={"resolved": True},
+        )
 
     async def reply_to_discussion(
         self, project_id: int, mr_iid: int, discussion_id: str, body: str
     ) -> None:
-        """Post a reply to an existing discussion thread."""
+        """Post a reply to an existing discussion thread.
 
-        def _reply() -> None:
-            project = self._gl.projects.get(project_id)
-            mr = project.mergerequests.get(mr_iid)
-            disc = mr.discussions.get(discussion_id)
-            disc.notes.create({"body": body})
+        Args:
+            project_id: Numeric project ID.
+            mr_iid: Merge request internal ID.
+            discussion_id: GitLab discussion ID.
+            body: Reply body text.
+        """
+        await self._request(
+            "POST",
+            (f"/projects/{project_id}/merge_requests/{mr_iid}/discussions/{discussion_id}/notes"),
+            json={"body": body},
+        )
 
-        await asyncio.to_thread(_reply)
+    # ------------------------------------------------------------------
+    # User
+    # ------------------------------------------------------------------
+
+    async def get_current_user(self) -> AgentIdentity:
+        """Discover the identity of the authenticated user.
+
+        Returns:
+            The agent's GitLab user ID and username.
+        """
+        resp = await self._request("GET", "/user")
+        data: dict[str, Any] = resp.json()
+        return AgentIdentity(user_id=int(data["id"]), username=str(data["username"]))
+
+    # ------------------------------------------------------------------
+    # Repository
+    # ------------------------------------------------------------------
 
     async def compare_commits(self, project_id: int, from_sha: str, to_sha: str) -> list[MRChange]:
         """Compare two commits via the Repository Compare API.
 
-        Returns file changes between from_sha and to_sha in the same
+        Returns file changes between *from_sha* and *to_sha* in the same
         shape as MR changes, enabling reuse of existing diff assembly.
+
+        Args:
+            project_id: Numeric project ID.
+            from_sha: Base commit SHA.
+            to_sha: Head commit SHA.
+
+        Returns:
+            List of file changes between the two commits.
         """
+        resp = await self._request(
+            "GET",
+            f"/projects/{project_id}/repository/compare",
+            params={"from": from_sha, "to": to_sha},
+        )
+        data: dict[str, Any] = resp.json()
+        raw_diffs: Any = data.get("diffs", [])  # type narrowed by isinstance below
+        if not isinstance(raw_diffs, list):
+            return []
+        return [
+            MRChange.model_validate(d)
+            for d in raw_diffs  # pyright: ignore[reportUnknownVariableType]
+            if isinstance(d, dict)
+        ]
 
-        def _compare() -> list[MRChange]:
-            project = self._gl.projects.get(project_id)
-            result: dict[str, object] = project.repository_compare(from_sha, to_sha)  # pyright: ignore[reportAssignmentType]
-            raw_diffs = result.get("diffs", [])
-            if not isinstance(raw_diffs, list):
-                return []
-            changes: list[MRChange] = []
-            for d in raw_diffs:  # pyright: ignore[reportUnknownVariableType]
-                if isinstance(d, dict):
-                    changes.append(MRChange.model_validate(d))
-            return changes
+    # ------------------------------------------------------------------
+    # Git operations (unchanged — delegates to git_operations module)
+    # ------------------------------------------------------------------
 
-        return await asyncio.to_thread(_compare)
+    async def clone_repo(
+        self, clone_url: str, branch: str, token: str, *, clone_dir: str | None = None
+    ) -> Path:
+        """Clone a repository via git subprocess.
 
-    async def get_mr_commits(self, project_id: int, mr_iid: int) -> list[MRCommit]:
-        """Fetch commits on a merge request for developer intent context."""
+        Args:
+            clone_url: Git HTTP clone URL.
+            branch: Branch to check out.
+            token: Token for git authentication.
+            clone_dir: Optional directory for the clone.
 
-        def _fetch() -> list[MRCommit]:
-            project = self._gl.projects.get(project_id)
-            mr = project.mergerequests.get(mr_iid)
-            raw_commits = mr.commits()  # pyright: ignore[reportUnknownMemberType]
-            return [
-                MRCommit.model_validate(c.attributes)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
-                for c in raw_commits  # pyright: ignore[reportUnknownVariableType]
-            ]
+        Returns:
+            Path to the cloned repository.
+        """
+        from gitlab_copilot_agent.git_operations import git_clone
 
-        return await asyncio.to_thread(_fetch)
+        return await git_clone(clone_url, branch, token, clone_dir=clone_dir)
+
+    async def cleanup(self, repo_path: Path) -> None:
+        """Remove a cloned repository from disk.
+
+        Args:
+            repo_path: Path to the cloned repository.
+        """
+        await asyncio.to_thread(shutil.rmtree, repo_path, True)
+        await log.ainfo("repo_cleaned", path=str(repo_path))
+
+
+# ------------------------------------------------------------------
+# Module-level helpers
+# ------------------------------------------------------------------
+
+
+def _retry_delay(resp: httpx.Response, attempt: int) -> float:
+    """Compute retry delay, respecting ``Retry-After`` header if present."""
+    retry_after = resp.headers.get("retry-after")
+    if retry_after is not None:
+        try:
+            return float(retry_after)
+        except ValueError:
+            pass
+    return _RETRY_BACKOFF * (2**attempt)
+
+
+def _parse_note(raw_note: dict[str, Any]) -> DiscussionNote:
+    """Parse a single raw note dict into a DiscussionNote model."""
+    position: dict[str, object] | None = None
+    raw_pos: dict[str, Any] | None = raw_note.get("position")
+    if raw_pos is not None:
+        position = {
+            "new_path": raw_pos.get("new_path"),
+            "old_path": raw_pos.get("old_path"),
+            "new_line": raw_pos.get("new_line"),
+            "old_line": raw_pos.get("old_line"),
+            "head_sha": raw_pos.get("head_sha"),
+        }
+
+    author: dict[str, Any] = raw_note.get("author", {})
+    raw_resolved_by: dict[str, Any] | None = raw_note.get("resolved_by")
+    resolved_by_id: int | None = None
+    if isinstance(raw_resolved_by, dict):
+        rbid = raw_resolved_by.get("id")
+        if isinstance(rbid, int):
+            resolved_by_id = rbid
+
+    return DiscussionNote(
+        note_id=raw_note["id"],
+        author_id=author.get("id", 0),
+        author_username=author.get("username", ""),
+        body=raw_note.get("body", ""),
+        created_at=raw_note.get("created_at", ""),
+        is_system=False,
+        resolved=raw_note.get("resolved"),
+        resolved_by_id=resolved_by_id,
+        resolvable=raw_note.get("resolvable", False),
+        position=position,
+    )
+
+
+def _parse_discussions(raw_discussions: list[dict[str, Any]]) -> list[Discussion]:
+    """Parse raw discussion dicts from the GitLab API into Discussion models."""
+    discussions: list[Discussion] = []
+
+    for raw_disc in raw_discussions:
+        notes: list[DiscussionNote] = []
+        is_inline = False
+
+        for raw_note in raw_disc.get("notes", []):
+            if raw_note.get("system", False):
+                continue
+            if raw_note.get("type") == "DiffNote":
+                is_inline = True
+            notes.append(_parse_note(raw_note))
+
+        if not notes:
+            continue
+
+        raw_notes: list[dict[str, Any]] = raw_disc.get("notes", [])
+        first_note = raw_notes[0] if raw_notes else {}
+        is_resolved = bool(first_note.get("resolved", False))
+
+        discussions.append(
+            Discussion(
+                discussion_id=raw_disc["id"],
+                notes=notes,
+                is_resolved=is_resolved,
+                is_inline=is_inline,
+            )
+        )
+
+    return discussions

--- a/tests/test_gitlab_client.py
+++ b/tests/test_gitlab_client.py
@@ -1,9 +1,9 @@
-"""Tests for the GitLab client."""
+"""Tests for the GitLab client — httpx-based async implementation."""
 
-import asyncio
-from pathlib import Path
-from unittest.mock import MagicMock
+from typing import Any
+from unittest.mock import AsyncMock
 
+import httpx
 import pytest
 
 from gitlab_copilot_agent.discussion_models import AgentIdentity
@@ -14,8 +14,9 @@ from gitlab_copilot_agent.gitlab_client import (
     MRCommit,
     MRDetails,
     MRDiffRef,
-    MRListItem,
     NoteListItem,
+    _parse_discussions,
+    _retry_delay,
 )
 from tests.conftest import GITLAB_TOKEN, GITLAB_URL, MR_IID, PROJECT_ID
 
@@ -31,26 +32,37 @@ NOTE_ID = 1
 PROJECT_PATH = "group/my-project"
 ISO_TIMESTAMP = "2024-01-01T00:00:00Z"
 SECRET_TOKEN = "glpat-secret-token-value"
-AUTHOR_ATTRS = {"id": 1, "username": "testuser"}
+AUTHOR_ATTRS: dict[str, Any] = {"id": 1, "username": "testuser"}
 MR_WEB_URL = f"{GITLAB_URL}/{PROJECT_PATH}/-/merge_requests/{MR_IID}"
 DISCUSSION_ID = "abc123discussion"
 DIFF_NOTE_PATH = "src/utils.py"
 BOT_USER_ID = 99
 BOT_USERNAME = "review-bot"
+COMPARE_FROM_SHA = "from111"
+COMPARE_TO_SHA = "to222"
+COMPARE_DIFF = "@@ -1,3 +1,4 @@\n+added\n"
+COMPARE_PATH = "src/compare.py"
+COMMIT_SHA = "abc123def456"
+COMMIT_TITLE = "feat: add new feature"
+COMMIT_MESSAGE = "feat: add new feature\n\nDetailed description of the change."
+RESOLVE_REPLY_BODY = "✅ Feedback addressed — marking resolved."
+
+# -- Helpers & fixtures --
+
+_DUMMY_REQUEST = httpx.Request("GET", "https://test")
 
 
-@pytest.fixture
-def mock_gl(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
-    mock = MagicMock()
-    mr_mock = MagicMock()
-    mr_mock.changes.return_value = {
+def _resp(data: object, status: int = 200) -> httpx.Response:
+    """Build a mock httpx.Response with JSON data."""
+    return httpx.Response(status_code=status, json=data, request=_DUMMY_REQUEST)
+
+
+def _mr_changes_json(**overrides: Any) -> dict[str, Any]:
+    """Standard MR changes API response with optional overrides."""
+    base: dict[str, Any] = {
         "title": MR_TITLE,
         "description": MR_DESCRIPTION,
-        "diff_refs": {
-            "base_sha": BASE_SHA,
-            "start_sha": START_SHA,
-            "head_sha": HEAD_SHA,
-        },
+        "diff_refs": {"base_sha": BASE_SHA, "start_sha": START_SHA, "head_sha": HEAD_SHA},
         "changes": [
             {
                 "old_path": OLD_PATH,
@@ -62,143 +74,13 @@ def mock_gl(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
             }
         ],
     }
-    mock.projects.get.return_value.mergerequests.get.return_value = mr_mock
-    monkeypatch.setattr("gitlab_copilot_agent.gitlab_client.gitlab.Gitlab", lambda *a, **kw: mock)
-    return mock
+    return {**base, **overrides}
 
 
-async def test_get_mr_details(mock_gl: MagicMock) -> None:
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
-    details = await client.get_mr_details(PROJECT_ID, MR_IID)
-
-    assert isinstance(details, MRDetails)
-    assert details.title == MR_TITLE
-    assert details.description == MR_DESCRIPTION
-    expected_refs = MRDiffRef(base_sha=BASE_SHA, start_sha=START_SHA, head_sha=HEAD_SHA)
-    assert details.diff_refs == expected_refs
-    assert len(details.changes) == 1
-    assert details.changes[0] == MRChange(
-        old_path=OLD_PATH,
-        new_path=OLD_PATH,
-        diff=DIFF_CONTENT,
-    )
-
-
-async def _run(*cmd: str) -> None:
-    proc = await asyncio.create_subprocess_exec(
-        *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
-    )
-    await proc.communicate()
-
-
-async def test_list_project_mrs(mock_gl: MagicMock) -> None:
-    mr_obj = MagicMock()
-    mr_obj.attributes = {
-        "iid": MR_IID,
-        "title": MR_TITLE,
-        "description": MR_DESCRIPTION,
-        "source_branch": "feature",
-        "target_branch": "main",
-        "sha": HEAD_SHA,
-        "web_url": MR_WEB_URL,
-        "state": "opened",
-        "author": AUTHOR_ATTRS,
-        "updated_at": ISO_TIMESTAMP,
-    }
-    mock_gl.projects.get.return_value.mergerequests.list.return_value = [mr_obj]
-
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
-    result = await client.list_project_mrs(PROJECT_ID, state="merged", updated_after=ISO_TIMESTAMP)
-
-    assert len(result) == 1
-    assert isinstance(result[0], MRListItem)
-    assert result[0].iid == MR_IID
-    assert result[0].sha == HEAD_SHA
-    assert result[0].author == MRAuthor(id=1, username="testuser")
-    mock_gl.projects.get.return_value.mergerequests.list.assert_called_once_with(
-        state="merged", get_all=True, updated_after=ISO_TIMESTAMP
-    )
-
-
-async def test_list_project_mrs_defaults(mock_gl: MagicMock) -> None:
-    mock_gl.projects.get.return_value.mergerequests.list.return_value = []
-
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
-    result = await client.list_project_mrs(PROJECT_ID)
-
-    assert result == []
-    mock_gl.projects.get.return_value.mergerequests.list.assert_called_once_with(
-        state="opened", get_all=True
-    )
-
-
-async def test_list_mr_notes(mock_gl: MagicMock) -> None:
-    note_obj = MagicMock()
-    note_obj.attributes = {
-        "id": NOTE_ID,
-        "body": NOTE_BODY,
-        "author": AUTHOR_ATTRS,
-        "system": False,
-        "created_at": ISO_TIMESTAMP,
-    }
-    mock_gl.projects.get.return_value.mergerequests.get.return_value.notes.list.return_value = [
-        note_obj
-    ]
-
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
-    result = await client.list_mr_notes(PROJECT_ID, MR_IID, created_after=ISO_TIMESTAMP)
-
-    assert len(result) == 1
-    assert isinstance(result[0], NoteListItem)
-    assert result[0].id == NOTE_ID
-    assert result[0].body == NOTE_BODY
-    mock_gl.projects.get.return_value.mergerequests.get.return_value.notes.list.assert_called_once_with(
-        get_all=True, created_after=ISO_TIMESTAMP
-    )
-
-
-async def test_list_mr_notes_defaults(mock_gl: MagicMock) -> None:
-    mock_gl.projects.get.return_value.mergerequests.get.return_value.notes.list.return_value = []
-
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
-    result = await client.list_mr_notes(PROJECT_ID, MR_IID)
-
-    assert result == []
-    mock_gl.projects.get.return_value.mergerequests.get.return_value.notes.list.assert_called_once_with(
-        get_all=True
-    )
-
-
-async def test_resolve_project_by_id(mock_gl: MagicMock) -> None:
-    mock_gl.projects.get.return_value.id = PROJECT_ID
-
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
-    result = await client.resolve_project(PROJECT_ID)
-
-    assert result == PROJECT_ID
-    mock_gl.projects.get.assert_called_with(PROJECT_ID)
-
-
-async def test_resolve_project_by_path(mock_gl: MagicMock) -> None:
-    mock_gl.projects.get.return_value.id = PROJECT_ID
-
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
-    result = await client.resolve_project(PROJECT_PATH)
-
-    assert result == PROJECT_ID
-    mock_gl.projects.get.assert_called_with(PROJECT_PATH)
-
-
-async def test_clone_repo_sanitizes_token_in_error(tmp_path: Path) -> None:
-    """Test that tokens are sanitized in clone error messages."""
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
-
-    with pytest.raises(RuntimeError, match="git clone failed") as exc_info:
-        await client.clone_repo("https://gitlab.com/nonexistent/repo.git", "main", SECRET_TOKEN)
-    assert SECRET_TOKEN not in str(exc_info.value)
-
-
-# -- list_mr_discussions tests --
+@pytest.fixture
+def client() -> GitLabClient:
+    """Pre-configured GitLabClient for tests (not connected to real server)."""
+    return GitLabClient(GITLAB_URL, GITLAB_TOKEN)
 
 
 def _make_raw_note(
@@ -210,8 +92,9 @@ def _make_raw_note(
     resolved: bool | None = None,
     resolvable: bool = False,
     position: dict[str, object] | None = None,
+    resolved_by: dict[str, Any] | None | str = "UNSET",
 ) -> dict[str, object]:
-    """Factory for raw discussion note dicts as returned by python-gitlab."""
+    """Factory for raw note dicts as returned by the GitLab API."""
     note: dict[str, object] = {
         "id": note_id,
         "body": body,
@@ -226,348 +109,455 @@ def _make_raw_note(
         note["resolved"] = resolved
     if position is not None:
         note["position"] = position
+    if resolved_by != "UNSET":
+        note["resolved_by"] = resolved_by
     return note
 
 
-def _make_discussion_mock(discussion_id: str, notes: list[dict[str, object]]) -> MagicMock:
-    """Factory for a raw discussion object with .attributes."""
-    disc = MagicMock()
-    disc.attributes = {"id": discussion_id, "notes": notes}
-    return disc
+def _make_raw_discussion(discussion_id: str, notes: list[dict[str, object]]) -> dict[str, Any]:
+    """Factory for raw discussion dicts from the GitLab API."""
+    return {"id": discussion_id, "notes": notes}
 
 
-async def test_list_mr_discussions_mixed_types(mock_gl: MagicMock) -> None:
-    """DiffNote sets is_inline=True; DiscussionNote keeps is_inline=False."""
-    diff_note = _make_raw_note(
-        note_id=10,
-        body="inline comment",
-        note_type="DiffNote",
-        position={
-            "new_path": DIFF_NOTE_PATH,
-            "old_path": DIFF_NOTE_PATH,
-            "new_line": 5,
-            "old_line": None,
-        },
+# ===================================================================
+# get_mr_details
+# ===================================================================
+
+
+async def test_get_mr_details(client: GitLabClient) -> None:
+    client._request = AsyncMock(return_value=_resp(_mr_changes_json()))
+    details = await client.get_mr_details(PROJECT_ID, MR_IID)
+
+    assert details == MRDetails(
+        title=MR_TITLE,
+        description=MR_DESCRIPTION,
+        diff_refs=MRDiffRef(base_sha=BASE_SHA, start_sha=START_SHA, head_sha=HEAD_SHA),
+        changes=[MRChange(old_path=OLD_PATH, new_path=OLD_PATH, diff=DIFF_CONTENT)],
     )
-    regular_note = _make_raw_note(note_id=20, body="general comment", note_type="DiscussionNote")
-
-    disc_inline = _make_discussion_mock("d1", [diff_note])
-    disc_general = _make_discussion_mock("d2", [regular_note])
-
-    mr_mock = mock_gl.projects.get.return_value.mergerequests.get.return_value
-    mr_mock.discussions.list.return_value = [disc_inline, disc_general]
-
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
-    result = await client.list_mr_discussions(PROJECT_ID, MR_IID)
-
-    assert len(result) == 2
-    assert result[0].is_inline is True
-    assert result[0].notes[0].note_id == 10
-    assert result[1].is_inline is False
-    assert result[1].notes[0].note_id == 20
 
 
-async def test_list_mr_discussions_system_notes_filtered(mock_gl: MagicMock) -> None:
-    """System notes are excluded from the returned discussion."""
-    system_note = _make_raw_note(note_id=30, body="system event", system=True)
-    user_note = _make_raw_note(note_id=31, body="user reply")
+async def test_get_mr_details_retries_null_diff_refs(client: GitLabClient) -> None:
+    """Retries when diff_refs is null (GitLab race on new MRs)."""
+    client._request = AsyncMock(
+        side_effect=[_resp(_mr_changes_json(diff_refs=None)), _resp(_mr_changes_json())]
+    )
+    details = await client.get_mr_details(PROJECT_ID, MR_IID)
+    assert details.diff_refs.head_sha == HEAD_SHA
+    assert client._request.await_count == 2
 
-    disc = _make_discussion_mock("d3", [system_note, user_note])
-    mr_mock = mock_gl.projects.get.return_value.mergerequests.get.return_value
-    mr_mock.discussions.list.return_value = [disc]
 
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
-    result = await client.list_mr_discussions(PROJECT_ID, MR_IID)
+async def test_get_mr_details_raises_after_null_diff_refs_exhausted(client: GitLabClient) -> None:
+    client._request = AsyncMock(return_value=_resp(_mr_changes_json(diff_refs=None)))
+    with pytest.raises(RuntimeError, match="diff_refs is null"):
+        await client.get_mr_details(PROJECT_ID, MR_IID)
+
+
+# ===================================================================
+# Paginated list endpoints
+# ===================================================================
+
+
+async def test_list_project_mrs(client: GitLabClient) -> None:
+    mr_data = {
+        "iid": MR_IID,
+        "title": MR_TITLE,
+        "description": MR_DESCRIPTION,
+        "source_branch": "feature",
+        "target_branch": "main",
+        "sha": HEAD_SHA,
+        "web_url": MR_WEB_URL,
+        "state": "opened",
+        "author": AUTHOR_ATTRS,
+        "updated_at": ISO_TIMESTAMP,
+    }
+    client._paginate = AsyncMock(return_value=[mr_data])
+
+    result = await client.list_project_mrs(PROJECT_ID, state="merged", updated_after=ISO_TIMESTAMP)
 
     assert len(result) == 1
-    assert len(result[0].notes) == 1
-    assert result[0].notes[0].note_id == 31
+    assert result[0].iid == MR_IID
+    assert result[0].author == MRAuthor(id=1, username="testuser")
+    params = client._paginate.call_args[1]["params"]
+    assert params["state"] == "merged"
+    assert params["updated_after"] == ISO_TIMESTAMP
 
 
-async def test_list_mr_discussions_all_system_notes_skipped(mock_gl: MagicMock) -> None:
-    """Discussions where ALL notes are system notes are dropped entirely."""
-    system_only = _make_raw_note(note_id=40, body="system", system=True)
-    disc = _make_discussion_mock("d4", [system_only])
-
-    mr_mock = mock_gl.projects.get.return_value.mergerequests.get.return_value
-    mr_mock.discussions.list.return_value = [disc]
-
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
-    result = await client.list_mr_discussions(PROJECT_ID, MR_IID)
-
-    assert result == []
+async def test_list_project_mrs_defaults(client: GitLabClient) -> None:
+    client._paginate = AsyncMock(return_value=[])
+    assert await client.list_project_mrs(PROJECT_ID) == []
+    assert client._paginate.call_args[1]["params"]["state"] == "opened"
 
 
-async def test_list_mr_discussions_position_extraction(mock_gl: MagicMock) -> None:
-    """DiffNote position fields are correctly extracted."""
-    position = {
-        "new_path": DIFF_NOTE_PATH,
-        "old_path": "src/old_utils.py",
-        "new_line": 42,
-        "old_line": 10,
+async def test_list_mr_notes(client: GitLabClient) -> None:
+    note_data = {
+        "id": NOTE_ID,
+        "body": NOTE_BODY,
+        "author": AUTHOR_ATTRS,
+        "system": False,
+        "created_at": ISO_TIMESTAMP,
     }
-    diff_note = _make_raw_note(note_id=50, note_type="DiffNote", position=position)
-    disc = _make_discussion_mock("d5", [diff_note])
+    client._paginate = AsyncMock(return_value=[note_data])
 
-    mr_mock = mock_gl.projects.get.return_value.mergerequests.get.return_value
-    mr_mock.discussions.list.return_value = [disc]
+    result = await client.list_mr_notes(PROJECT_ID, MR_IID, created_after=ISO_TIMESTAMP)
 
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
-    result = await client.list_mr_discussions(PROJECT_ID, MR_IID)
+    assert len(result) == 1
+    assert result[0] == NoteListItem(
+        id=NOTE_ID, body=NOTE_BODY, author=MRAuthor(**AUTHOR_ATTRS), created_at=ISO_TIMESTAMP
+    )
 
-    note = result[0].notes[0]
+
+async def test_list_mr_notes_defaults(client: GitLabClient) -> None:
+    client._paginate = AsyncMock(return_value=[])
+    assert await client.list_mr_notes(PROJECT_ID, MR_IID) == []
+
+
+# ===================================================================
+# resolve_project
+# ===================================================================
+
+
+async def test_resolve_project_by_id(client: GitLabClient) -> None:
+    assert await client.resolve_project(PROJECT_ID) == PROJECT_ID
+
+
+async def test_resolve_project_by_path(client: GitLabClient) -> None:
+    client._request = AsyncMock(return_value=_resp({"id": PROJECT_ID}))
+    assert await client.resolve_project(PROJECT_PATH) == PROJECT_ID
+    assert "group%2Fmy-project" in client._request.call_args[0][1]
+
+
+# ===================================================================
+# clone_repo
+# ===================================================================
+
+
+async def test_clone_repo_sanitizes_token_in_error(client: GitLabClient) -> None:
+    with pytest.raises(RuntimeError, match="git clone failed") as exc_info:
+        await client.clone_repo("https://gitlab.com/nonexistent/repo.git", "main", SECRET_TOKEN)
+    assert SECRET_TOKEN not in str(exc_info.value)
+
+
+# ===================================================================
+# _parse_discussions
+# ===================================================================
+
+
+async def test_discussions_mixed_types() -> None:
+    """DiffNote -> is_inline=True; DiscussionNote -> is_inline=False."""
+    raw = [
+        _make_raw_discussion(
+            "d1",
+            [
+                _make_raw_note(
+                    note_id=10,
+                    note_type="DiffNote",
+                    position={
+                        "new_path": DIFF_NOTE_PATH,
+                        "old_path": DIFF_NOTE_PATH,
+                        "new_line": 5,
+                        "old_line": None,
+                    },
+                )
+            ],
+        ),
+        _make_raw_discussion("d2", [_make_raw_note(note_id=20, note_type="DiscussionNote")]),
+    ]
+    result = _parse_discussions(raw)
+    assert [(d.is_inline, d.notes[0].note_id) for d in result] == [(True, 10), (False, 20)]
+
+
+async def test_discussions_system_notes_filtered() -> None:
+    raw = [
+        _make_raw_discussion(
+            "d3",
+            [_make_raw_note(note_id=30, system=True), _make_raw_note(note_id=31)],
+        )
+    ]
+    result = _parse_discussions(raw)
+    assert len(result) == 1
+    assert [n.note_id for n in result[0].notes] == [31]
+
+
+async def test_discussions_all_system_notes_dropped() -> None:
+    raw = [_make_raw_discussion("d4", [_make_raw_note(note_id=40, system=True)])]
+    assert _parse_discussions(raw) == []
+
+
+async def test_discussions_position_extraction() -> None:
+    pos = {"new_path": DIFF_NOTE_PATH, "old_path": "src/old.py", "new_line": 42, "old_line": 10}
+    raw = [
+        _make_raw_discussion(
+            "d5", [_make_raw_note(note_id=50, note_type="DiffNote", position=pos)]
+        )
+    ]
+    note = _parse_discussions(raw)[0].notes[0]
     assert note.position is not None
-    assert note.position["new_path"] == DIFF_NOTE_PATH
-    assert note.position["old_path"] == "src/old_utils.py"
-    assert note.position["new_line"] == 42
-    assert note.position["old_line"] == 10
+    assert (note.position["new_path"], note.position["new_line"]) == (DIFF_NOTE_PATH, 42)
 
 
-async def test_list_mr_discussions_empty(mock_gl: MagicMock) -> None:
-    """Empty discussions list returns empty result."""
-    mr_mock = mock_gl.projects.get.return_value.mergerequests.get.return_value
-    mr_mock.discussions.list.return_value = []
-
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
-    result = await client.list_mr_discussions(PROJECT_ID, MR_IID)
-
-    assert result == []
-    mr_mock.discussions.list.assert_called_once_with(get_all=True)
+async def test_discussions_empty(client: GitLabClient) -> None:
+    client._paginate = AsyncMock(return_value=[])
+    assert await client.list_mr_discussions(PROJECT_ID, MR_IID) == []
 
 
-# -- resolved_by extraction tests --
-
-RESOLVED_BY_USER = {"id": 42, "username": "human-dev"}
-
-
-async def test_list_mr_discussions_resolved_by_present(mock_gl: MagicMock) -> None:
-    """resolved_by dict populates resolved_by_id on the note."""
-    note = _make_raw_note(note_id=60, resolved=True, resolvable=True)
-    note["resolved_by"] = RESOLVED_BY_USER
-    disc = _make_discussion_mock("d-rb-1", [note])
-
-    mr_mock = mock_gl.projects.get.return_value.mergerequests.get.return_value
-    mr_mock.discussions.list.return_value = [disc]
-
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
-    result = await client.list_mr_discussions(PROJECT_ID, MR_IID)
-
-    assert len(result) == 1
-    assert result[0].notes[0].resolved_by_id == RESOLVED_BY_USER["id"]
+@pytest.mark.parametrize(
+    ("resolved_by", "expected_id"),
+    [
+        ({"id": 42, "username": "human-dev"}, 42),
+        ("UNSET", None),  # key absent
+        (None, None),  # key present but null
+    ],
+    ids=["present", "absent", "null"],
+)
+async def test_discussions_resolved_by(
+    resolved_by: dict[str, Any] | None | str,
+    expected_id: int | None,
+) -> None:
+    note = _make_raw_note(note_id=60, resolved=True, resolvable=True, resolved_by=resolved_by)
+    raw = [_make_raw_discussion("d-rb", [note])]
+    assert _parse_discussions(raw)[0].notes[0].resolved_by_id == expected_id
 
 
-async def test_list_mr_discussions_resolved_by_absent(mock_gl: MagicMock) -> None:
-    """Missing resolved_by key gives resolved_by_id=None."""
-    note = _make_raw_note(note_id=61, resolved=False, resolvable=True)
-    # No resolved_by key at all
-    disc = _make_discussion_mock("d-rb-2", [note])
-
-    mr_mock = mock_gl.projects.get.return_value.mergerequests.get.return_value
-    mr_mock.discussions.list.return_value = [disc]
-
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
-    result = await client.list_mr_discussions(PROJECT_ID, MR_IID)
-
-    assert len(result) == 1
-    assert result[0].notes[0].resolved_by_id is None
+# ===================================================================
+# Simple write endpoints (parametrized)
+# ===================================================================
 
 
-async def test_list_mr_discussions_resolved_by_non_dict(mock_gl: MagicMock) -> None:
-    """Non-dict resolved_by (e.g. null from API) gives resolved_by_id=None."""
-    note = _make_raw_note(note_id=62, resolved=True, resolvable=True)
-    note["resolved_by"] = None  # GitLab can return null
-    disc = _make_discussion_mock("d-rb-3", [note])
+@pytest.mark.parametrize(
+    ("method_name", "args", "expected_verb", "expected_json"),
+    [
+        ("resolve_discussion", (PROJECT_ID, MR_IID, DISCUSSION_ID), "PUT", {"resolved": True}),
+        (
+            "reply_to_discussion",
+            (PROJECT_ID, MR_IID, DISCUSSION_ID, RESOLVE_REPLY_BODY),
+            "POST",
+            {"body": RESOLVE_REPLY_BODY},
+        ),
+        ("post_mr_comment", (PROJECT_ID, MR_IID, "Great work!"), "POST", {"body": "Great work!"}),
+    ],
+    ids=["resolve_discussion", "reply_to_discussion", "post_mr_comment"],
+)
+async def test_write_endpoint(
+    client: GitLabClient,
+    method_name: str,
+    args: tuple[Any, ...],
+    expected_verb: str,
+    expected_json: dict[str, Any],
+) -> None:
+    client._request = AsyncMock(return_value=_resp({}))
+    await getattr(client, method_name)(*args)
+    call = client._request.call_args
+    assert call[0][0] == expected_verb
+    assert call[1]["json"] == expected_json
 
-    mr_mock = mock_gl.projects.get.return_value.mergerequests.get.return_value
-    mr_mock.discussions.list.return_value = [disc]
 
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
-    result = await client.list_mr_discussions(PROJECT_ID, MR_IID)
+async def test_create_mr_discussion(client: GitLabClient) -> None:
+    client._request = AsyncMock(return_value=_resp({}))
+    position = {"base_sha": BASE_SHA, "position_type": "text", "new_line": 10}
+    await client.create_mr_discussion(PROJECT_ID, MR_IID, "Bug", position)
+    call = client._request.call_args
+    assert call[0][0] == "POST"
+    assert call[1]["json"] == {"body": "Bug", "position": position}
 
-    assert len(result) == 1
-    assert result[0].notes[0].resolved_by_id is None
+
+async def test_create_merge_request(client: GitLabClient) -> None:
+    client._request = AsyncMock(return_value=_resp({"iid": 42}))
+    assert await client.create_merge_request(PROJECT_ID, "feat", "main", "T", "D") == 42
 
 
-async def test_get_current_user(mock_gl: MagicMock) -> None:
-    """Returns AgentIdentity with user_id and username from authenticated user."""
-    mock_gl.user = MagicMock()
-    mock_gl.user.id = BOT_USER_ID
-    mock_gl.user.username = BOT_USERNAME
+# ===================================================================
+# get_current_user
+# ===================================================================
 
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
+
+async def test_get_current_user(client: GitLabClient) -> None:
+    client._request = AsyncMock(return_value=_resp({"id": BOT_USER_ID, "username": BOT_USERNAME}))
     identity = await client.get_current_user()
-
-    mock_gl.auth.assert_called_once()
-    assert isinstance(identity, AgentIdentity)
-    assert identity.user_id == BOT_USER_ID
-    assert identity.username == BOT_USERNAME
+    assert identity == AgentIdentity(user_id=BOT_USER_ID, username=BOT_USERNAME)
 
 
-# -- resolve_discussion / reply_to_discussion tests --
-
-RESOLVE_REPLY_BODY = "✅ Feedback addressed — marking resolved."
-
-
-async def test_resolve_discussion(mock_gl: MagicMock) -> None:
-    """Verify resolve_discussion sets resolved=True and calls save()."""
-    disc_mock = MagicMock()
-    mr_mock = mock_gl.projects.get.return_value.mergerequests.get.return_value
-    mr_mock.discussions.get.return_value = disc_mock
-
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
-    await client.resolve_discussion(PROJECT_ID, MR_IID, DISCUSSION_ID)
-
-    mock_gl.projects.get.assert_called_with(PROJECT_ID)
-    assert disc_mock.resolved is True
-    disc_mock.save.assert_called_once()
+# ===================================================================
+# compare_commits
+# ===================================================================
 
 
-async def test_reply_to_discussion(mock_gl: MagicMock) -> None:
-    """Verify reply_to_discussion posts a note with the given body."""
-    disc_mock = MagicMock()
-    mr_mock = mock_gl.projects.get.return_value.mergerequests.get.return_value
-    mr_mock.discussions.get.return_value = disc_mock
-
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
-    await client.reply_to_discussion(PROJECT_ID, MR_IID, DISCUSSION_ID, RESOLVE_REPLY_BODY)
-
-    disc_mock.notes.create.assert_called_once_with({"body": RESOLVE_REPLY_BODY})
-
-
-# -- compare_commits tests --
-
-COMPARE_FROM_SHA = "from111"
-COMPARE_TO_SHA = "to222"
-COMPARE_DIFF = "@@ -1,3 +1,4 @@\n+added\n"
-COMPARE_PATH = "src/compare.py"
-
-
-async def test_compare_commits_returns_mr_changes(mock_gl: MagicMock) -> None:
-    """repository_compare returning diffs produces a list[MRChange]."""
-    mock_gl.projects.get.return_value.repository_compare.return_value = {
-        "diffs": [
+async def test_compare_commits(client: GitLabClient) -> None:
+    client._request = AsyncMock(
+        return_value=_resp(
             {
-                "old_path": COMPARE_PATH,
-                "new_path": COMPARE_PATH,
-                "diff": COMPARE_DIFF,
-                "new_file": False,
-                "deleted_file": False,
-                "renamed_file": False,
+                "diffs": [
+                    {
+                        "old_path": COMPARE_PATH,
+                        "new_path": COMPARE_PATH,
+                        "diff": COMPARE_DIFF,
+                        "new_file": False,
+                        "deleted_file": False,
+                        "renamed_file": False,
+                    }
+                ]
             }
-        ]
-    }
-
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
-    result = await client.compare_commits(PROJECT_ID, COMPARE_FROM_SHA, COMPARE_TO_SHA)
-
-    assert len(result) == 1
-    assert isinstance(result[0], MRChange)
-    assert result[0].new_path == COMPARE_PATH
-    assert result[0].diff == COMPARE_DIFF
-    mock_gl.projects.get.return_value.repository_compare.assert_called_once_with(
-        COMPARE_FROM_SHA, COMPARE_TO_SHA
+        )
     )
-
-
-async def test_compare_commits_empty_diffs(mock_gl: MagicMock) -> None:
-    """repository_compare with no diffs returns empty list."""
-    mock_gl.projects.get.return_value.repository_compare.return_value = {"diffs": []}
-
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
     result = await client.compare_commits(PROJECT_ID, COMPARE_FROM_SHA, COMPARE_TO_SHA)
+    assert len(result) == 1 and result[0].diff == COMPARE_DIFF
 
-    assert result == []
+
+async def test_compare_commits_empty(client: GitLabClient) -> None:
+    client._request = AsyncMock(return_value=_resp({"diffs": []}))
+    assert await client.compare_commits(PROJECT_ID, COMPARE_FROM_SHA, COMPARE_TO_SHA) == []
 
 
-async def test_compare_commits_propagates_error(mock_gl: MagicMock) -> None:
-    """repository_compare raising an exception propagates to caller."""
-    mock_gl.projects.get.return_value.repository_compare.side_effect = RuntimeError("API failure")
+# ===================================================================
+# get_mr_commits
+# ===================================================================
 
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
 
+async def test_get_mr_commits(client: GitLabClient) -> None:
+    client._paginate = AsyncMock(
+        return_value=[{"id": COMMIT_SHA, "title": COMMIT_TITLE, "message": COMMIT_MESSAGE}]
+    )
+    result = await client.get_mr_commits(PROJECT_ID, MR_IID)
+    assert len(result) == 1 and result[0].id == COMMIT_SHA
+
+
+async def test_get_mr_commits_empty(client: GitLabClient) -> None:
+    client._paginate = AsyncMock(return_value=[])
+    assert await client.get_mr_commits(PROJECT_ID, MR_IID) == []
+
+
+# ===================================================================
+# Error propagation (parametrized)
+# ===================================================================
+
+
+@pytest.mark.parametrize(
+    ("method_name", "mock_attr", "args"),
+    [
+        ("compare_commits", "_request", (PROJECT_ID, COMPARE_FROM_SHA, COMPARE_TO_SHA)),
+        ("get_mr_commits", "_paginate", (PROJECT_ID, MR_IID)),
+    ],
+    ids=["compare_commits", "get_mr_commits"],
+)
+async def test_error_propagation(
+    client: GitLabClient,
+    method_name: str,
+    mock_attr: str,
+    args: tuple[Any, ...],
+) -> None:
+    setattr(client, mock_attr, AsyncMock(side_effect=RuntimeError("API failure")))
     with pytest.raises(RuntimeError, match="API failure"):
-        await client.compare_commits(PROJECT_ID, COMPARE_FROM_SHA, COMPARE_TO_SHA)
+        await getattr(client, method_name)(*args)
 
 
-# -- MRCommit model tests --
-
-COMMIT_SHA = "abc123def456"
-COMMIT_TITLE = "feat: add new feature"
-COMMIT_MESSAGE = "feat: add new feature\n\nDetailed description of the change."
+# ===================================================================
+# MRCommit model
+# ===================================================================
 
 
-def test_mr_commit_model_validation() -> None:
-    """MRCommit validates correctly from a dict."""
-    data = {"id": COMMIT_SHA, "title": COMMIT_TITLE, "message": COMMIT_MESSAGE}
-    commit = MRCommit.model_validate(data)
-    assert commit.id == COMMIT_SHA
-    assert commit.title == COMMIT_TITLE
-    assert commit.message == COMMIT_MESSAGE
+def test_mr_commit_validation() -> None:
+    commit = MRCommit.model_validate(
+        {"id": COMMIT_SHA, "title": COMMIT_TITLE, "message": COMMIT_MESSAGE}
+    )
+    assert (commit.id, commit.title) == (COMMIT_SHA, COMMIT_TITLE)
 
 
 def test_mr_commit_extra_fields_ignored() -> None:
-    """MRCommit ignores extra fields from the GitLab API."""
-    data = {
-        "id": COMMIT_SHA,
-        "title": COMMIT_TITLE,
-        "message": COMMIT_MESSAGE,
-        "author_name": "Test User",
-        "authored_date": "2024-01-01T00:00:00Z",
-        "committer_name": "Test User",
-    }
-    commit = MRCommit.model_validate(data)
-    assert commit.id == COMMIT_SHA
+    commit = MRCommit.model_validate(
+        {"id": COMMIT_SHA, "title": COMMIT_TITLE, "message": COMMIT_MESSAGE, "author_name": "X"}
+    )
     assert not hasattr(commit, "author_name")
 
 
 def test_mr_commit_frozen() -> None:
-    """MRCommit is immutable (frozen)."""
     commit = MRCommit(id=COMMIT_SHA, title=COMMIT_TITLE, message=COMMIT_MESSAGE)
     with pytest.raises(Exception):  # noqa: B017
-        commit.id = "new-sha"  # type: ignore[misc]
+        commit.id = "new"  # type: ignore[misc]
 
 
-# -- get_mr_commits tests --
+# ===================================================================
+# _request retry behavior
+# ===================================================================
 
 
-async def test_get_mr_commits_success(mock_gl: MagicMock) -> None:
-    """get_mr_commits returns list[MRCommit] from mr.commits()."""
-    commit_obj = MagicMock()
-    commit_obj.attributes = {
-        "id": COMMIT_SHA,
-        "title": COMMIT_TITLE,
-        "message": COMMIT_MESSAGE,
-    }
-    mock_gl.projects.get.return_value.mergerequests.get.return_value.commits.return_value = [
-        commit_obj
-    ]
-
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
-    result = await client.get_mr_commits(PROJECT_ID, MR_IID)
-
-    assert len(result) == 1
-    assert isinstance(result[0], MRCommit)
-    assert result[0].id == COMMIT_SHA
-    assert result[0].message == COMMIT_MESSAGE
-
-
-async def test_get_mr_commits_empty(mock_gl: MagicMock) -> None:
-    """get_mr_commits returns empty list when no commits."""
-    mock_gl.projects.get.return_value.mergerequests.get.return_value.commits.return_value = []
-
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
-    result = await client.get_mr_commits(PROJECT_ID, MR_IID)
-
-    assert result == []
-
-
-async def test_get_mr_commits_propagates_error(mock_gl: MagicMock) -> None:
-    """get_mr_commits propagates exceptions from the API."""
-    mock_gl.projects.get.return_value.mergerequests.get.return_value.commits.side_effect = (
-        RuntimeError("API failure")
+async def test_request_retries_get_on_429(client: GitLabClient) -> None:
+    rate_limited = httpx.Response(
+        status_code=429, headers={"retry-after": "0.01"}, request=_DUMMY_REQUEST
     )
+    ok = httpx.Response(status_code=200, json={}, request=_DUMMY_REQUEST)
+    client._client = AsyncMock()
+    client._client.request = AsyncMock(side_effect=[rate_limited, ok])
 
-    client = GitLabClient(GITLAB_URL, GITLAB_TOKEN)
+    assert (await client._request("GET", "/t")).status_code == 200
+    assert client._client.request.await_count == 2
 
-    with pytest.raises(RuntimeError, match="API failure"):
-        await client.get_mr_commits(PROJECT_ID, MR_IID)
+
+async def test_request_no_retry_post_on_500(client: GitLabClient) -> None:
+    client._client = AsyncMock()
+    client._client.request = AsyncMock(
+        return_value=httpx.Response(status_code=500, request=_DUMMY_REQUEST)
+    )
+    with pytest.raises(httpx.HTTPStatusError):
+        await client._request("POST", "/t")
+    assert client._client.request.await_count == 1
+
+
+async def test_request_retries_get_on_transport_error(client: GitLabClient) -> None:
+    ok = httpx.Response(status_code=200, json={}, request=_DUMMY_REQUEST)
+    client._client = AsyncMock()
+    client._client.request = AsyncMock(side_effect=[httpx.ConnectError("refused"), ok])
+    assert (await client._request("GET", "/t")).status_code == 200
+
+
+# ===================================================================
+# _retry_delay (parametrized)
+# ===================================================================
+
+
+@pytest.mark.parametrize(
+    ("status", "headers", "attempt", "expected"),
+    [
+        (429, {"retry-after": "5"}, 0, 5.0),
+        (500, {}, 0, 1.0),
+        (500, {}, 1, 2.0),
+        (500, {}, 2, 4.0),
+    ],
+    ids=["retry-after-header", "backoff-0", "backoff-1", "backoff-2"],
+)
+def test_retry_delay(status: int, headers: dict[str, str], attempt: int, expected: float) -> None:
+    resp = httpx.Response(status_code=status, headers=headers, request=_DUMMY_REQUEST)
+    assert _retry_delay(resp, attempt) == expected
+
+
+# ===================================================================
+# Lifecycle (aclose / context manager)
+# ===================================================================
+
+
+async def test_aclose(client: GitLabClient) -> None:
+    await client.aclose()
+    with pytest.raises(RuntimeError):
+        await client._client.get("/test")
+
+
+async def test_context_manager() -> None:
+    async with GitLabClient(GITLAB_URL, GITLAB_TOKEN) as c:
+        assert c is not None
+
+
+# ===================================================================
+# _paginate
+# ===================================================================
+
+
+async def test_paginate_single_page(client: GitLabClient) -> None:
+    client._request = AsyncMock(return_value=_resp([{"id": i} for i in range(5)]))
+    assert len(await client._paginate("/t")) == 5
+    assert client._request.await_count == 1
+
+
+async def test_paginate_multiple_pages(client: GitLabClient) -> None:
+    page1 = [{"id": i} for i in range(100)]
+    page2 = [{"id": i} for i in range(100, 110)]
+    client._request = AsyncMock(side_effect=[_resp(page1), _resp(page2)])
+    result = await client._paginate("/t")
+    assert len(result) == 110 and client._request.await_count == 2


### PR DESCRIPTION
## What

Rewrite `GitLabClient` from python-gitlab (sync, `asyncio.to_thread` wrappers) to native async httpx. Also migrate `credential_registry._fetch_identity()` to httpx.

**Phase 3, Step 3.1a** of the architecture restructuring (#365, epic #370).

## Why

- python-gitlab is sync-only — every call wrapped in `asyncio.to_thread()` adds overhead
- Incomplete types require `pyright: ignore` comments throughout
- Only 14 REST endpoints are used — a thin httpx client is simpler and fully typed

## How

### GitLabClient (complete rewrite)
- `httpx.AsyncClient` with `PRIVATE-TOKEN` header, 30s timeout
- `_request()`: retry on 429/5xx/TransportError for **GET only** (POST/PUT not retried to avoid duplicate side-effects); respects `Retry-After` header
- `_paginate()`: handles GitLab `page`/`per_page` pagination for all list endpoints
- `aclose()` + `__aenter__`/`__aexit__` for proper lifecycle management
- New `create_mr_discussion()` method for inline diff comments (needed by comment_poster migration in follow-up PR)
- `get_mr_details()`: retries null `diff_refs` with `await asyncio.sleep()` (was `time.sleep()`)
- `resolve_project()`: URL-encodes paths via `urllib.parse.quote`
- Discussion parsing extracted to `_parse_discussions()`/`_parse_note()` module-level helpers

### credential_registry.py
- `_fetch_identity()`: replaced `gitlab.Gitlab().auth()` + `to_thread` with async `httpx GET /api/v4/user`

### Tests (complete rewrite of test_gitlab_client.py)
- Tests mock at `_request`/`_paginate` level — no more python-gitlab `MagicMock` chains
- New tests for retry behavior, pagination, context manager, `Retry-After` header

### What is NOT in this PR
- python-gitlab still in `pyproject.toml` deps — `orchestrator.py`, `comment_poster.py`, `discussion_orchestrator.py` still use `gitlab.Gitlab()` directly
- Consumer migration (comment_poster, orchestrators) and dependency removal are in the follow-up PR
- JiraClient retry (Step 3.2) is a separate PR

## Test results
- 842 tests pass (was 828 — 14 net new tests)
- 93.38% coverage (was 93.23%)
- Lint ratchet improved: 136 → 131 violations
- pyright: 0 errors

## Code review
- Cross-vendor review (gpt-5.4): 1 High — client lifecycle not wired in consumers. This is intentional: consumer migration is the follow-up PR. Current callers never managed lifecycle with python-gitlab either.
- OWASP review: pending (will update)

Closes #365 (partial)