### PR TITLE
refactor(events): add TaskEvent model and migrate orchestrators from webhook payloads

### DIFF
--- a/src/gitlab_copilot_agent/discussion_orchestrator.py
+++ b/src/gitlab_copilot_agent/discussion_orchestrator.py
@@ -23,6 +23,7 @@ from gitlab_copilot_agent.discussion_engine import (
 )
 from gitlab_copilot_agent.discussion_models import AgentIdentity, Discussion, DiscussionHistory
 from gitlab_copilot_agent.error_messages import branch_deleted_message, user_error_message
+from gitlab_copilot_agent.events import TaskEvent
 from gitlab_copilot_agent.git_operations import (
     TransientCloneError,
     git_commit,
@@ -31,7 +32,6 @@ from gitlab_copilot_agent.git_operations import (
 )
 from gitlab_copilot_agent.gitlab_client import GitLabClient
 from gitlab_copilot_agent.mapping_models import ResolutionBehavior
-from gitlab_copilot_agent.models import NoteWebhookPayload
 from gitlab_copilot_agent.prompt_defaults import get_prompt
 from gitlab_copilot_agent.task_executor import (
     CodingResult,
@@ -58,30 +58,36 @@ def _find_triggering_discussion(
 
 async def handle_discussion_interaction(
     settings: Settings,
-    payload: NoteWebhookPayload,
+    event: TaskEvent,
     executor: TaskExecutor,
     agent_identity: AgentIdentity,
-    project_token: str | None = None,
     repo_locks: DistributedLock | None = None,
-    resolution_behavior: ResolutionBehavior = "suggest",
 ) -> None:
     """Handle an @mention or thread-reply interaction on an MR.
 
     Full pipeline: clone → fetch context → build prompt → LLM → post reply.
     If the LLM returns code changes, also commit and push.
     """
-    mr = payload.merge_request
-    project = payload.project
-    note_id = payload.object_attributes.id
+    project_id = event.project_id
+    mr_iid = event.mr_iid
+    if mr_iid is None:
+        msg = "discussion events require mr_iid"
+        raise ValueError(msg)
+    note_id = event.note_id
+    if note_id is None:
+        msg = "discussion events require note_id"
+        raise ValueError(msg)
+    clone_url = event.clone_url
+    token = event.token
+    resolution_behavior: ResolutionBehavior = event.resolution_behavior
 
     with _tracer.start_as_current_span(
         "mr.discussion_interaction",
-        attributes={"project_id": project.id, "mr_iid": mr.iid},
+        attributes={"project_id": project_id, "mr_iid": mr_iid},
     ):
-        bound_log = log.bind(project_id=project.id, mr_iid=mr.iid, note_id=note_id)
+        bound_log = log.bind(project_id=project_id, mr_iid=mr_iid, note_id=note_id)
         await bound_log.ainfo("discussion_interaction_started")
 
-        token = project_token or settings.gitlab_token
         gl_client = GitLabClient(settings.gitlab_url, token)
         repo_path: Path | None = None
 
@@ -90,10 +96,10 @@ async def handle_discussion_interaction(
             try:
                 # 1. Clone repo (always — questions may need full context)
                 try:
-                    validate_clone_url_host(project.git_http_url, settings.gitlab_url)
+                    validate_clone_url_host(clone_url, settings.gitlab_url)
                     repo_path = await gl_client.clone_repo(
-                        project.git_http_url,
-                        mr.source_branch,
+                        clone_url,
+                        event.branch,
                         token,
                         clone_dir=settings.clone_dir,
                     )
@@ -102,21 +108,21 @@ async def handle_discussion_interaction(
                     if "not found" in clone_err or "not allowed" in clone_err:
                         await bound_log.awarning(
                             "branch_deleted_or_inaccessible",
-                            branch=mr.source_branch,
+                            branch=event.branch,
                             error=str(clone_exc),
                         )
                         # Try to reply in the triggering thread
                         try:
-                            discussions = await gl_client.list_mr_discussions(project.id, mr.iid)
+                            discussions = await gl_client.list_mr_discussions(project_id, mr_iid)
                             triggering = _find_triggering_discussion(discussions, note_id)
                             if triggering:
                                 gl = gitlab.Gitlab(settings.gitlab_url, private_token=token)
-                                gl_project = gl.projects.get(project.id)
-                                gl_mr = gl_project.mergerequests.get(mr.iid)
+                                gl_project = gl.projects.get(project_id)
+                                gl_mr = gl_project.mergerequests.get(mr_iid)
                                 disc_obj = gl_mr.discussions.get(triggering.discussion_id)
                                 await asyncio.to_thread(
                                     disc_obj.notes.create,
-                                    {"body": branch_deleted_message(mr.source_branch)},
+                                    {"body": branch_deleted_message(event.branch)},
                                 )
                         except Exception:
                             await bound_log.awarning("branch_deleted_reply_failed", exc_info=True)
@@ -124,8 +130,8 @@ async def handle_discussion_interaction(
                     raise
 
                 # 2. Fetch MR details + discussions
-                mr_details = await gl_client.get_mr_details(project.id, mr.iid)
-                discussions = await gl_client.list_mr_discussions(project.id, mr.iid)
+                mr_details = await gl_client.get_mr_details(project_id, mr_iid)
+                discussions = await gl_client.list_mr_discussions(project_id, mr_iid)
                 discussion_history = DiscussionHistory(
                     discussions=discussions, agent=agent_identity
                 )
@@ -142,10 +148,10 @@ async def handle_discussion_interaction(
                     executor,
                     settings,
                     str(repo_path),
-                    project.git_http_url,
+                    clone_url,
                     system_prompt=get_prompt(settings, "discussion"),
                     user_prompt=user_prompt,
-                    source_branch=mr.source_branch,
+                    source_branch=event.branch,
                     note_id=note_id,
                 )
 
@@ -159,24 +165,27 @@ async def handle_discussion_interaction(
                     has_code_changes=has_patch,
                 )
 
+                # Build commit message from note body or fallback
+                commit_subject = (event.note_body or "discussion fix")[:50]
+
                 if has_patch:
                     await apply_coding_result(result, repo_path)
                     has_changes = await git_commit(
                         repo_path,
-                        f"fix: {payload.object_attributes.note[:50]}",
+                        f"fix: {commit_subject}",
                         settings.agent_author_name,
                         settings.agent_author_email,
                     )
                     if has_changes:
-                        await git_push(repo_path, "origin", mr.source_branch, token)
+                        await git_push(repo_path, "origin", event.branch, token)
                         response = response.model_copy(
                             update={"reply": f"{response.reply}\n\n✅ Changes pushed."}
                         )
 
                 # 7. Post reply to the existing thread
                 gl = gitlab.Gitlab(settings.gitlab_url, private_token=token)
-                gl_project = gl.projects.get(project.id)
-                gl_mr = gl_project.mergerequests.get(mr.iid)
+                gl_project = gl.projects.get(project_id)
+                gl_mr = gl_project.mergerequests.get(mr_iid)
                 disc_obj = gl_mr.discussions.get(triggering.discussion_id)
                 await asyncio.to_thread(disc_obj.notes.create, {"body": response.reply})
                 await bound_log.ainfo("discussion_reply_posted")
@@ -221,7 +230,7 @@ async def handle_discussion_interaction(
                 )
                 try:
                     await gl_client.post_mr_comment(
-                        project.id, mr.iid, user_error_message(error_str)
+                        project_id, mr_iid, user_error_message(error_str)
                     )
                 except Exception:
                     await bound_log.awarning("error_comment_failed", exc_info=True)
@@ -234,8 +243,8 @@ async def handle_discussion_interaction(
                 )
                 try:
                     await gl_client.post_mr_comment(
-                        project.id,
-                        mr.iid,
+                        project_id,
+                        mr_iid,
                         "❌ Unable to process your request. "
                         "The service encountered an unexpected error. "
                         "Please try again or contact the project administrator.",
@@ -248,7 +257,7 @@ async def handle_discussion_interaction(
                     await asyncio.to_thread(shutil.rmtree, repo_path, True)
 
         if repo_locks:
-            async with repo_locks.acquire(project.git_http_url):
+            async with repo_locks.acquire(clone_url):
                 await _execute()
         else:
             await _execute()

--- a/src/gitlab_copilot_agent/events.py
+++ b/src/gitlab_copilot_agent/events.py
@@ -1,0 +1,109 @@
+"""Internal event models — unified trigger → pipeline contract.
+
+All trigger paths (webhook, GitLab poller, Jira poller) produce ``TaskEvent``;
+orchestrators and future pipelines consume it.  Replaces direct webhook
+payload passing and eliminates synthetic payload construction in pollers.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from gitlab_copilot_agent.mapping_models import (
+    ResolutionBehavior,  # noqa: TC001 — Pydantic runtime
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+TriggerSource = Literal["webhook", "gitlab_poller", "jira_poller"]
+TaskType = Literal["review", "discussion", "coding"]
+
+
+class TaskEvent(BaseModel):
+    """Unified internal event from any trigger.
+
+    Carries enough context for dedup, scheduling, and pipeline execution.
+    Frozen after construction — treat as immutable value object.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    task_type: TaskType = Field(description="Pipeline to invoke")
+    project_id: int = Field(description="GitLab numeric project ID")
+    repo: str = Field(description="GitLab repo path_with_namespace")
+    clone_url: str = Field(description="Git HTTP clone URL")
+    branch: str = Field(description="Source branch to review/work on")
+    target_branch: str = Field(description="Target branch for MR")
+    mr_iid: int | None = Field(
+        default=None, description="MR IID (None for coding tasks without MR)"
+    )
+    head_sha: str | None = Field(default=None, description="HEAD commit SHA for dedup")
+    trigger_source: TriggerSource = Field(description="Which trigger produced this event")
+    token: str = Field(
+        description="GitLab token for this project",
+        repr=False,
+        exclude=True,
+    )
+    credential_ref: str = Field(default="default", description="Credential registry key")
+    resolution_behavior: ResolutionBehavior = Field(
+        default="suggest", description="Resolution behavior for this project"
+    )
+
+    # Discussion-specific fields
+    note_id: int | None = Field(default=None, description="Triggering note ID (discussion events)")
+    discussion_id: str | None = Field(
+        default=None, description="Discussion ID (discussion events)"
+    )
+    note_body: str | None = Field(default=None, description="Note body text (discussion events)")
+
+    # Coding-specific fields
+    jira_issue_key: str | None = Field(default=None, description="Jira issue key (coding events)")
+
+    @model_validator(mode="after")
+    def _validate_task_fields(self) -> TaskEvent:
+        """Enforce required fields per task type to prevent invalid states."""
+        if self.task_type == "review":
+            if self.mr_iid is None:
+                msg = "review events require mr_iid"
+                raise ValueError(msg)
+            if self.head_sha is None:
+                msg = "review events require head_sha"
+                raise ValueError(msg)
+        elif self.task_type == "discussion":
+            if self.mr_iid is None:
+                msg = "discussion events require mr_iid"
+                raise ValueError(msg)
+            if self.note_id is None:
+                msg = "discussion events require note_id"
+                raise ValueError(msg)
+        return self
+
+    def log_safe(self) -> dict[str, object]:
+        """Return a dict safe for structured logging — no secrets.
+
+        Token is already excluded by ``Field(exclude=True)``, but this
+        method provides defense-in-depth by explicitly removing it.
+        """
+        d = self.model_dump()
+        d.pop("token", None)
+        return d
+
+    def __iter__(self) -> Iterator[tuple[str, object]]:  # type: ignore[override]
+        """Prevent token leakage via dict(event) or **event."""
+        yield from self.model_dump().items()
+
+
+class ScheduledTask(BaseModel):
+    """Deduped, enriched task ready for pipeline execution.
+
+    Produced by the scheduler/dedup layer after the duplicate check passes.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    event: TaskEvent = Field(description="Original trigger event")
+    dedup_key: str = Field(description="Key used for dedup check")
+    trace_id: str = Field(default="", description="W3C trace ID for cross-boundary propagation")

--- a/src/gitlab_copilot_agent/gitlab_poller.py
+++ b/src/gitlab_copilot_agent/gitlab_poller.py
@@ -14,22 +14,11 @@ from gitlab_copilot_agent.config import Settings
 from gitlab_copilot_agent.credential_registry import CredentialRegistry
 from gitlab_copilot_agent.discussion_models import AgentIdentity
 from gitlab_copilot_agent.discussion_orchestrator import handle_discussion_interaction
+from gitlab_copilot_agent.events import TaskEvent
 from gitlab_copilot_agent.gitlab_client import (
     GitLabClient,
     GitLabClientProtocol,
-    MRAuthor,
     MRListItem,
-    NoteListItem,
-)
-from gitlab_copilot_agent.models import (
-    MergeRequestWebhookPayload,
-    MRLastCommit,
-    MRObjectAttributes,
-    NoteMergeRequest,
-    NoteObjectAttributes,
-    NoteWebhookPayload,
-    WebhookProject,
-    WebhookUser,
 )
 from gitlab_copilot_agent.orchestrator import handle_review
 from gitlab_copilot_agent.project_registry import ProjectRegistry
@@ -194,29 +183,11 @@ class GitLabPoller:
             key = f"review:{project_id}:{mr.iid}"
         if await self._dedup.is_seen(key):
             return
-        # Extract path from web_url: https://gitlab.example.com/group/project/-/merge_requests/1
+        # Extract namespace from web_url: https://gitlab.example.com/group/project/-/merge_requests/1
         project_url = mr.web_url.split("/-/")[0]
         ns = project_url.removeprefix(self._settings.gitlab_url).strip("/")
-        payload = MergeRequestWebhookPayload(
-            object_kind="merge_request",
-            user=WebhookUser(id=mr.author.id, username=mr.author.username),
-            project=WebhookProject(
-                id=project_id,
-                path_with_namespace=ns,
-                git_http_url=f"{project_url}.git",
-            ),
-            object_attributes=MRObjectAttributes(
-                iid=mr.iid,
-                title=mr.title,
-                description=mr.description or "",
-                action="update",
-                source_branch=mr.source_branch,
-                target_branch=mr.target_branch,
-                last_commit=MRLastCommit(id=mr.sha, message=""),
-                url=mr.web_url,
-                oldrev=None,
-            ),
-        )
+        clone_url = f"{project_url}.git"
+
         credential_ref = "default"
         resolution_behavior = self._settings.resolution_behavior
         if self._project_registry is not None:
@@ -224,15 +195,28 @@ class GitLabPoller:
             if resolved is not None:
                 credential_ref = resolved.credential_ref
                 resolution_behavior = resolved.resolution_behavior
+
+        token = self._resolve_token(project_id) or self._settings.gitlab_token
+        event = TaskEvent(
+            task_type="review",
+            project_id=project_id,
+            repo=ns,
+            clone_url=clone_url,
+            branch=mr.source_branch,
+            target_branch=mr.target_branch,
+            mr_iid=mr.iid,
+            head_sha=mr.sha,
+            trigger_source="gitlab_poller",
+            token=token,
+            credential_ref=credential_ref,
+            resolution_behavior=resolution_behavior,
+        )
         try:
             await handle_review(
                 self._settings,
-                payload,
+                event,
                 self._executor,
-                project_token=self._resolve_token(project_id),
                 credential_registry=self._credential_registry,
-                resolution_behavior=resolution_behavior,
-                credential_ref=credential_ref,
             )
         except TaskExecutionError:
             await log.awarning("gitlab_review_task_failed", project_id=project_id, mr_iid=mr.iid)
@@ -270,6 +254,17 @@ class GitLabPoller:
         mention_pattern = re.compile(
             rf"(?<![.\w-])@{re.escape(agent_identity.username)}(?![.\w-])"
         )
+
+        # Resolve per-project settings once
+        credential_ref = "default"
+        resolution_behavior = self._settings.resolution_behavior
+        if self._project_registry is not None:
+            resolved = self._project_registry.get_by_project_id(project_id)
+            if resolved is not None:
+                credential_ref = resolved.credential_ref
+                resolution_behavior = resolved.resolution_behavior
+        token = self._resolve_token(project_id) or self._settings.gitlab_token
+
         for mr in mrs:
             if mr.sha is None:
                 continue
@@ -279,6 +274,11 @@ class GitLabPoller:
             except Exception:
                 await log.awarning("discussion_fetch_failed", project_id=project_id, mr_iid=mr.iid)
                 continue
+
+            # Extract namespace from web_url
+            project_url = mr.web_url.split("/-/")[0]
+            ns = project_url.removeprefix(self._settings.gitlab_url).strip("/")
+            clone_url = f"{project_url}.git"
 
             for disc in discussions:
                 if disc.is_resolved:
@@ -310,27 +310,29 @@ class GitLabPoller:
                 if await self._dedup.is_seen(note_key):
                     continue
 
-                # Build payload from the discussion note
-                note_as_list_item = NoteListItem(
-                    id=latest_note.note_id,
-                    body=latest_note.body,
-                    author=MRAuthor(
-                        id=latest_note.author_id, username=latest_note.author_username
-                    ),
-                    system=latest_note.is_system,
-                    created_at=latest_note.created_at,
+                event = TaskEvent(
+                    task_type="discussion",
+                    project_id=project_id,
+                    repo=ns,
+                    clone_url=clone_url,
+                    branch=mr.source_branch,
+                    target_branch=mr.target_branch,
+                    mr_iid=mr.iid,
+                    trigger_source="gitlab_poller",
+                    token=token,
+                    credential_ref=credential_ref,
+                    resolution_behavior=resolution_behavior,
+                    note_id=latest_note.note_id,
+                    discussion_id=disc.discussion_id,
+                    note_body=latest_note.body,
                 )
-                payload = _build_note_payload(note_as_list_item, mr, project_id, self._settings)
-                # Add discussion_id to the payload for the handler
-                payload.object_attributes.discussion_id = disc.discussion_id
 
                 try:
                     await handle_discussion_interaction(
                         self._settings,
-                        payload,
+                        event,
                         self._executor,
                         agent_identity,
-                        project_token=self._resolve_token(project_id),
                         repo_locks=self._repo_locks,
                     )
                 except TaskExecutionError:
@@ -343,34 +345,3 @@ class GitLabPoller:
                     await self._dedup.mark_seen(note_key, ttl_seconds=_DEDUP_TTL)
                     continue
                 await self._dedup.mark_seen(note_key, ttl_seconds=_DEDUP_TTL)
-
-
-def _build_note_payload(
-    note: NoteListItem,
-    mr: MRListItem,
-    project_id: int,
-    settings: Settings,
-) -> NoteWebhookPayload:
-    """Synthesize a NoteWebhookPayload from API models."""
-    project_url = mr.web_url.split("/-/")[0]
-    ns = project_url.removeprefix(settings.gitlab_url).strip("/")
-    return NoteWebhookPayload(
-        object_kind="note",
-        user=WebhookUser(id=note.author.id, username=note.author.username),
-        project=WebhookProject(
-            id=project_id,
-            path_with_namespace=ns,
-            git_http_url=f"{project_url}.git",
-        ),
-        object_attributes=NoteObjectAttributes(
-            id=note.id,
-            note=note.body,
-            noteable_type="MergeRequest",
-        ),
-        merge_request=NoteMergeRequest(
-            iid=mr.iid,
-            title=mr.title,
-            source_branch=mr.source_branch,
-            target_branch=mr.target_branch,
-        ),
-    )

--- a/src/gitlab_copilot_agent/orchestrator.py
+++ b/src/gitlab_copilot_agent/orchestrator.py
@@ -27,8 +27,7 @@ from gitlab_copilot_agent.telemetry import get_tracer
 if TYPE_CHECKING:
     from gitlab_copilot_agent.config import Settings
     from gitlab_copilot_agent.credential_registry import CredentialRegistry
-    from gitlab_copilot_agent.mapping_models import ResolutionBehavior
-    from gitlab_copilot_agent.models import MergeRequestWebhookPayload
+    from gitlab_copilot_agent.events import TaskEvent
     from gitlab_copilot_agent.task_executor import TaskExecutor
 
 log = structlog.get_logger()
@@ -37,44 +36,50 @@ _tracer = get_tracer(__name__)
 
 async def handle_review(
     settings: Settings,
-    payload: MergeRequestWebhookPayload,
+    event: TaskEvent,
     executor: TaskExecutor,
-    project_token: str | None = None,
     credential_registry: CredentialRegistry | None = None,
-    resolution_behavior: ResolutionBehavior = "suggest",
-    credential_ref: str = "default",
 ) -> None:
     """Full review pipeline: clone → review → parse → post comments."""
-    mr = payload.object_attributes
-    project = payload.project
+    project_id = event.project_id
+    mr_iid = event.mr_iid
+    if mr_iid is None:
+        msg = "review events require mr_iid"
+        raise ValueError(msg)
+    head_sha = event.head_sha
+    if head_sha is None:
+        msg = "review events require head_sha"
+        raise ValueError(msg)
+    token = event.token
+    clone_url = event.clone_url
+
     start = time.monotonic()
     outcome = "error"
     with _tracer.start_as_current_span(
-        "mr.review", attributes={"project_id": project.id, "mr_iid": mr.iid}
+        "mr.review", attributes={"project_id": project_id, "mr_iid": mr_iid}
     ):
-        bound_log = log.bind(project_id=project.id, mr_iid=mr.iid)
+        bound_log = log.bind(project_id=project_id, mr_iid=mr_iid)
 
         bound_log.info("review_started")
 
-        token = project_token or settings.gitlab_token
         gl_client = GitLabClient(settings.gitlab_url, token)
         repo_path: Path | None = None
 
         try:
-            validate_clone_url_host(project.git_http_url, settings.gitlab_url)
+            validate_clone_url_host(clone_url, settings.gitlab_url)
             repo_path = await gl_client.clone_repo(
-                project.git_http_url,
-                mr.source_branch,
+                clone_url,
+                event.branch,
                 token,
                 clone_dir=settings.clone_dir,
             )
 
-            mr_details = await gl_client.get_mr_details(project.id, mr.iid)
+            mr_details = await gl_client.get_mr_details(project_id, mr_iid)
 
             # Fetch commit messages for developer intent context (graceful degradation)
             commit_messages: list[str] = []
             try:
-                commits = await gl_client.get_mr_commits(project.id, mr.iid)
+                commits = await gl_client.get_mr_commits(project_id, mr_iid)
                 commit_messages = [c.message for c in commits]
                 bound_log.info("commits_loaded", commit_count=len(commits))
             except Exception:
@@ -85,9 +90,9 @@ async def handle_review(
             discussion_history: DiscussionHistory | None = None
             if credential_registry is not None:
                 try:
-                    discussions = await gl_client.list_mr_discussions(project.id, mr.iid)
+                    discussions = await gl_client.list_mr_discussions(project_id, mr_iid)
                     agent_identity = await credential_registry.resolve_identity(
-                        credential_ref, settings.gitlab_url
+                        event.credential_ref, settings.gitlab_url
                     )
                     discussion_history = DiscussionHistory(
                         discussions=discussions, agent=agent_identity
@@ -103,7 +108,6 @@ async def handle_review(
                 bound_log.debug("discussion_history_skipped", reason="no_credential_registry")
 
             # Build diff text — incremental when a prior review marker exists
-            head_sha = mr.last_commit.id
             is_incremental = False
             diff_text = ""
             last_reviewed_sha = extract_last_reviewed_sha(discussion_history)
@@ -111,7 +115,7 @@ async def handle_review(
             if last_reviewed_sha and last_reviewed_sha != head_sha:
                 try:
                     incremental_changes = await gl_client.compare_commits(
-                        project.id, last_reviewed_sha, head_sha
+                        project_id, last_reviewed_sha, head_sha
                     )
                     if incremental_changes:
                         diff_text = "\n".join(
@@ -134,10 +138,10 @@ async def handle_review(
                 )
 
             review_req = ReviewRequest(
-                title=mr.title,
-                description=mr.description,
-                source_branch=mr.source_branch,
-                target_branch=mr.target_branch,
+                title=mr_details.title,
+                description=mr_details.description,
+                source_branch=event.branch,
+                target_branch=event.target_branch,
                 commit_messages=commit_messages,
             )
 
@@ -145,7 +149,7 @@ async def handle_review(
                 executor,
                 settings,
                 str(repo_path),
-                project.git_http_url,
+                clone_url,
                 review_req,
                 diff_text=diff_text,
                 discussion_history=discussion_history,
@@ -178,12 +182,12 @@ async def handle_review(
 
             await post_review(
                 gl,
-                project.id,
-                mr.iid,
+                project_id,
+                mr_iid,
                 mr_details.diff_refs,
                 parsed,
                 mr_details.changes,
-                resolution_behavior=resolution_behavior,
+                resolution_behavior=event.resolution_behavior,
                 allowed_discussion_ids=allowed_discussion_ids,
                 head_sha=head_sha,
             )
@@ -194,8 +198,8 @@ async def handle_review(
             bound_log.error("review_task_failed", error=error_str)
             try:
                 await gl_client.post_mr_comment(
-                    project.id,
-                    mr.iid,
+                    project_id,
+                    mr_iid,
                     f"⚠️ Automated review failed.\n\n{user_error_message(error_str)}",
                 )
             except Exception:
@@ -209,8 +213,8 @@ async def handle_review(
             )
             try:
                 await gl_client.post_mr_comment(
-                    project.id,
-                    mr.iid,
+                    project_id,
+                    mr_iid,
                     "⚠️ Automated review failed. "
                     "The service encountered an unexpected error. "
                     "Please try again or contact the project administrator.",

--- a/src/gitlab_copilot_agent/webhook.py
+++ b/src/gitlab_copilot_agent/webhook.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, Request
 from gitlab_copilot_agent.app_context import get_app_context
 from gitlab_copilot_agent.discussion_models import AgentIdentity
 from gitlab_copilot_agent.discussion_orchestrator import handle_discussion_interaction
+from gitlab_copilot_agent.events import TaskEvent
 from gitlab_copilot_agent.gitlab_client import GitLabClient
 from gitlab_copilot_agent.metrics import webhook_errors_total, webhook_received_total
 from gitlab_copilot_agent.models import MergeRequestWebhookPayload, NoteWebhookPayload
@@ -71,17 +72,29 @@ async def _process_review(request: Request, payload: MergeRequestWebhookPayload)
             resolution_behavior = resolved.resolution_behavior
             credential_ref = resolved.credential_ref
 
-    bound = log.bind(project_id=project_id, mr_iid=mr.iid, head_sha=head_sha)
+    event = TaskEvent(
+        task_type="review",
+        project_id=project_id,
+        repo=payload.project.path_with_namespace,
+        clone_url=payload.project.git_http_url,
+        branch=mr.source_branch,
+        target_branch=mr.target_branch,
+        mr_iid=mr.iid,
+        head_sha=head_sha,
+        trigger_source="webhook",
+        token=project_token,
+        credential_ref=credential_ref,
+        resolution_behavior=resolution_behavior,
+    )
+
+    bound = log.bind(**event.log_safe())
     bound.info("background_review_starting")
     try:
         await handle_review(
             settings,
-            payload,
+            event,
             executor,
-            project_token=project_token,
             credential_registry=credential_registry,
-            resolution_behavior=resolution_behavior,
-            credential_ref=credential_ref,
         )
         review_tracker.mark(project_id, mr.iid, head_sha)
         # Also mark in shared dedup store so the poller won't re-review
@@ -151,26 +164,44 @@ async def _process_discussion(
 
     # Resolve resolution behavior from project registry or global settings
     resolution_behavior = settings.resolution_behavior
+    credential_ref = "default"
     if registry is not None:
         resolved_project = registry.get_by_project_id(payload.project.id)
         if resolved_project is not None:
             resolution_behavior = resolved_project.resolution_behavior
+            credential_ref = resolved_project.credential_ref
+
+    mr_iid = payload.merge_request.iid if payload.merge_request else 0
+    event = TaskEvent(
+        task_type="discussion",
+        project_id=payload.project.id,
+        repo=payload.project.path_with_namespace,
+        clone_url=payload.project.git_http_url,
+        branch=payload.merge_request.source_branch,
+        target_branch=payload.merge_request.target_branch,
+        mr_iid=mr_iid,
+        trigger_source="webhook",
+        token=project_token,
+        credential_ref=credential_ref,
+        resolution_behavior=resolution_behavior,
+        note_id=payload.object_attributes.id,
+        discussion_id=payload.object_attributes.discussion_id,
+        note_body=payload.object_attributes.note,
+    )
 
     bound = log.bind(
         project_id=payload.project.id,
-        mr_iid=payload.merge_request.iid if payload.merge_request else None,
+        mr_iid=mr_iid,
         note_body=payload.object_attributes.note[:80],
     )
     bound.info("background_discussion_starting")
     try:
         await handle_discussion_interaction(
             settings,
-            payload,
+            event,
             executor,
             agent_identity,
-            project_token=project_token,
             repo_locks=repo_locks,
-            resolution_behavior=resolution_behavior,
         )
         bound.info("background_discussion_completed")
     except Exception:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from httpx import ASGITransport, AsyncClient
 
 from gitlab_copilot_agent.app_context import AppContext
 from gitlab_copilot_agent.config import Settings
+from gitlab_copilot_agent.events import TaskEvent
 from gitlab_copilot_agent.gitlab_client import MRChange, MRDiffRef
 from gitlab_copilot_agent.main import app
 from gitlab_copilot_agent.models import (
@@ -155,6 +156,29 @@ def make_webhook_payload(**attr_overrides: Any) -> MergeRequestWebhookPayload:
         project=WebhookProject(**MR_PAYLOAD["project"]),
         object_attributes=MRObjectAttributes(**attrs),
     )
+
+
+def make_task_event(**overrides: Any) -> TaskEvent:
+    """Create a TaskEvent with test defaults for the review path.
+
+    Override any field. For discussion events, pass ``task_type="discussion"``
+    plus ``note_id`` and ``note_body``.
+    """
+    defaults: dict[str, Any] = {
+        "task_type": "review",
+        "project_id": PROJECT_ID,
+        "repo": "group/my-project",
+        "clone_url": "https://gitlab.example.com/group/my-project.git",
+        "branch": "feature/x",
+        "target_branch": "main",
+        "mr_iid": MR_IID,
+        "head_sha": "abc123",
+        "trigger_source": "webhook",
+        "token": GITLAB_TOKEN,
+        "credential_ref": "default",
+        "resolution_behavior": "suggest",
+    }
+    return TaskEvent(**(defaults | overrides))
 
 
 # -- Fixtures --

--- a/tests/test_discussion_orchestrator.py
+++ b/tests/test_discussion_orchestrator.py
@@ -15,20 +15,12 @@ from gitlab_copilot_agent.discussion_models import (
     Discussion,
     DiscussionNote,
 )
-from gitlab_copilot_agent.models import (
-    NoteMergeRequest,
-    NoteObjectAttributes,
-    NoteWebhookPayload,
-    WebhookProject,
-    WebhookUser,
-)
+from gitlab_copilot_agent.events import TaskEvent
 from gitlab_copilot_agent.task_executor import CodingResult, ReviewResult, TaskExecutionError
-from tests.conftest import make_settings
+from tests.conftest import GITLAB_TOKEN, MR_IID, PROJECT_ID, make_settings
 
-# -- Test constants --
+# -- Test constants (discussion-specific) --
 
-PROJECT_ID = 42
-MR_IID = 7
 NOTE_ID = 501
 DISCUSSION_ID = "disc-001"
 AGENT_USER_ID = 99
@@ -38,7 +30,6 @@ TARGET_BRANCH = "main"
 CLONE_URL = "https://gitlab.example.com/group/project.git"
 PROJECT_PATH = "group/project"
 NOTE_TEXT = "@review-bot please explain this"
-MR_TITLE = "Test MR"
 REPLY_TEXT = "Here is my explanation."
 CHANGES_PUSHED_MARKER = "✅ Changes pushed."
 GENERIC_ERROR_SNIPPET = "❌ Unable to process your request"
@@ -50,29 +41,22 @@ _MOD = "gitlab_copilot_agent.discussion_orchestrator"
 # -- Factories --
 
 
-def _make_payload(**overrides: Any) -> NoteWebhookPayload:
+def _make_event(**overrides: Any) -> TaskEvent:
     defaults: dict[str, Any] = {
-        "object_kind": "note",
-        "user": WebhookUser(id=1, username="developer"),
-        "project": WebhookProject(
-            id=PROJECT_ID,
-            path_with_namespace=PROJECT_PATH,
-            git_http_url=CLONE_URL,
-        ),
-        "object_attributes": NoteObjectAttributes(
-            id=NOTE_ID,
-            note=NOTE_TEXT,
-            noteable_type="MergeRequest",
-            discussion_id=DISCUSSION_ID,
-        ),
-        "merge_request": NoteMergeRequest(
-            iid=MR_IID,
-            title=MR_TITLE,
-            source_branch=SOURCE_BRANCH,
-            target_branch=TARGET_BRANCH,
-        ),
+        "task_type": "discussion",
+        "project_id": PROJECT_ID,
+        "repo": PROJECT_PATH,
+        "clone_url": CLONE_URL,
+        "branch": SOURCE_BRANCH,
+        "target_branch": TARGET_BRANCH,
+        "mr_iid": MR_IID,
+        "trigger_source": "webhook",
+        "token": GITLAB_TOKEN,
+        "note_id": NOTE_ID,
+        "discussion_id": DISCUSSION_ID,
+        "note_body": NOTE_TEXT,
     }
-    return NoteWebhookPayload(**(defaults | overrides))
+    return TaskEvent(**(defaults | overrides))
 
 
 def _make_agent() -> AgentIdentity:
@@ -167,7 +151,7 @@ async def test_qa_reply_no_code_changes(
     executor = AsyncMock()
     await handle_discussion_interaction(
         make_settings(),
-        _make_payload(),
+        _make_event(),
         executor,
         _make_agent(),
     )
@@ -220,7 +204,7 @@ async def test_coding_reply_with_changes(
     executor = AsyncMock()
     await handle_discussion_interaction(
         make_settings(),
-        _make_payload(),
+        _make_event(),
         executor,
         _make_agent(),
     )
@@ -271,7 +255,7 @@ async def test_coding_reply_empty_patch(
     executor = AsyncMock()
     await handle_discussion_interaction(
         make_settings(),
-        _make_payload(),
+        _make_event(),
         executor,
         _make_agent(),
     )
@@ -303,7 +287,7 @@ async def test_triggering_discussion_not_found(
     executor = AsyncMock()
     await handle_discussion_interaction(
         make_settings(),
-        _make_payload(),
+        _make_event(),
         executor,
         _make_agent(),
     )
@@ -337,7 +321,7 @@ async def test_task_execution_error_posts_user_error(
     with pytest.raises(TaskExecutionError):
         await handle_discussion_interaction(
             make_settings(),
-            _make_payload(),
+            _make_event(),
             executor,
             _make_agent(),
         )
@@ -364,7 +348,7 @@ async def test_general_exception_posts_generic_error(
     with pytest.raises(RuntimeError, match="unexpected"):
         await handle_discussion_interaction(
             make_settings(),
-            _make_payload(),
+            _make_event(),
             executor,
             _make_agent(),
         )
@@ -393,7 +377,7 @@ async def test_cleanup_runs_on_failure(
     with pytest.raises(RuntimeError):
         await handle_discussion_interaction(
             make_settings(),
-            _make_payload(),
+            _make_event(),
             executor,
             _make_agent(),
         )
@@ -442,7 +426,7 @@ async def test_repo_lock_used_when_provided(
     executor = AsyncMock()
     await handle_discussion_interaction(
         make_settings(),
-        _make_payload(),
+        _make_event(),
         executor,
         _make_agent(),
         repo_locks=repo_locks,
@@ -488,7 +472,7 @@ async def test_deleted_branch_replies_with_warning(
 
     await handle_discussion_interaction(
         make_settings(),
-        _make_payload(),
+        _make_event(),
         AsyncMock(),
         _make_agent(),
     )
@@ -558,10 +542,9 @@ async def test_discussion_interaction_auto_resolve(
     executor = AsyncMock()
     await handle_discussion_interaction(
         make_settings(),
-        _make_payload(),
+        _make_event(resolution_behavior="auto-resolve"),
         executor,
         _make_agent(),
-        resolution_behavior="auto-resolve",
     )
 
     # Reply posted
@@ -606,10 +589,9 @@ async def test_discussion_interaction_suggest_no_resolve(
     executor = AsyncMock()
     await handle_discussion_interaction(
         make_settings(),
-        _make_payload(),
+        _make_event(resolution_behavior="suggest"),
         executor,
         _make_agent(),
-        resolution_behavior="suggest",
     )
 
     # Reply posted
@@ -653,10 +635,9 @@ async def test_discussion_interaction_off_no_action(
     executor = AsyncMock()
     await handle_discussion_interaction(
         make_settings(),
-        _make_payload(),
+        _make_event(resolution_behavior="off"),
         executor,
         _make_agent(),
-        resolution_behavior="off",
     )
 
     # Reply still posted
@@ -700,10 +681,9 @@ async def test_discussion_interaction_partial_never_resolved(
     executor = AsyncMock()
     await handle_discussion_interaction(
         make_settings(),
-        _make_payload(),
+        _make_event(resolution_behavior="auto-resolve"),
         executor,
         _make_agent(),
-        resolution_behavior="auto-resolve",
     )
 
     # Reply posted
@@ -755,10 +735,9 @@ async def test_discussion_interaction_resolution_error_logged(
     # Should NOT raise — resolution errors are swallowed and logged
     await handle_discussion_interaction(
         make_settings(),
-        _make_payload(),
+        _make_event(resolution_behavior="auto-resolve"),
         executor,
         _make_agent(),
-        resolution_behavior="auto-resolve",
     )
 
     # Reply still posted successfully

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,122 @@
+"""Tests for TaskEvent and ScheduledTask models."""
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from gitlab_copilot_agent.events import ScheduledTask
+from tests.conftest import GITLAB_TOKEN, MR_IID, PROJECT_ID, make_task_event
+
+_CODING_OPTIONAL = {"task_type": "coding", "mr_iid": None, "head_sha": None}
+
+
+# -- Construction --
+
+
+@pytest.mark.parametrize(
+    ("overrides", "field", "expected"),
+    [
+        ({}, "task_type", "review"),
+        ({}, "project_id", PROJECT_ID),
+        ({}, "mr_iid", MR_IID),
+        ({}, "head_sha", "abc123"),
+        ({"task_type": "discussion", "head_sha": None, "note_id": 99}, "note_id", 99),
+        ({**_CODING_OPTIONAL, "jira_issue_key": "P-1"}, "jira_issue_key", "P-1"),
+        (_CODING_OPTIONAL, "mr_iid", None),
+    ],
+    ids=[
+        "review-type",
+        "project-id",
+        "mr-iid",
+        "head-sha",
+        "discussion-note-id",
+        "coding-jira-key",
+        "coding-no-mr",
+    ],
+)
+def test_task_event_field_access(overrides: dict[str, Any], field: str, expected: object) -> None:
+    assert getattr(make_task_event(**overrides), field) == expected
+
+
+def test_frozen_model_prevents_mutation() -> None:
+    with pytest.raises(ValidationError):
+        make_task_event().project_id = 999  # type: ignore[misc]
+
+
+# -- Validation: required fields per task_type --
+
+_DISC_BASE = {"task_type": "discussion", "head_sha": None}
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"mr_iid": None}, "review events require mr_iid"),
+        ({"head_sha": None}, "review events require head_sha"),
+        ({**_DISC_BASE, "mr_iid": None, "note_id": 1}, "discussion events require mr_iid"),
+        (_DISC_BASE, "discussion events require note_id"),
+    ],
+    ids=["review-no-mr", "review-no-sha", "discussion-no-mr", "discussion-no-note"],
+)
+def test_task_event_rejects_invalid(overrides: dict[str, Any], match: str) -> None:
+    with pytest.raises(ValidationError, match=match):
+        make_task_event(**overrides)
+
+
+def test_coding_allows_all_optional() -> None:
+    assert make_task_event(**_CODING_OPTIONAL).task_type == "coding"
+
+
+# -- S1: token never leaks through serialization --
+
+
+@pytest.mark.parametrize(
+    "serialize",
+    [
+        lambda e: e.model_dump(),
+        dict,
+        lambda e: e.log_safe(),
+    ],
+    ids=["model_dump", "dict", "log_safe"],
+)
+def test_token_excluded_from_dict_output(serialize: Any) -> None:
+    assert "token" not in serialize(make_task_event())
+
+
+@pytest.mark.parametrize(
+    "to_str",
+    [lambda e: e.model_dump_json(), repr],
+    ids=["json", "repr"],
+)
+def test_token_excluded_from_string_output(to_str: Any) -> None:
+    assert GITLAB_TOKEN not in to_str(make_task_event())
+
+
+def test_token_accessible_for_execution() -> None:
+    assert make_task_event().token == GITLAB_TOKEN
+
+
+# -- log_safe preserves non-secret data --
+
+
+def test_log_safe_contains_expected_fields() -> None:
+    safe = make_task_event().log_safe()
+    assert safe["project_id"] == PROJECT_ID
+    assert safe["task_type"] == "review"
+
+
+# -- ScheduledTask --
+
+
+def test_scheduled_task_wraps_event() -> None:
+    event = make_task_event()
+    task = ScheduledTask(event=event, dedup_key="review:42:7:abc")
+    assert task.event is event
+    assert task.dedup_key == "review:42:7:abc"
+    assert task.trace_id == ""
+
+
+def test_scheduled_task_frozen() -> None:
+    with pytest.raises(ValidationError):
+        ScheduledTask(event=make_task_event(), dedup_key="x").dedup_key = "y"  # type: ignore[misc]

--- a/tests/test_gitlab_poller.py
+++ b/tests/test_gitlab_poller.py
@@ -14,7 +14,7 @@ from gitlab_copilot_agent.gitlab_client import MRAuthor, MRListItem, NoteListIte
 from gitlab_copilot_agent.gitlab_poller import GitLabPoller
 from gitlab_copilot_agent.project_registry import ProjectRegistry, ResolvedProject
 from gitlab_copilot_agent.task_executor import TaskExecutionError
-from tests.conftest import GITLAB_URL, MR_IID, PROJECT_ID, make_settings
+from tests.conftest import GITLAB_TOKEN, GITLAB_URL, MR_IID, PROJECT_ID, make_settings
 
 # -- Constants --
 MR_SHA = "deadbeef1234"
@@ -112,8 +112,8 @@ async def test_poll_once_discovers_mr(mock_hr: AsyncMock) -> None:
     cl.list_project_mrs.return_value = [_mr_item()]
     await poller._poll_once()
     mock_hr.assert_called_once()
-    assert mock_hr.call_args[0][1].object_attributes.iid == MR_IID
-    assert mock_hr.call_args[0][1].project.git_http_url == f"{GITLAB_URL}/{PATH_WITH_NS}.git"
+    assert mock_hr.call_args[0][1].mr_iid == MR_IID
+    assert mock_hr.call_args[0][1].clone_url == f"{GITLAB_URL}/{PATH_WITH_NS}.git"
 
 
 @pytest.mark.asyncio
@@ -227,9 +227,9 @@ async def test_note_discovery_triggers_discussion_orchestrator(
     cl.list_mr_discussions.return_value = [_discussion()]
     await poller._poll_once()
     mock_hd.assert_called_once()
-    payload = mock_hd.call_args[0][1]
-    assert payload.object_attributes.note == MENTION_BODY
-    assert payload.merge_request.iid == MR_IID
+    event = mock_hd.call_args[0][1]
+    assert event.note_body == MENTION_BODY
+    assert event.mr_iid == MR_IID
 
 
 @pytest.mark.asyncio
@@ -309,10 +309,9 @@ async def test_note_payload_has_correct_project_info(
     cl.list_project_mrs.return_value = [_mr_item()]
     cl.list_mr_discussions.return_value = [_discussion()]
     await poller._poll_once()
-    payload = mock_hd.call_args[0][1]
-    assert payload.project.path_with_namespace == PATH_WITH_NS
-    assert payload.project.git_http_url == f"{GITLAB_URL}/{PATH_WITH_NS}.git"
-    assert payload.user.username == NOTE_AUTHOR.username
+    event = mock_hd.call_args[0][1]
+    assert event.repo == PATH_WITH_NS
+    assert event.clone_url == f"{GITLAB_URL}/{PATH_WITH_NS}.git"
 
 
 @pytest.mark.asyncio
@@ -370,8 +369,8 @@ async def test_poll_passes_per_project_token_to_review(mock_hr: AsyncMock) -> No
     cl.list_project_mrs.return_value = [_mr_item()]
     await poller._poll_once()
     mock_hr.assert_called_once()
-    _, kwargs = mock_hr.call_args
-    assert kwargs["project_token"] == PER_PROJECT_TOKEN
+    event = mock_hr.call_args[0][1]
+    assert event.token == PER_PROJECT_TOKEN
 
 
 @pytest.mark.asyncio
@@ -388,22 +387,23 @@ async def test_poll_passes_credential_registry_and_ref_to_review(mock_hr: AsyncM
     mock_hr.assert_called_once()
     _, kwargs = mock_hr.call_args
     assert kwargs["credential_registry"] is creds
-    assert kwargs["credential_ref"] == "default"
-    assert kwargs["resolution_behavior"] == "suggest"
+    event = mock_hr.call_args[0][1]
+    assert event.credential_ref == "default"
+    assert event.resolution_behavior == "suggest"
 
 
 @pytest.mark.asyncio
 @patch(_HANDLE_REVIEW, new_callable=AsyncMock)
-async def test_poll_falls_back_to_none_when_not_in_registry(mock_hr: AsyncMock) -> None:
-    """Poller passes None token when project not in registry (global fallback)."""
+async def test_poll_falls_back_to_global_token_when_not_in_registry(mock_hr: AsyncMock) -> None:
+    """Poller uses global token when project not in registry."""
     registry = _make_project_registry(project_id=9999)
     poller, cl, _ = _poller()
     poller._project_registry = registry
     cl.list_project_mrs.return_value = [_mr_item()]
     await poller._poll_once()
     mock_hr.assert_called_once()
-    _, kwargs = mock_hr.call_args
-    assert kwargs["project_token"] is None
+    event = mock_hr.call_args[0][1]
+    assert event.token == GITLAB_TOKEN
 
 
 @pytest.mark.asyncio
@@ -421,8 +421,8 @@ async def test_poll_passes_per_project_token_to_discussion_orchestrator(
     cl.list_mr_discussions.return_value = [_discussion()]
     await poller._poll_once()
     mock_hd.assert_called_once()
-    _, kwargs = mock_hd.call_args
-    assert kwargs["project_token"] == PER_PROJECT_TOKEN
+    event = mock_hd.call_args[0][1]
+    assert event.token == PER_PROJECT_TOKEN
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -25,7 +25,7 @@ from tests.conftest import (
     PROJECT_ID,
     make_mr_changes,
     make_settings,
-    make_webhook_payload,
+    make_task_event,
 )
 
 
@@ -106,7 +106,7 @@ async def test_orchestrator_cleans_up_on_error(
     mock_gl_instance.cleanup = AsyncMock()
 
     with pytest.raises(RuntimeError, match="SDK crashed"):
-        await handle_review(make_settings(), make_webhook_payload(), AsyncMock())
+        await handle_review(make_settings(), make_task_event(), AsyncMock())
 
     mock_gl_instance.cleanup.assert_awaited_once()
 
@@ -170,10 +170,7 @@ async def test_discussion_history_passed_with_credential_registry(
     mock_registry.resolve_identity = AsyncMock(return_value=_AGENT_IDENTITY)
 
     await handle_review(
-        make_settings(),
-        make_webhook_payload(),
-        AsyncMock(),
-        credential_registry=mock_registry,
+        make_settings(), make_task_event(), AsyncMock(), credential_registry=mock_registry
     )
 
     mock_gl_instance.list_mr_discussions.assert_awaited_once_with(PROJECT_ID, MR_IID)
@@ -199,7 +196,7 @@ async def test_discussion_history_none_without_credential_registry(
     """Without credential_registry, discussion_history is None."""
     _setup_mocks(mock_client_class, mock_run_review)
 
-    await handle_review(make_settings(), make_webhook_payload(), AsyncMock())
+    await handle_review(make_settings(), make_task_event(), AsyncMock())
 
     review_kwargs = mock_run_review.call_args[1]
     assert review_kwargs["discussion_history"] is None
@@ -222,10 +219,7 @@ async def test_discussion_history_failure_is_non_fatal(
     mock_registry.resolve_identity = AsyncMock(side_effect=RuntimeError("API down"))
 
     await handle_review(
-        make_settings(),
-        make_webhook_payload(),
-        AsyncMock(),
-        credential_registry=mock_registry,
+        make_settings(), make_task_event(), AsyncMock(), credential_registry=mock_registry
     )
 
     # Review still ran, but without discussion_history
@@ -252,10 +246,7 @@ async def test_discussion_threads_flow_through_pipeline(
     mock_registry.resolve_identity = AsyncMock(return_value=_AGENT_IDENTITY)
 
     await handle_review(
-        make_settings(),
-        make_webhook_payload(),
-        AsyncMock(),
-        credential_registry=mock_registry,
+        make_settings(), make_task_event(), AsyncMock(), credential_registry=mock_registry
     )
 
     review_kwargs = mock_run_review.call_args[1]
@@ -301,9 +292,8 @@ async def test_resolution_behavior_flows_to_post_review(
 
     await handle_review(
         make_settings(),
-        make_webhook_payload(),
+        make_task_event(resolution_behavior="auto-resolve"),
         AsyncMock(),
-        resolution_behavior="auto-resolve",
     )
 
     mock_post_review.assert_awaited_once()
@@ -348,7 +338,7 @@ async def test_prior_feedback_rendered_in_prompt(
 
     await handle_review(
         make_settings(),
-        make_webhook_payload(),
+        make_task_event(),
         mock_executor,
         credential_registry=mock_registry,
     )
@@ -443,7 +433,7 @@ async def test_incremental_review_with_marker(
 
     await handle_review(
         make_settings(),
-        make_webhook_payload(),
+        make_task_event(),
         mock_executor,
         credential_registry=mock_registry,
     )
@@ -492,7 +482,7 @@ async def test_incremental_review_compare_fails_fallback(
 
     await handle_review(
         make_settings(),
-        make_webhook_payload(),
+        make_task_event(),
         mock_executor,
         credential_registry=mock_registry,
     )
@@ -607,7 +597,7 @@ async def test_suppressed_feedback_rendered_in_prompt(
 
     await handle_review(
         make_settings(),
-        make_webhook_payload(),
+        make_task_event(),
         mock_executor,
         credential_registry=mock_registry,
     )
@@ -659,7 +649,7 @@ async def test_commit_messages_in_review_prompt(
 
     await handle_review(
         make_settings(),
-        make_webhook_payload(),
+        make_task_event(),
         mock_executor,
     )
 
@@ -699,7 +689,7 @@ async def test_commit_fetch_failure_graceful_degradation(
 
     await handle_review(
         make_settings(),
-        make_webhook_payload(),
+        make_task_event(),
         mock_executor,
     )
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -19,7 +19,7 @@ from tests.conftest import (
     HEADERS,
     MR_PAYLOAD,
     make_settings,
-    make_webhook_payload,
+    make_task_event,
 )
 
 
@@ -132,7 +132,7 @@ async def test_review_pipeline_records_success_metrics(
         patch("gitlab_copilot_agent.orchestrator.reviews_total", mock_total),
         patch("gitlab_copilot_agent.orchestrator.reviews_duration", mock_duration),
     ):
-        await handle_review(make_settings(), make_webhook_payload(), AsyncMock())
+        await handle_review(make_settings(), make_task_event(), AsyncMock())
 
     mock_total.add.assert_called_once_with(1, {"outcome": "success"})
     mock_duration.record.assert_called_once()
@@ -162,7 +162,7 @@ async def test_review_pipeline_records_error_metrics(
         patch("gitlab_copilot_agent.orchestrator.reviews_duration", mock_duration),
         pytest.raises(RuntimeError),
     ):
-        await handle_review(make_settings(), make_webhook_payload(), AsyncMock())
+        await handle_review(make_settings(), make_task_event(), AsyncMock())
 
     mock_total.add.assert_called_once_with(1, {"outcome": "error"})
     mock_duration.record.assert_called_once()
@@ -188,7 +188,7 @@ async def test_review_task_execution_failure_posts_comment_without_raising(
     mock_run_review.side_effect = TaskExecutionError("Task failed: runner error")
 
     with pytest.raises(TaskExecutionError, match="runner error"):
-        await handle_review(make_settings(), make_webhook_payload(), AsyncMock())
+        await handle_review(make_settings(), make_task_event(), AsyncMock())
 
     mock_gl.post_mr_comment.assert_awaited_once()
     comment = mock_gl.post_mr_comment.call_args[0][2]

--- a/tests/test_multi_credential_integration.py
+++ b/tests/test_multi_credential_integration.py
@@ -220,7 +220,7 @@ async def test_note_webhook_multi_project_token_isolation(
             await asyncio.sleep(0.1)
 
             mock_handle.assert_awaited_once()
-            _, kwargs = mock_handle.call_args
-            assert kwargs["project_token"] == PROJECT_BETA_TOKEN
+            event = mock_handle.call_args[0][1]
+            assert event.token == PROJECT_BETA_TOKEN
     finally:
         app.state.project_registry = None

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -258,8 +258,8 @@ async def test_webhook_review_uses_per_project_token(client: AsyncClient) -> Non
             await asyncio.sleep(0.1)
 
         mock_handle.assert_awaited_once()
-        _, kwargs = mock_handle.call_args
-        assert kwargs["project_token"] == PER_PROJECT_TOKEN
+        event = mock_handle.call_args[0][1]
+        assert event.token == PER_PROJECT_TOKEN
     finally:
         app.state.project_registry = None
 
@@ -275,8 +275,8 @@ async def test_webhook_review_falls_back_to_global_token(client: AsyncClient) ->
             await asyncio.sleep(0.1)
 
         mock_handle.assert_awaited_once()
-        _, kwargs = mock_handle.call_args
-        assert kwargs["project_token"] == GITLAB_TOKEN
+        event = mock_handle.call_args[0][1]
+        assert event.token == GITLAB_TOKEN
     finally:
         app.state.project_registry = None
 
@@ -295,8 +295,8 @@ async def test_webhook_discussion_uses_per_project_token(client: AsyncClient) ->
             await asyncio.sleep(0.1)
 
         mock_handle.assert_awaited_once()
-        _, kwargs = mock_handle.call_args
-        assert kwargs["project_token"] == PER_PROJECT_TOKEN
+        event = mock_handle.call_args[0][1]
+        assert event.token == PER_PROJECT_TOKEN
     finally:
         app.state.project_registry = None
 
@@ -311,8 +311,8 @@ async def test_webhook_review_works_without_registry(client: AsyncClient) -> Non
         await asyncio.sleep(0.1)
 
     mock_handle.assert_awaited_once()
-    _, kwargs = mock_handle.call_args
-    assert kwargs["project_token"] == GITLAB_TOKEN
+    event = mock_handle.call_args[0][1]
+    assert event.token == GITLAB_TOKEN
 
 
 async def test_webhook_review_passes_credential_registry(client: AsyncClient) -> None:


### PR DESCRIPTION
## What

Introduce `TaskEvent` as the canonical internal event model (Phase 4, Step 4.1 — R3 Internal Event Model). All trigger paths now produce `TaskEvent`; orchestrators consume it instead of raw webhook payload objects.

Closes #382

## Why

- GitLab poller synthesized fake `MergeRequestWebhookPayload` and `NoteWebhookPayload` to call orchestrators — brittle and confusing
- `handle_review` took 7 parameters (payload + 4 separate kwargs for token/credential_ref/resolution_behavior/credential_registry) — hard to maintain
- No unified event shape across webhook, poller, and Jira trigger paths
- Poller discussion path silently dropped `resolution_behavior` (always defaulted to "suggest")

## How

**New module: `events.py`**
- `TaskEvent` — frozen Pydantic model with fields for all trigger types
- `ScheduledTask` — dedup wrapper (prep for Step 4.2)
- Token excluded from serialization via `Field(exclude=True, repr=False)` (S1)
- Model validator enforces required fields per `task_type` (review needs `mr_iid` + `head_sha`, discussion needs `mr_iid` + `note_id`)
- `log_safe()` method for structured logging without secrets

**Orchestrator signature changes:**
- `handle_review(settings, event: TaskEvent, executor, credential_registry=None)` — token, resolution_behavior, credential_ref all on event
- `handle_discussion_interaction(settings, event: TaskEvent, executor, agent_identity, repo_locks=None)` — same consolidation
- `ReviewRequest` title/description now sourced from `MRDetails` API response (already fetched) rather than webhook payload snapshot

**Trigger updates:**
- `webhook.py` — `_process_review`/`_process_discussion` create `TaskEvent` from parsed payloads
- `gitlab_poller.py` — creates `TaskEvent` directly from API data; **eliminates all payload synthesis** (removed `_build_note_payload()` and 20+ lines of `MergeRequestWebhookPayload` construction)
- Fixed: poller discussion path now correctly populates `resolution_behavior` from project registry

## Testing

- 863 tests passing (19 new for TaskEvent model)
- 97.33% coverage (baseline: 97.30%)
- `make lint` clean (ratchet + format + pyright)

## OWASP Self-Review
- [x] Broken Access Control — N/A (no auth changes)
- [x] Cryptographic Failures — token excluded from serialization, repr, log_safe()
- [x] Injection — N/A
- [x] Insecure Design — model validator prevents invalid states
- [x] Security Misconfiguration — N/A
- [x] Vulnerable Components — N/A (no new deps)
- [x] Auth Failures — token resolution flow preserved
- [x] Data Integrity — TaskEvent is frozen/immutable
- [x] Logging — log_safe() ensures no token leakage
- [x] SSRF — validate_clone_url_host() still called at orchestrator layer
