### PR TITLE
docs(adr): add ADRs 0012-0016 for Phases 3-5 design decisions

### DIFF
--- a/docs/adr/0001-mr-review-service-architecture.md
+++ b/docs/adr/0001-mr-review-service-architecture.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Partially superseded by [ADR-0015](0015-pipeline-protocol.md) — pipeline protocol replaces the flow design; tech stack decisions (FastAPI, Copilot SDK, background tasks) still hold.
 
 ## Context
 

--- a/docs/adr/0012-httpx-gitlab-client.md
+++ b/docs/adr/0012-httpx-gitlab-client.md
@@ -1,0 +1,56 @@
+# 0012. Drop python-gitlab, Rewrite GitLabClient with httpx
+
+## Status
+
+Accepted
+
+## Context
+
+The service used `python-gitlab` (a synchronous SDK) for all GitLab API access. Since the application is fully async (FastAPI + asyncio), every `python-gitlab` call was wrapped in `asyncio.to_thread()` to avoid blocking the event loop. This created several problems:
+
+1. **Sync-in-async wrapping** — every API call required `await asyncio.to_thread(gl.projects.get(...))`, adding boilerplate and hiding the actual HTTP call
+2. **Connection management** — `python-gitlab` manages its own `requests.Session`, making it impossible to share connection pools or configure timeouts consistently
+3. **Retry complexity** — retry logic had to wrap the `to_thread` call rather than the HTTP request, preventing per-request retry configuration
+4. **Type safety** — `python-gitlab` returns dynamic `RESTObject` instances with no static type information; pyright couldn't verify field access
+
+The research analysis identified that pollers were synthesizing `MergeRequestWebhookPayload` objects to reuse webhook-oriented code paths, partly because the GitLab client API was tightly coupled to `python-gitlab`'s object model.
+
+## Options Considered
+
+### Option A: Keep python-gitlab, improve wrapping
+
+Add a typed async wrapper around `python-gitlab` calls.
+
+- Pros: No API rewrite, smaller diff
+- Cons: Still sync underneath, still untyped responses, still can't control connection lifecycle
+
+### Option B: Replace with httpx async client
+
+Write a native async `GitLabClient` using `httpx.AsyncClient` with typed Pydantic response models.
+
+- Pros: Native async, typed responses, shared connection pool, configurable retries/timeouts, full control over pagination
+- Cons: Must rewrite all API interactions (~15 endpoints)
+
+### Option C: Use gidgetlab (async GitLab library)
+
+- Pros: Async-native, maintained
+- Cons: New dependency with smaller community than httpx; still returns untyped dicts
+
+## Decision
+
+**Option B** — Native async `GitLabClient` with httpx.
+
+The client uses `httpx.AsyncClient` internally with `PRIVATE-TOKEN` header authentication. All responses are parsed into Pydantic models (`MRDetails`, `MRChange`, `MRCommit`, `Discussion`, `DiscussionNote`, etc.) providing full type safety. The client owns its connection lifecycle via async context manager protocol.
+
+Key design choices:
+- **Protocol-based interface**: `GitLabClientProtocol` allows testing with mock implementations
+- **Pagination built-in**: `list_project_mrs`, `list_mr_discussions` handle `per_page`/`page` parameters
+- **No `python-gitlab` dependency**: removed from `pyproject.toml`
+
+## Consequences
+
+- All `asyncio.to_thread()` wrappers for GitLab API calls eliminated
+- Response types are statically verified by pyright
+- `CredentialRegistry` creates `GitLabClient` instances per credential ref with shared configuration
+- Tests mock `GitLabClient` directly (or use `GitLabClientProtocol`) instead of patching `gitlab.Gitlab`
+- ~15 API endpoints rewritten as typed async methods on `GitLabClient`

--- a/docs/adr/0013-task-event-model.md
+++ b/docs/adr/0013-task-event-model.md
@@ -1,0 +1,51 @@
+# 0013. Internal TaskEvent Model Replacing Webhook Payload Synthesis
+
+## Status
+
+Accepted
+
+## Context
+
+The service had three trigger sources (webhook, GitLab poller, Jira poller) that all needed to invoke the same review/discussion pipelines. The original design used `MergeRequestWebhookPayload` and `NoteWebhookPayload` (Pydantic models of the GitLab webhook JSON) as the internal contract. This forced non-webhook triggers to synthesize fake webhook payloads:
+
+1. **GitLab poller** constructed `MergeRequestWebhookPayload` objects from `MRListItem` API responses, mapping fields like `web_url` → `git_http_url`, `sha` → `last_commit.id`
+2. **Discussion note scanning** constructed `NoteWebhookPayload` objects from discussion API data
+3. **Field mismatches** — poller-synthesized payloads left webhook-specific fields (like `action`, `oldrev`) as dummy values since they had no meaning outside webhooks
+4. **Tight coupling** — any change to webhook payload parsing required updating poller synthesis code
+
+The research analysis identified this as a key coupling point: "pollers synthesize webhook payloads to reuse webhook-oriented orchestrators."
+
+## Options Considered
+
+### Option A: Keep webhook payloads as internal contract
+
+Add optional fields and factory methods for non-webhook sources.
+
+- Pros: No new model, smaller diff
+- Cons: Perpetuates the semantic mismatch; payload grows with fields that only one trigger uses
+
+### Option B: Internal TaskEvent model
+
+Define a `TaskEvent` Pydantic model with exactly the fields needed by pipelines, produced by all trigger sources.
+
+- Pros: Clean contract, each trigger maps its own data into the shared model, no dummy fields
+- Cons: New model to maintain; migration touches every trigger and every pipeline
+
+## Decision
+
+**Option B** — `TaskEvent` as the internal event contract.
+
+`TaskEvent` is a frozen Pydantic model (`ConfigDict(frozen=True)`) in `events.py` with fields: `task_type`, `project_id`, `repo`, `clone_url`, `branch`, `target_branch`, `mr_iid`, `head_sha`, `trigger_source`, `token`, `credential_ref`, `resolution_behavior`, `note_id`, `discussion_id`, `note_body`.
+
+Key design choices:
+- **Token security**: `token` uses `Field(exclude=True, repr=False)` so it's excluded from serialization and `repr()`. A `log_safe()` method returns all fields except token for structured logging.
+- **Per-task-type validation**: `model_validator` enforces that discussion tasks have `note_id` and `discussion_id`, review tasks have `head_sha`, etc.
+- **Trigger-agnostic**: `trigger_source` is metadata for logging/tracing; pipelines don't branch on it.
+
+## Consequences
+
+- Webhook, GitLab poller, and Jira poller each construct `TaskEvent` from their own data shapes
+- Pipelines receive `TaskEvent` instead of webhook payload models
+- No more `MergeRequestWebhookPayload` synthesis in pollers
+- Token is never accidentally logged or serialized
+- `ScheduledTask` (for queue-based dispatch) wraps `TaskEvent` for serialization across the queue boundary

--- a/docs/adr/0014-unified-dedup-service.md
+++ b/docs/adr/0014-unified-dedup-service.md
@@ -1,0 +1,53 @@
+# 0014. Unified DeduplicationService with Pluggable Backend
+
+## Status
+
+Accepted
+
+## Context
+
+Deduplication was spread across three independent implementations:
+
+1. **`ReviewedMRTracker`** — tracked `(project_id, mr_iid, head_sha)` tuples for MR reviews, with an Azure Table backend and local set cache
+2. **`ProcessedIssueTracker`** — tracked Jira issue keys, with its own Azure Table backend
+3. **`DeduplicationStore` protocol** — a lower-level abstraction used by `ReviewedMRTracker` but not by `ProcessedIssueTracker`
+
+Each had its own keying scheme, caching strategy, and error handling. The Azure Table backends had subtly different failure modes (reviewed-MR tracker failed open on auth errors; issue tracker raised). Note deduplication for discussion interactions didn't exist at all — it was added ad-hoc in webhook/poller code.
+
+## Options Considered
+
+### Option A: Keep separate trackers, add note tracker
+
+Add a third tracker class for note deduplication.
+
+- Pros: Minimal change to existing code
+- Cons: Three classes with duplicated caching/backend logic; inconsistent error handling
+
+### Option B: Unified DeduplicationService
+
+One service class with typed methods (`is_review_seen`/`mark_review`, `is_note_seen`/`mark_note`, `is_issue_seen`/`mark_issue`) backed by a single `DeduplicationStore` protocol implementation.
+
+- Pros: Single API surface, consistent error handling, local cache for all key types, one backend to configure
+- Cons: Migration requires updating all callers
+
+## Decision
+
+**Option B** — `DeduplicationService` in `dedup.py`.
+
+The service provides six methods (is/mark × review/note/issue) with consistent behavior:
+- **Local `MemoryDedup` front-cache** for fast repeated checks within a process
+- **Shared backend** (`AzureTableDedup` or `MemoryDedup`) for cross-instance visibility
+- **Fail-open on auth/permission errors** — returns `seen=True` to prevent duplicate processing when the backend is inaccessible
+- **Fail-safe on transient errors** — returns `seen=False` to allow retry
+- **Review key strategy** — configurable via `review_on_push`: when true, keys on `(project, sha)` to deduplicate across MRs sharing a head commit; when false, keys on `(project, mr_iid, sha)`
+- **Issue dedup is local-only** — run-scoped, cleared on registry reload
+
+After unification, `ReviewedMRTracker` and `ProcessedIssueTracker` were deleted.
+
+## Consequences
+
+- Single `DeduplicationService` instance created in `main.py` lifespan and stored in `AppContext`
+- All callers (`gitlab_webhook.py`, `gitlab_poller.py`, `jira_poller.py`) use the same service
+- Note deduplication added as a first-class operation (prevents duplicate webhook deliveries)
+- Backend is selected at startup based on Azure Storage configuration
+- `aclose()` method for graceful shutdown of backend connections

--- a/docs/adr/0015-pipeline-protocol.md
+++ b/docs/adr/0015-pipeline-protocol.md
@@ -1,0 +1,67 @@
+# 0015. Pipeline Protocol with Stage-Based Execution
+
+## Status
+
+Accepted — Partially supersedes ADR-0001 (flow design)
+
+## Context
+
+The service had three task types (MR review, discussion interaction, Jira coding) each implemented as monolithic async functions:
+
+1. **`handle_review()`** in `orchestrator.py` — 188 lines: clone, fetch MR details, build diff, run LLM, parse comments, post review, cleanup
+2. **`handle_discussion_interaction()`** in `discussion_orchestrator.py` — 196 lines: clone, fetch threads, build prompt, run LLM, apply patch, post reply, cleanup
+3. **`CodingOrchestrator.handle()`** in `coding_orchestrator.py` — 155 lines: clone, branch, run LLM, apply patch, commit, push, create MR, cleanup
+
+Each function mixed resource lifecycle (clone/cleanup), business logic (LLM invocation, comment parsing), and error handling (post user-visible errors, record metrics) in a single scope. Cleanup was inconsistent — some functions used try/finally, others relied on callers.
+
+## Options Considered
+
+### Option A: Refactor monoliths into smaller functions
+
+Break each handler into helper functions called sequentially.
+
+- Pros: Simple, no new abstractions
+- Cons: Cleanup guarantees still depend on caller discipline; no shared contract; tracing requires per-function instrumentation
+
+### Option B: Pipeline protocol with four-stage contract
+
+Define a `Pipeline` protocol with typed stages (`prepare → execute → process → cleanup`) and a generic runner that enforces ordering, tracing, and cleanup.
+
+- Pros: Consistent contract across all task types; cleanup always runs; per-stage tracing; error handling via `handle_error` callback; testable stages
+- Cons: New abstraction layer; each task type must restructure into four stages
+
+### Option C: Actor/message-based pipeline
+
+Use an actor framework or message queue between stages.
+
+- Pros: Decoupled stages, parallelizable
+- Cons: Massive over-engineering for three task types; adds async coordination complexity
+
+## Decision
+
+**Option B** — `Pipeline` protocol in `pipeline.py` with `run_pipeline()` runner.
+
+The protocol defines five methods: `prepare`, `execute`, `process`, `cleanup`, `handle_error`. The generic `run_pipeline()` function:
+
+1. Calls `prepare → execute → process` in sequence, each wrapped in a trace span
+2. On success, sets `outcome = "success"` (unless the pipeline set a specific outcome like `no_changes`)
+3. On failure, calls `handle_error` (which posts user-visible error messages), then `cleanup`
+4. On success, calls `cleanup` after process
+5. **Cleanup always runs** — even on error, even if handle_error itself fails
+6. `suppress_exception` flag allows pipelines to handle errors gracefully without re-raising (used by `CodingPipeline` for transient clone failures)
+
+Three pipeline implementations:
+- `ReviewPipeline` — clone, fetch MR+discussions+commits, run review LLM, post comments
+- `DiscussionPipeline` — clone, fetch threads, run discussion LLM, optionally apply+push, post reply
+- `CodingPipeline` — clone, branch, run coding LLM, apply+commit+push, create MR, update Jira
+
+Each pipeline uses `BasePipelineContext` (Pydantic model) to thread mutable state between stages.
+
+## Consequences
+
+- All three task types follow the same four-stage contract
+- `run_pipeline()` is the single entry point — callers don't manage stage ordering or cleanup
+- Per-stage trace spans provide consistent observability across task types
+- `handle_error` implementations own user-facing error messages (MR comment, Jira comment, thread reply)
+- Orchestrator modules (`orchestrator.py`, `discussion_orchestrator.py`, `coding_orchestrator.py`) were reduced to thin wrappers, then eliminated entirely in Phase 6.2
+- `stage_requires()` helper enforces inter-stage data contracts at runtime

--- a/docs/adr/0016-prompt-strategy-toggle.md
+++ b/docs/adr/0016-prompt-strategy-toggle.md
@@ -1,0 +1,52 @@
+# 0016. Prompt Strategy Toggle (Inline vs File-Based Context Delivery)
+
+## Status
+
+Proposed — Config field added; runtime implementation deferred to a future phase.
+
+## Context
+
+The Copilot SDK supports two modes for delivering context to the LLM:
+
+1. **Inline** — all context (diff, MR description, prior feedback, commit messages) is concatenated into the `user_prompt` string passed to the executor
+2. **File-based** — context is written to temporary files and referenced in the prompt, allowing the LLM to selectively read files rather than processing everything in the prompt window
+
+The current implementation uses inline delivery exclusively. For large MRs (>5000 lines of diff), the inline prompt can exceed context window limits or degrade review quality as the LLM struggles with extremely long inputs.
+
+## Options Considered
+
+### Option A: Always inline
+
+Keep the current approach.
+
+- Pros: Simple, no file management
+- Cons: Context window pressure on large MRs; no way to scale to large diffs
+
+### Option B: Configurable toggle
+
+Add a `prompt_strategy` config field (`inline` | `file`) that controls how context is delivered. Default to `inline` for backward compatibility.
+
+- Pros: Gradual rollout, per-deployment control, backward compatible
+- Cons: Two code paths to maintain; file-based delivery requires temporary file management and cleanup
+
+### Option C: Automatic selection based on diff size
+
+Automatically switch to file-based delivery when the diff exceeds a threshold.
+
+- Pros: No manual configuration
+- Cons: Less predictable behavior; threshold tuning is deployment-specific
+
+## Decision
+
+**Option B** — Configurable `prompt_strategy` field in `Settings`.
+
+The `prompt_strategy` field is added to `CopilotSettingsMixin` in `config/base.py` with a default of `"inline"`. The field is available to all pipeline implementations via `settings.prompt_strategy`.
+
+**Current state**: Only the config field exists. The `inline` strategy is the only implemented path. File-based delivery is deferred until the executor and prompt builders are updated to support it.
+
+## Consequences
+
+- `prompt_strategy` config field is available in `Settings` and `TaskRunnerSettings`
+- All pipeline prompt builders can check `settings.prompt_strategy` when constructing prompts
+- No behavioral change until file-based delivery is implemented
+- File-based implementation will require: temp file creation in `prepare`, file references in prompt template, cleanup in `cleanup` stage


### PR DESCRIPTION
## What

Add 5 missing Architecture Decision Records that should have been created alongside their respective implementation phases:

| ADR | Decision | Phase |
|---|---|---|
| 0012 | Drop python-gitlab, rewrite GitLabClient with httpx | Phase 3 |
| 0013 | Internal TaskEvent model replacing webhook payload synthesis | Phase 4 |
| 0014 | Unified DeduplicationService with pluggable backend | Phase 4 |
| 0015 | Pipeline protocol with stage-based execution | Phase 5 |
| 0016 | Prompt strategy toggle (inline vs file-based) — config only, runtime deferred | Phase 5 |

Also updates ADR-0001 status to "Partially superseded by ADR-0015."

## Why

The implementation plan specified ADRs 0010–0018 to be written alongside each phase. ADRs 0010–0011 were created during Phase 1, but 0012–0016 were missed during Phases 3–5. Identified during Phase 6 review.

## Verification

- Documentation only — no code changes
- `make lint && make test` green (891 passed, 97.27% coverage)